### PR TITLE
update note-prefix spec.

### DIFF
--- a/api/indexer.oas2.json
+++ b/api/indexer.oas2.json
@@ -1290,7 +1290,8 @@
       "type": "string",
       "description": "Specifies a prefix which must be contained in the note field.",
       "name": "note-prefix",
-      "in": "query"
+      "in": "query",
+      "x-algorand-format": "base64" 
     },
     "round": {
       "type": "integer",


### PR DESCRIPTION
This is necessary to generate the note-prefix as byte[]. 