### PR TITLE
Fix rewind: payment close-to account

### DIFF
--- a/accounting/rewind.go
+++ b/accounting/rewind.go
@@ -87,7 +87,7 @@ func AccountAtRound(account models.Account, round uint64, db idb.IndexerDb) (acc
 				acct.AmountWithoutPendingRewards -= uint64(stxn.ReceiverRewards)
 			}
 			if addr == stxn.Txn.CloseRemainderTo {
-				acct.AmountWithoutPendingRewards += uint64(stxn.ClosingAmount)
+				acct.AmountWithoutPendingRewards -= uint64(stxn.ClosingAmount)
 				acct.AmountWithoutPendingRewards -= uint64(stxn.CloseRewards)
 			}
 		case atypes.KeyRegistrationTx:


### PR DESCRIPTION
When rewinding an account, if the account is named as the close-to address, the closing amount needs to be removed from the balance.