### PR TITLE
Config file updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,14 +137,14 @@ The command line arguments always take priority over the config file and environ
 ## configuration file
 Default values are placed in the configuration file. They can be overridden with environment variables and command line arguments.
 
-The configuration file must named **algorand-indexer**, **algorand-indexer.yml**, or **algorand-indexer.yaml**. It must also be in the correct location. Only one configuration file is loaded, the path is searched in the following order:
+The configuration file must named **indexer**, **indexer.yml**, or **indexer.yaml**. It must also be in the correct location. Only one configuration file is loaded, the path is searched in the following order:
 * `./` (current working directory)
 * `$HOME`
 * `$HOME/.algorand-indexer`
 * `$HOME/.config/algorand-indexer`
 * `/etc/algorand-indexer/`
 
-Here is an example **algorand-indexer.yml** file:
+Here is an example **indexer.yml** file:
 ```
 postgres-connection-string: "host=mydb.mycloud.com user=postgres password=password dbname=mainnet"
 pidfile: "/var/lib/algorand/algorand-indexer.pid"

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -173,10 +173,7 @@ func configureLogger() error {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-<<<<<<< HEAD
 		logger.WithError(err).Error("an error occurred running indexer")
-=======
->>>>>>> Config file updates.
 		os.Exit(1)
 	}
 }

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -129,13 +129,21 @@ func init() {
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			// Config file not found; the error message indicates locations where we look
-			fmt.Fprintf(os.Stderr, "Could not find config file: %v", err)
+			// Config file not found. Returns an error string like:
+			//   Config File "indexer" Not Found in "[...search locations...]"
+
+			// Since we're in an init function the error message happens before
+			// any other program output which looks a little strange.
+
+			//fmt.Println(err.Error())
 		} else {
 			fmt.Fprintf(os.Stderr, "invalid config file (%s): %v", viper.ConfigFileUsed(), err)
 			os.Exit(1)
 		}
+	} else {
+		fmt.Printf("Using configuration file: %s\n", viper.ConfigFileUsed())
 	}
+
 
 	viper.SetEnvPrefix(config.EnvPrefix)
 	viper.AutomaticEnv()
@@ -165,7 +173,10 @@ func configureLogger() error {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
+<<<<<<< HEAD
 		logger.WithError(err).Error("an error occurred running indexer")
+=======
+>>>>>>> Config file updates.
 		os.Exit(1)
 	}
 }

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -129,13 +129,7 @@ func init() {
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			// Config file not found. Returns an error string like:
-			//   Config File "indexer" Not Found in "[...search locations...]"
-
-			// Since we're in an init function the error message happens before
-			// any other program output which looks a little strange.
-
-			//fmt.Println(err.Error())
+			// Config file not found, not an error since it may be set on the CLI.
 		} else {
 			fmt.Fprintf(os.Stderr, "invalid config file (%s): %v", viper.ConfigFileUsed(), err)
 			os.Exit(1)

--- a/config/config.go
+++ b/config/config.go
@@ -15,8 +15,9 @@ const EnvPrefix = "INDEXER"
 // FileType is the type of the config file.
 const FileType = "yaml"
 
-// FileName is the name of the config file.
-const FileName = "algorand-indexer"
+// FileName is the name of the config file. Don't use 'algorand-indexer', viper
+// gets confused and thinks the binary is a config file with no extension.
+const FileName = "indexer"
 
 // ConfigPaths are the different locations that algorand-indexer should look for config files.
 var ConfigPaths = [...]string{".", "$HOME", "$HOME/.algorand-indexer/", "$HOME/.config/algorand-indexer/", "/etc/algorand-indexer/"}


### PR DESCRIPTION
I noticed that there were strange errors when launching indexer from the CWD, it turns out the config file library was trying to read the binary as a config file.

This change renames the base config filename from `algorand-indexer` to `indexer`, and tweaks console output.