### PR TITLE
Fix rewind: asset create.

### DIFF
--- a/accounting/rewind.go
+++ b/accounting/rewind.go
@@ -95,13 +95,7 @@ func AccountAtRound(account models.Account, round uint64, db idb.IndexerDb) (acc
 		case atypes.AssetConfigTx:
 			if stxn.Txn.ConfigAsset == 0 {
 				// create asset, unwind the application of the value
-				var block types.Block
-				block, err = db.GetBlock(round - 1)
-				if err != nil {
-					return
-				}
-				assetId := block.TxnCounter + uint64(txnrow.Intra) + 1
-				assetUpdate(&acct, assetId, 0, stxn.Txn.AssetParams.Total)
+				assetUpdate(&acct, txnrow.AssetId, 0, stxn.Txn.AssetParams.Total)
 			}
 		case atypes.AssetTransferTx:
 			if addr == stxn.Txn.AssetSender || addr == stxn.Txn.Sender {


### PR DESCRIPTION
This "fixes" it in my test, but I think the code is still incorrect. It looks like `assetUpdate` assumes that the sender is the reserve address.

```
func assetUpdate(account *models.Account, assetid uint64, add, sub uint64) {
	if account.Assets == nil {
		account.Assets = new([]models.AssetHolding)
	}
	assets := *account.Assets
	for i, ah := range assets {
		if ah.AssetId == assetid {
			ah.Amount += add
			ah.Amount -= sub
			assets[i] = ah
			return
		}
	}
	assets = append(assets, models.AssetHolding{
		Amount:  add - sub,
		AssetId: assetid,
		//Creator: base32 addr string of asset creator, TODO
		//IsFrozen: leave nil? // TODO: on close record frozen state for rewind
	})
	*account.Assets = assets
}
```

Maybe the code below needs to be:
```
if stxn.Txn.ConfigAsset == 0 && addr == stxn.Txn.AssetParams.Reserve {
	// create asset, unwind the application of the value
	assetUpdate(&acct, txnrow.AssetId, 0, stxn.Txn.AssetParams.Total)
}
```

I'm not sure, what do you think?