### PR TITLE
IndexerDb should block importer until db is available.

### DIFF
--- a/idb/migration/migration.go
+++ b/idb/migration/migration.go
@@ -162,7 +162,7 @@ func (m *Migration) update(err error, status string, running bool, blocking bool
 // migration runs. This call will block execution until it completes and should be run in a go routine if that is not
 // expected.
 func (m *Migration) RunMigrations() {
-	m.log.Println("Migration starting.")
+	m.log.Printf("Running %d migrations.", len(m.tasks))
 	blocking := true
 	for _, task := range m.tasks {
 		if task.MigrationID > m.blockUntil {


### PR DESCRIPTION
Block the importer from starting until IndexerDb health reports the DB is available.