### PR TITLE
Fix app key deletion when the only one key in deltas

### DIFF
--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -23,6 +23,7 @@ import (
 	"github.com/algorand/go-algorand-sdk/encoding/json"
 	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
 	atypes "github.com/algorand/go-algorand-sdk/types"
+
 	// Load the postgres sql.DB implementation
 	_ "github.com/lib/pq"
 	log "github.com/sirupsen/logrus"
@@ -611,6 +612,10 @@ func (tkv *TealKeyValue) delete(key []byte) {
 	for i, ktv := range tkv.They {
 		if bytes.Equal(ktv.Key, key) {
 			last := len(tkv.They) - 1
+			if last == 0 {
+				tkv.They = nil
+				return
+			}
 			if i < last {
 				tkv.They[i] = tkv.They[last]
 				tkv.They = tkv.They[:last]

--- a/idb/postgres/postgres_test.go
+++ b/idb/postgres/postgres_test.go
@@ -84,3 +84,30 @@ func TestNoMigrationsNeeded(t *testing.T) {
 
 	require.Equal(t, (*h.Data)["migration-status"], "Migrations Complete")
 }
+
+func TestTealKeyValue(t *testing.T) {
+	a := require.New(t)
+
+	k1 := []byte("key1")
+	k2 := []byte("key2")
+
+	var tkv TealKeyValue
+	_, ok := tkv.get(k1)
+	a.False(ok)
+
+	tkv.put(k1, TealValue{})
+	_, ok = tkv.get(k1)
+	a.True(ok)
+
+	tkv.put(k2, TealValue{})
+	_, ok = tkv.get(k2)
+	a.True(ok)
+
+	tkv.delete(k1)
+	_, ok = tkv.get(k1)
+	a.False(ok)
+
+	tkv.delete(k2)
+	_, ok = tkv.get(k2)
+	a.False(ok)
+}


### PR DESCRIPTION
## Summary

When local state delta has a single key, deletion did not happen.

## Test Plan

Added unit test, added state test (see https://github.com/algorand/go-algorand/pull/1812)