### PR TITLE
Acct query fix

### DIFF
--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -28,8 +28,6 @@ var (
 	noAlgod          bool
 	developerMode    bool
 	tokenString      string
-
-	logger *log.Logger
 )
 
 var daemonCmd = &cobra.Command{
@@ -100,15 +98,14 @@ var daemonCmd = &cobra.Command{
 
 		// TODO: trap SIGTERM and call cf() to exit gracefully
 		fmt.Printf("serving on %s\n", daemonServerAddr)
-		api.Serve(ctx, daemonServerAddr, db, logger, tokenArray, developerMode)
+		api.Serve(ctx, daemonServerAddr, db, log.StandardLogger(), tokenArray, developerMode)
 	},
 }
 
 func init() {
-	logger = log.New()
-	logger.SetFormatter(&log.JSONFormatter{})
-	logger.SetOutput(os.Stdout)
-	logger.SetLevel(log.InfoLevel)
+	log.SetFormatter(&log.JSONFormatter{})
+	log.SetOutput(os.Stdout)
+	log.SetLevel(log.InfoLevel)
 
 	daemonCmd.Flags().StringVarP(&algodDataDir, "algod", "d", "", "path to algod data dir, or $ALGORAND_DATA")
 	daemonCmd.Flags().StringVarP(&algodAddr, "algod-net", "", "", "host:port of algod")

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -1526,7 +1526,7 @@ func (db *PostgresIndexerDb) yieldAccountsThread(req *getAccountsRequest) {
 		end := time.Now()
 		dt := end.Sub(req.start)
 		if dt > (1 * time.Second) {
-			log.Printf("long query %fs: %s", dt.Seconds(), req.query)
+			log.Warnf("long query %fs: %s", dt.Seconds(), req.query)
 		}
 	}()
 	for req.rows.Next() {


### PR DESCRIPTION
fix for #246
move LIMIT inside an earlier clause to fix postgres query handling
for future bad queries, log any SQL that takes longer than 1 second to run
change against `master` branch