### PR TITLE
Add auth addr to account.

### DIFF
--- a/idb/postgres.go
+++ b/idb/postgres.go
@@ -1594,9 +1594,11 @@ func (db *PostgresIndexerDb) yieldAccountsThread(ctx context.Context, opts Accou
 				account.Participation = part
 			}
 
-			var spendingkey atypes.Address
-			copy(spendingkey[:], ad.SpendingKey[:])
-			account.AuthAddr=stringPtr(spendingkey.String())
+			if ! ad.SpendingKey.IsZero() {
+				var spendingkey atypes.Address
+				copy(spendingkey[:], ad.SpendingKey[:])
+				account.AuthAddr = stringPtr(spendingkey.String())
+			}
 		}
 
 		if account.Status == "NotParticipating" {

--- a/idb/postgres.go
+++ b/idb/postgres.go
@@ -1593,6 +1593,10 @@ func (db *PostgresIndexerDb) yieldAccountsThread(ctx context.Context, opts Accou
 				part.VoteKeyDilution = ad.VoteKeyDilution
 				account.Participation = part
 			}
+
+			var spendingkey atypes.Address
+			copy(spendingkey[:], ad.SpendingKey[:])
+			account.AuthAddr=stringPtr(spendingkey.String())
 		}
 
 		if account.Status == "NotParticipating" {


### PR DESCRIPTION
We weren't adding the spending key to the account response. Added it in. Tested against mainnet with some known rekey-accounts.
```
~ $ curl "localhost:8980/v2/accounts/DKKBELTHN74B3BIR2SU7PM6DA73R5KOMYI5YMY3ISXKIOCOSYVHDKC3SNM?pretty"
{
  "account": {
    "address": "DKKBELTHN74B3BIR2SU7PM6DA73R5KOMYI5YMY3ISXKIOCOSYVHDKC3SNM",
    "amount": 9999000,
    "amount-without-pending-rewards": 9999000,
    "auth-addr": "MJAKVCNT5WRP2VUZV7WDDILZAQBAWMZOYKCCDAEX63VIYBO4535IRQ5QZU",
    "pending-rewards": 0,
    "reward-base": 12496,
    "rewards": 0,
    "round": 5205535,
    "sig-type": "sig",
    "status": "Offline"
  },
  "current-round": 5205535
}
~ $ curl "localhost:8980/v2/accounts/MJAKVCNT5WRP2VUZV7WDDILZAQBAWMZOYKCCDAEX63VIYBO4535IRQ5QZU?pretty"
{
  "account": {
    "address": "MJAKVCNT5WRP2VUZV7WDDILZAQBAWMZOYKCCDAEX63VIYBO4535IRQ5QZU",
    "amount": 100000000,
    "amount-without-pending-rewards": 100000000,
    "pending-rewards": 0,
    "reward-base": 12496,
    "rewards": 0,
    "round": 5205541,
    "status": "Offline"
  },
  "current-round": 5205541
}
```