### PR TITLE
Fast asset filter

### DIFF
--- a/cmd/e2equeries/main.go
+++ b/cmd/e2equeries/main.go
@@ -59,6 +59,7 @@ func main() {
 	}
 
 	printAccountQuery(db, idb.AccountQueryOptions{EqualToAuthAddr: rekeyTo[:], Limit: 1})
+	printAccountQuery(db, idb.AccountQueryOptions{HasAssetId: 25, Limit: 2})
 
 	dt := time.Now().Sub(start)
 	exitValue := testutil.ExitValue()

--- a/cmd/e2equeries/main.go
+++ b/cmd/e2equeries/main.go
@@ -59,7 +59,23 @@ func main() {
 	}
 
 	printAccountQuery(db, idb.AccountQueryOptions{EqualToAuthAddr: rekeyTo[:], Limit: 1})
-	printAccountQuery(db, idb.AccountQueryOptions{HasAssetId: 25, Limit: 2})
+
+	// find an asset with > 1 account
+	countByAssetID := make(map[uint64]uint64)
+	for abr := range db.AssetBalances(context.Background(), idb.AssetBalanceQuery{}) {
+		countByAssetID[abr.AssetId] = countByAssetID[abr.AssetId] + 1
+	}
+	var bestid uint64
+	var bestcount uint64 = 0
+	for assetid, count := range countByAssetID {
+		if (bestcount == 0) || (count > 1 && count < bestcount) {
+			bestcount = count
+			bestid = assetid
+		}
+	}
+	if bestcount != 0 {
+		printAccountQuery(db, idb.AccountQueryOptions{HasAssetId: bestid, Limit: bestcount})
+	}
 
 	dt := time.Now().Sub(start)
 	exitValue := testutil.ExitValue()

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -1646,6 +1646,7 @@ func (db *PostgresIndexerDb) yieldAccountsThread(ctx context.Context, opts idb.A
 		// not implemented: account.Rewards sum of all rewards ever
 
 		const nullarraystr = "[null]"
+		// TODO: delete client side filter when server side filter demonstrated
 		reject := opts.HasAssetId != 0
 
 		if len(holdingAssetid) > 0 && string(holdingAssetid) != nullarraystr {
@@ -1806,6 +1807,7 @@ func (db *PostgresIndexerDb) yieldAccountsThread(ctx context.Context, opts idb.A
 			account.CreatedApps = &aout
 		}
 
+		// TODO: delete client side filter when server side filter demonstrated
 		reject = opts.HasAppId != 0
 		if len(localStateAppIds) > 0 {
 			var appIds []uint64
@@ -1998,11 +2000,23 @@ func (db *PostgresIndexerDb) GetAccounts(ctx context.Context, opts idb.AccountQu
 
 func (db *PostgresIndexerDb) buildAccountQuery(opts idb.AccountQueryOptions) (query string, whereArgs []interface{}) {
 	// Construct query for fetching accounts...
-	query = `SELECT a.addr, a.microalgos, a.rewardsbase, a.keytype, a.account_data FROM account a`
 	const maxWhereParts = 14
 	whereParts := make([]string, 0, maxWhereParts)
 	whereArgs = make([]interface{}, 0, maxWhereParts)
 	partNumber := 1
+	withClauses := make([]string, 0, maxWhereParts)
+	// filter by has-asset or has-app
+	if opts.HasAssetId != 0 {
+		withClauses = append(withClauses, fmt.Sprintf("qasf AS (SELECT addr FROM account_asset WHERE assetid = $%d)", partNumber))
+		whereArgs = append(whereArgs, opts.HasAssetId)
+		partNumber++
+	}
+	if opts.HasAppId != 0 {
+		withClauses = append(withClauses, fmt.Sprintf("qapf AS (SELECT addr FROM account_app WHERE app = $%d)", partNumber))
+		whereArgs = append(whereArgs, opts.HasAppId)
+		partNumber++
+	}
+	// filters against main account table
 	if len(opts.GreaterThanAddress) > 0 {
 		whereParts = append(whereParts, fmt.Sprintf("a.addr > $%d", partNumber))
 		whereArgs = append(whereArgs, opts.GreaterThanAddress)
@@ -2028,17 +2042,23 @@ func (db *PostgresIndexerDb) buildAccountQuery(opts idb.AccountQueryOptions) (qu
 		whereArgs = append(whereArgs, opts.EqualToAuthAddr)
 		partNumber++
 	}
+	query = `SELECT a.addr, a.microalgos, a.rewardsbase, a.keytype, a.account_data FROM account a`
+	if opts.HasAssetId != 0 {
+		// inner join requires match, filtering on presence of asset
+		query += " JOIN qasf ON a.addr = qasf.addr"
+	}
+	if opts.HasAppId != 0 {
+		// inner join requires match, filtering on presence of app
+		query += " JOIN qapf ON a.addr = qapf.addr"
+	}
 	if len(whereParts) > 0 {
 		whereStr := strings.Join(whereParts, " AND ")
 		query += " WHERE " + whereStr
 	}
 	query += " ORDER BY a.addr ASC"
-	if opts.Limit != 0 && opts.HasAssetId == 0 && opts.HasAppId == 0 {
-		// sql limit gets disabled when we filter client side
-		query += fmt.Sprintf(" LIMIT %d", opts.Limit)
-	}
 	// TODO: asset holdings and asset params are optional, but practically always used. Either make them actually always on, or make app-global and app-local clauses also optional (they are currently always on).
-	query = "WITH qaccounts AS (" + query + ")"
+	withClauses = append(withClauses, "qaccounts AS ("+query+")")
+	query = "WITH " + strings.Join(withClauses, ", ")
 	if opts.IncludeAssetHoldings {
 		query += `, qaa AS (SELECT xa.addr, json_agg(aa.assetid) as haid, json_agg(aa.amount) as hamt, json_agg(aa.frozen) as hf FROM account_asset aa JOIN qaccounts xa ON aa.addr = xa.addr GROUP BY 1)`
 	}
@@ -2060,7 +2080,11 @@ func (db *PostgresIndexerDb) buildAccountQuery(opts idb.AccountQueryOptions) (qu
 	if opts.IncludeAssetParams {
 		query += ` LEFT JOIN qap ON za.addr = qap.addr`
 	}
-	query += " LEFT JOIN qapp ON za.addr = qapp.addr LEFT JOIN qls ON qls.addr = za.addr ORDER BY za.addr ASC;"
+	query += " LEFT JOIN qapp ON za.addr = qapp.addr LEFT JOIN qls ON qls.addr = za.addr ORDER BY za.addr ASC"
+	if opts.Limit != 0 {
+		query += fmt.Sprintf(" LIMIT %d", opts.Limit)
+	}
+	query += ";"
 	return query, whereArgs
 }
 


### PR DESCRIPTION
do has-asset and has-app filtering in sql instead of client side.
total query looks like
``` sql
WITH qasf AS (SELECT addr FROM account_asset WHERE assetid = $1 AND amount > $2),
qaccounts AS (SELECT a.addr, a.microalgos, a.rewardsbase, a.keytype, a.account_data FROM account a JOIN qasf ON a.addr = qasf.addr ORDER BY a.addr ASC),
qaa AS (SELECT xa.addr, json_agg(aa.assetid) as haid, json_agg(aa.amount) as hamt, json_agg(aa.frozen) as hf FROM account_asset aa JOIN qaccounts xa ON aa.addr = xa.addr GROUP BY 1), qap AS (SELECT ya.addr, json_agg(ap.index) as paid, json_agg(ap.params) as pp FROM asset ap JOIN qaccounts ya ON ap.creator_addr = ya.addr GROUP BY 1),
qapp AS (SELECT app.creator as addr, json_agg(app.index) as papps, json_agg(app.params) as ppa FROM app JOIN qaccounts ON qaccounts.addr = app.creator GROUP BY 1),
qls AS (SELECT la.addr, json_agg(la.app) as lsapps, json_agg(la.localstate) as lsls FROM account_app la JOIN qaccounts ON qaccounts.addr = la.addr GROUP BY 1)
SELECT za.addr, za.microalgos, za.rewardsbase, za.keytype, za.account_data, qaa.haid, qaa.hamt, qaa.hf, qap.paid, qap.pp, qapp.papps, qapp.ppa, qls.lsapps, qls.lsls FROM qaccounts za LEFT JOIN qaa ON za.addr = qaa.addr LEFT JOIN qap ON za.addr = qap.addr LEFT JOIN qapp ON za.addr = qapp.addr LEFT JOIN qls ON qls.addr = za.addr ORDER BY za.addr ASC LIMIT 100;
```
#222 
