### PR TITLE
db read-only

### DIFF
--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -59,7 +59,11 @@ var daemonCmd = &cobra.Command{
 		if algodDataDir == "" {
 			algodDataDir = os.Getenv("ALGORAND_DATA")
 		}
-		db := globalIndexerDb()
+		opts := idb.IndexerDbOptions{}
+		if noAlgod {
+			opts.ReadOnly = true
+		}
+		db := globalIndexerDb(&opts)
 
 		ctx, cf := context.WithCancel(context.Background())
 		defer cf()

--- a/cmd/algorand-indexer/import.go
+++ b/cmd/algorand-indexer/import.go
@@ -243,7 +243,7 @@ var importCmd = &cobra.Command{
 	Short: "import block file or tar file of blocks",
 	Long:  "import block file or tar file of blocks. arguments are interpret as file globs (e.g. *.tar.bz2)",
 	Run: func(cmd *cobra.Command, args []string) {
-		db := globalIndexerDb()
+		db := globalIndexerDb(nil)
 
 		err := importer.ImportProto(db)
 		maybeFail(err, "import proto, %v", err)

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -66,18 +66,17 @@ var (
 	postgresAddr   string
 	dummyIndexerDb bool
 	doVersion      bool
-	dbReadOnly     bool
 	cpuProfile     string
 	pidFilePath    string
 	db             idb.IndexerDb
 	profFile       io.WriteCloser
 )
 
-func globalIndexerDb() idb.IndexerDb {
+func globalIndexerDb(opts *idb.IndexerDbOptions) idb.IndexerDb {
 	if db == nil {
 		if postgresAddr != "" {
 			var err error
-			db, err = idb.IndexerDbByName("postgres", postgresAddr, &idb.IndexerDbOptions{ReadOnly: dbReadOnly})
+			db, err = idb.IndexerDbByName("postgres", postgresAddr, opts)
 			maybeFail(err, "could not init db, %v\n", err)
 		} else if dummyIndexerDb {
 			db = idb.DummyIndexerDb()
@@ -95,7 +94,6 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVarP(&postgresAddr, "postgres", "P", "", "connection string for postgres database")
 	rootCmd.PersistentFlags().BoolVarP(&dummyIndexerDb, "dummydb", "n", false, "use dummy indexer db")
-	rootCmd.PersistentFlags().BoolVarP(&dbReadOnly, "db-readonly", "", false, "connect to db in read-only mode")
 	rootCmd.PersistentFlags().StringVarP(&cpuProfile, "cpuprofile", "", "", "file to record cpu profile to")
 	rootCmd.PersistentFlags().StringVarP(&pidFilePath, "pidfile", "", "", "file to write daemon's process id to")
 	rootCmd.PersistentFlags().BoolVarP(&doVersion, "version", "v", false, "print version and exit")

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -66,6 +66,7 @@ var (
 	postgresAddr   string
 	dummyIndexerDb bool
 	doVersion      bool
+	dbReadOnly     bool
 	cpuProfile     string
 	pidFilePath    string
 	db             idb.IndexerDb
@@ -76,7 +77,7 @@ func globalIndexerDb() idb.IndexerDb {
 	if db == nil {
 		if postgresAddr != "" {
 			var err error
-			db, err = idb.IndexerDbByName("postgres", postgresAddr)
+			db, err = idb.IndexerDbByName("postgres", postgresAddr, &idb.IndexerDbOptions{ReadOnly: dbReadOnly})
 			maybeFail(err, "could not init db, %v\n", err)
 		} else if dummyIndexerDb {
 			db = idb.DummyIndexerDb()
@@ -94,6 +95,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVarP(&postgresAddr, "postgres", "P", "", "connection string for postgres database")
 	rootCmd.PersistentFlags().BoolVarP(&dummyIndexerDb, "dummydb", "n", false, "use dummy indexer db")
+	rootCmd.PersistentFlags().BoolVarP(&dbReadOnly, "db-readonly", "", false, "connect to db in read-only mode")
 	rootCmd.PersistentFlags().StringVarP(&cpuProfile, "cpuprofile", "", "", "file to record cpu profile to")
 	rootCmd.PersistentFlags().StringVarP(&pidFilePath, "pidfile", "", "", "file to write daemon's process id to")
 	rootCmd.PersistentFlags().BoolVarP(&doVersion, "version", "v", false, "print version and exit")

--- a/cmd/e2equeries/main.go
+++ b/cmd/e2equeries/main.go
@@ -41,7 +41,7 @@ func main() {
 	flag.Parse()
 	testutil.SetQuiet(quiet)
 
-	db, err := idb.OpenPostgres(pgdb)
+	db, err := idb.OpenPostgres(pgdb, &idb.IndexerDbOptions{ReadOnly: true})
 	maybeFail(err, "open postgres, %v", err)
 
 	rekeyTxnQuery := idb.TransactionFilter{RekeyTo: &truev, Limit: 1}

--- a/cmd/idbtest/idbtest.go
+++ b/cmd/idbtest/idbtest.go
@@ -128,7 +128,7 @@ func main() {
 	flag.Parse()
 	testutil.SetQuiet(quiet)
 
-	db, err := idb.OpenPostgres(pgdb)
+	db, err := idb.OpenPostgres(pgdb, nil)
 	maybeFail(err, "open postgres, %v", err)
 
 	if accounttest {

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -103,7 +103,7 @@ func (db *dummyIndexerDb) Applications(ctx context.Context, filter *models.Searc
 
 type IndexerFactory interface {
 	Name() string
-	Build(arg string) (IndexerDb, error)
+	Build(arg string, opts *IndexerDbOptions) (IndexerDb, error)
 }
 
 type TxnRow struct {
@@ -330,7 +330,7 @@ type dummyFactory struct {
 func (df dummyFactory) Name() string {
 	return "dummy"
 }
-func (df dummyFactory) Build(arg string) (IndexerDb, error) {
+func (df dummyFactory) Build(arg string, opts *IndexerDbOptions) (IndexerDb, error) {
 	return &dummyIndexerDb{}, nil
 }
 
@@ -341,10 +341,14 @@ func init() {
 	indexerFactories = append(indexerFactories, &dummyFactory{})
 }
 
-func IndexerDbByName(factoryname, arg string) (IndexerDb, error) {
+type IndexerDbOptions struct {
+	ReadOnly bool
+}
+
+func IndexerDbByName(factoryname, arg string, opts *IndexerDbOptions) (IndexerDb, error) {
 	for _, ifac := range indexerFactories {
 		if ifac.Name() == factoryname {
-			return ifac.Build(arg)
+			return ifac.Build(arg, opts)
 		}
 	}
 	return nil, fmt.Errorf("no IndexerDb factory for %s", factoryname)

--- a/idb/postgres.go
+++ b/idb/postgres.go
@@ -29,7 +29,7 @@ import (
 	"github.com/algorand/indexer/types"
 )
 
-func OpenPostgres(connection string) (pdb *PostgresIndexerDb, err error) {
+func OpenPostgres(connection string, opts *IndexerDbOptions) (pdb *PostgresIndexerDb, err error) {
 	db, err := sql.Open("postgres", connection)
 	if err != nil {
 		return nil, err
@@ -39,7 +39,8 @@ func OpenPostgres(connection string) (pdb *PostgresIndexerDb, err error) {
 		protoCache: make(map[string]types.ConsensusParams, 20),
 	}
 	// e.g. a user named "readonly" is in the connection string
-	if !strings.Contains(connection, "readonly") {
+	readonly := ((opts != nil) && opts.ReadOnly) || strings.Contains(connection, "readonly")
+	if !readonly {
 		err = pdb.init()
 	}
 	return
@@ -2280,8 +2281,8 @@ type postgresFactory struct {
 func (df postgresFactory) Name() string {
 	return "postgres"
 }
-func (df postgresFactory) Build(arg string) (IndexerDb, error) {
-	return OpenPostgres(arg)
+func (df postgresFactory) Build(arg string, opts *IndexerDbOptions) (IndexerDb, error) {
+	return OpenPostgres(arg, opts)
 }
 
 func init() {

--- a/idb/postgres.go
+++ b/idb/postgres.go
@@ -1895,6 +1895,8 @@ func bytesStr(addr []byte) *string {
 	return out
 }
 
+var readOnlyTx = sql.TxOptions{ReadOnly: true}
+
 func (db *PostgresIndexerDb) GetAccounts(ctx context.Context, opts AccountQueryOptions) <-chan AccountRow {
 	out := make(chan AccountRow, 1)
 
@@ -1908,7 +1910,7 @@ func (db *PostgresIndexerDb) GetAccounts(ctx context.Context, opts AccountQueryO
 	}
 
 	// Begin transaction so we get everything at one consistent point in time and round of accounting.
-	tx, err := db.db.BeginTx(ctx, nil)
+	tx, err := db.db.BeginTx(ctx, &readOnlyTx)
 	if err != nil {
 		err = fmt.Errorf("account tx err %v", err)
 		out <- AccountRow{Error: err}


### PR DESCRIPTION
Make a read-only transaction flagged as such.
When --no-algorand flag is set then migrations and other db init should not be done.
#181 