### PR TITLE
Lowercase the package name

### DIFF
--- a/misc/debian/control
+++ b/misc/debian/control
@@ -1,4 +1,4 @@
-Package: Algorand-Indexer
+Package: algorand-indexer
 Homepage: https://www.algorand.com/
 Maintainer: Algorand developers <dev@algorand.com>
 Version: @VER@


### PR DESCRIPTION
Lowercasing the package name to `algorand-indexer` will be consistent with other packages that we're serving out of our apt repo (`algorand` and `algorand-beta`).

This also allows for the package to go into the same parent directory as the other packages in our repo.  For example, since all the packages begin with "a", this will put the `algorand-indexer` package in with the others.  Without this change, a new "A" parent directory will be auto-generated by aptly.