### PR TITLE
Remove idb from accounting.State

### DIFF
--- a/accounting/accounting.go
+++ b/accounting/accounting.go
@@ -46,11 +46,6 @@ func (accounting *State) InitRound(block types.Block) error {
 	return nil
 }
 
-// Close is part of the Closer interface.
-func (accounting *State) Close() error {
-	return nil
-}
-
 var zeroAddr = [32]byte{}
 
 func addrIsZero(a types.Address) bool {

--- a/accounting/accounting.go
+++ b/accounting/accounting.go
@@ -39,6 +39,7 @@ func New() *State {
 }
 
 func (accounting *State) InitRound(block types.Block) error {
+	accounting.RoundUpdates.Clear()
 	accounting.feeAddr = block.FeeSink
 	accounting.rewardAddr = block.RewardsPool
 	accounting.rewardsLevel = block.RewardsLevel

--- a/accounting/accounting.go
+++ b/accounting/accounting.go
@@ -38,6 +38,7 @@ func New() *State {
 	return &State{defaultFrozen: make(map[uint64]bool)}
 }
 
+// InitRound should be called before each round to initialize the accounting state.
 func (accounting *State) InitRound(block types.Block) error {
 	accounting.RoundUpdates.Clear()
 	accounting.feeAddr = block.FeeSink
@@ -211,7 +212,9 @@ func blankLsig(lsig atypes.LogicSig) bool {
 	return len(lsig.Logic) == 0
 }
 
-var ErrWrongRound error = errors.New("Wrong round.")
+// ErrWrongRound is returned when adding a transaction which belongs to a different round
+// than what the State is configured for.
+var ErrWrongRound error = errors.New("wrong round")
 
 // AddTransaction updates the State with the provided idb.TxnRow data.
 func (accounting *State) AddTransaction(txnr *idb.TxnRow) (err error) {

--- a/accounting/accounting_test.go
+++ b/accounting/accounting_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/algorand/indexer/idb"
-	"github.com/algorand/indexer/idb/mocks"
 )
 
 var mainAcct = decodeAddressOrPanic("GJR76Q6OXNZ2CYIVCFCDTJRBAAR6TYEJJENEII3G2U3JH546SPBQA62IFY")
@@ -75,8 +74,7 @@ func assertUpdates(t *testing.T, update *idb.AlgoUpdate, closed bool, balance, r
 }
 
 func getAccounting() *State {
-	mockIndexer := &mocks.IndexerDb{}
-	accountingState := New(mockIndexer)
+	accountingState := New()
 	accountingState.feeAddr = feeAddr
 	accountingState.rewardAddr = rewardAddr
 	accountingState.currentRound = closeMainToBC.Round

--- a/importer/helper.go
+++ b/importer/helper.go
@@ -262,12 +262,10 @@ func updateAccounting(db idb.IndexerDb, genesisJSONPath string, numRoundsLimit i
 	for txn := range txns {
 		maybeFail(txn.Error, l, "updateAccounting txn fetch, %v", txn.Error)
 		if txn.Round != currentRound {
-			if blockPtr != nil {
-				// TODO: commit rounds with no transactions to avoid a special case to update the db metastate.
-				if txnForRound > 0 {
-					err = db.CommitRoundAccounting(act.RoundUpdates, currentRound, blockPtr.RewardsLevel)
-					maybeFail(err, l, "failed to commit round accounting")
-				}
+			// TODO: commit rounds with no transactions to avoid a special case to update the db metastate.
+			if blockPtr != nil && txnForRound > 0 {
+				err = db.CommitRoundAccounting(act.RoundUpdates, currentRound, blockPtr.RewardsLevel)
+				maybeFail(err, l, "failed to commit round accounting")
 			}
 
 			// initialize accounting for next round
@@ -300,13 +298,11 @@ func updateAccounting(db idb.IndexerDb, genesisJSONPath string, numRoundsLimit i
 		txnForRound++
 	}
 
-	// Commit the last round
-	if blockPtr != nil {
-		// TODO: commit rounds with empty paysets to avoid a special case to update the db metastate.
-		if txnForRound > 0 {
-			err = db.CommitRoundAccounting(act.RoundUpdates, currentRound, blockPtr.RewardsLevel)
-			maybeFail(err, l, "failed to commit round accounting")
-		}
+	// Commit the final round
+	// TODO: commit rounds with empty paysets to avoid a special case to update the db metastate.
+	if blockPtr != nil && txnForRound > 0 {
+		err = db.CommitRoundAccounting(act.RoundUpdates, currentRound, blockPtr.RewardsLevel)
+		maybeFail(err, l, "failed to commit round accounting")
 	}
 
 	rounds += roundsSeen

--- a/test/common.sh
+++ b/test/common.sh
@@ -147,8 +147,10 @@ function start_indexer_with_blocks() {
   local TEMPDIR=$(mktemp -d -t ci-XXXXXXX)
   tar -xf "$2" -C $TEMPDIR
 
-  echo "Start args 'import -P \"${CONNECTION_STRING/DB_NAME_HERE/$1}\" --genesis \"$TEMPDIR/algod/genesis.json\" $TEMPDIR/blocktars/*"
-  #sleep infinity
+  if [ ! -z $3 ]; then
+    echo "Start args 'import -P \"${CONNECTION_STRING/DB_NAME_HERE/$1}\" --genesis \"$TEMPDIR/algod/genesis.json\" $TEMPDIR/blocktars/*"
+    sleep infinity
+  fi
   ALGORAND_DATA= ../cmd/algorand-indexer/algorand-indexer import \
     -P "${CONNECTION_STRING/DB_NAME_HERE/$1}" \
     --genesis "$TEMPDIR/algod/genesis.json" \

--- a/test/postgres_integration_test.sh
+++ b/test/postgres_integration_test.sh
@@ -18,6 +18,7 @@ start_postgres
 ## RUN TESTS ##
 ###############
 # Test 1
+print_alert "Integration Test 1"
 kill_indexer
 start_indexer_with_blocks createdestroy blockdata/create_destroy.tar.bz2
 wait_for_ready

--- a/test/postgres_migration_test.sh
+++ b/test/postgres_migration_test.sh
@@ -34,6 +34,7 @@ start_postgres
 ###############
 
 # Rewards tests
+print_alert "Migration Rewards Tests"
 kill_indexer
 initialize_db test1 migrations/cumulative_rewards_dump.txt
 start_indexer test1
@@ -41,6 +42,7 @@ wait_for_ready
 cumulative_rewards_tests
 
 # Create Delete Tests
+print_alert "Create Delete Tests"
 kill_indexer
 initialize_db test2 migrations/create_delete.2.2.1.txt
 start_indexer test2


### PR DESCRIPTION
## Summary

Move db.CommitRoundAccounting out of the accounting package. This will make it easier to use the AddTransaction function in different ways. For example the RoundAccounting object can be extracted and filtered such that it only applies updates for a single account.