### PR TITLE
Update readme with version requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 The Indexer is a standalone service reads committed blocks from the Algorand blockchain and maintains a database of transactions and accounts that are searchable and indexed.
 
+# Minimum Version Requirements
+
+* go 1.13
+* Postgres 11
+
 # Quickstart
 
 We prepared a docker compose file to bring up indexer and postgres preloaded with some data. From the root directory run:


### PR DESCRIPTION
I'll wait for @bricerisingalgorand to confirm that upgrading postgres from 10 -> 11 fixed the problem we were seeing.

For future SEO purposes, here is the problem we encountered with Postgres 10:
```
{
    "message": "failed while searching for account: account_round err pq: cannot cast type jsonb to bigint"
}
```