### PR TITLE
some migrations should prevent Indexer from starting up until they're done

### DIFF
--- a/importer/importer.go
+++ b/importer/importer.go
@@ -21,19 +21,18 @@ type dbImporter struct {
 	db idb.IndexerDb
 }
 
-var typeEnumList = []util.StringInt{
-	{"pay", idb.TypeEnumPay},
-	{"keyreg", idb.TypeEnumKeyreg},
-	{"acfg", idb.TypeEnumAssetConfig},
-	{"axfer", idb.TypeEnumAssetTransfer},
-	{"afrz", idb.TypeEnumAssetFreeze},
-	{"appl", idb.TypeEnumApplication},
+var TypeEnumMap = map[string]int{
+	"pay":    idb.TypeEnumPay,
+	"keyreg": idb.TypeEnumKeyreg,
+	"acfg":   idb.TypeEnumAssetConfig,
+	"axfer":  idb.TypeEnumAssetTransfer,
+	"afrz":   idb.TypeEnumAssetFreeze,
+	"appl":   idb.TypeEnumApplication,
 }
-var TypeEnumMap map[string]int
+
 var TypeEnumString string
 
 func init() {
-	TypeEnumMap = util.EnumListToMap(typeEnumList)
 	TypeEnumString = util.KeysStringInt(TypeEnumMap)
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -17,16 +17,3 @@ func KeysStringBool(m map[string]bool) string {
 	}
 	return strings.Join(keys, ", ")
 }
-
-type StringInt struct {
-	Str string
-	I   int
-}
-
-func EnumListToMap(list []StringInt) map[string]int {
-	out := make(map[string]int, len(list))
-	for _, tf := range list {
-		out[tf.Str] = tf.I
-	}
-	return out
-}


### PR DESCRIPTION
add annotation to postgres migrations about whether they should "prevent startup" (e.g. due to schema change that would make operational txns fail)
simplify async migration model by making each migration blocking but maybe run the loop over migrations in a thread.
cleanup a `go vet` issue in importer.
fix #188