### PR TITLE
Possible fix for account rewind.

### DIFF
--- a/accounting/rewind.go
+++ b/accounting/rewind.go
@@ -56,9 +56,9 @@ func AccountAtRound(account models.Account, round uint64, db idb.IndexerDb) (acc
 		return
 	}
 	tf := idb.TransactionFilter{
-		Address:     addr[:],
-		MinRound:    round + 1,
-		MaxRound:    account.Round,
+		Address:  addr[:],
+		MinRound: round + 1,
+		MaxRound: account.Round,
 	}
 	txns := db.Transactions(context.Background(), tf)
 	txcount := 0


### PR DESCRIPTION
It looked like `AssetCloseTo` wasn't being updated properly.

Also it looks like `Address` defaults to only searching for the sender, so I added in the `AddressRole` bitmask.