### PR TITLE
[prototyping] Re-Index Account Subcommand

### DIFF
--- a/accounting/accounting.go
+++ b/accounting/accounting.go
@@ -64,10 +64,6 @@ func bytesAreZero(b []byte) bool {
 }
 
 func (accounting *State) closeAccount(addr types.Address) {
-	if accounting.AlgoUpdates == nil {
-		accounting.AlgoUpdates = make(map[[32]byte]*idb.AlgoUpdate)
-	}
-
 	update, hasKey := accounting.AlgoUpdates[addr]
 
 	if !hasKey {
@@ -98,10 +94,6 @@ func (accounting *State) updateAlgo(addr types.Address, amount int64) {
 }
 
 func (accounting *State) updateAlgoAndRewards(addr types.Address, amount, rewards int64) {
-	if accounting.AlgoUpdates == nil {
-		accounting.AlgoUpdates = make(map[[32]byte]*idb.AlgoUpdate)
-	}
-
 	update, hasKey := accounting.AlgoUpdates[addr]
 
 	if !hasKey {
@@ -118,16 +110,10 @@ func (accounting *State) updateAlgoAndRewards(addr types.Address, amount, reward
 }
 
 func (accounting *State) updateAccountType(addr types.Address, ktype string) {
-	if accounting.AccountTypes == nil {
-		accounting.AccountTypes = make(map[[32]byte]string)
-	}
 	accounting.AccountTypes[addr] = ktype
 }
 
 func (accounting *State) updateAccountData(addr types.Address, key string, field interface{}) {
-	if accounting.AccountDataUpdates == nil {
-		accounting.AccountDataUpdates = make(map[[32]byte]map[string]interface{})
-	}
 	au, ok := accounting.AccountDataUpdates[addr]
 	if !ok {
 		au = make(map[string]interface{})
@@ -154,9 +140,6 @@ func (accounting *State) updateAsset(addr types.Address, assetID uint64, add, su
 			return
 		}
 	}
-	if accounting.AssetUpdates == nil {
-		accounting.AssetUpdates = make(map[[32]byte][]idb.AssetUpdate)
-	}
 
 	au := idb.AssetUpdate{AssetID: assetID, DefaultFrozen: accounting.defaultFrozen[assetID]}
 	if add != 0 {
@@ -172,6 +155,7 @@ func (accounting *State) updateAsset(addr types.Address, assetID uint64, add, su
 	accounting.AssetUpdates[addr] = append(updatelist, au)
 }
 
+// TODO: Figure out if this is dead code. Delete if it is.
 func (accounting *State) updateTxnAsset(round uint64, intra int, assetID uint64) {
 	accounting.TxnAssetUpdates = append(accounting.TxnAssetUpdates, idb.TxnAssetUpdate{Round: round, Offset: intra, AssetID: assetID})
 }

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -174,7 +174,7 @@ func (bih *blockImporterHandler) HandleBlock(block *types.EncodedBlockCert) {
 		logger.Errorf("received block %d when expecting %d", block.Block.Round, bih.round+1)
 	}
 	bih.imp.ImportDecodedBlock(block)
-	filter := idb.UpdateFilter{StartRound: int64(block.Block.Round)}
+	filter := idb.UpdateFilter{StartRound: int64(block.Block.Round) - 1}
 	importer.UpdateAccounting(bih.db, filter, logger)
 	dt := time.Now().Sub(start)
 	if len(block.Block.Payset) == 0 {

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -175,9 +175,9 @@ func (bih *blockImporterHandler) HandleBlock(block *types.EncodedBlockCert) {
 	}
 	bih.imp.ImportDecodedBlock(block)
 	filter := idb.UpdateFilter{StartRound: int64(block.Block.Round)}
-	importer.UpdateAccounting(bih.db, filter, logger)
+	_, txns := importer.UpdateAccounting(bih.db, filter, logger)
 	dt := time.Now().Sub(start)
-	if len(block.Block.Payset) == 0 {
+	if txns == 0 {
 		// accounting won't have updated the round state, so we do it here
 		state, err := db.GetImportState()
 		maybeFail(err, "failed to get import state")

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -174,7 +174,7 @@ func (bih *blockImporterHandler) HandleBlock(block *types.EncodedBlockCert) {
 		logger.Errorf("received block %d when expecting %d", block.Block.Round, bih.round+1)
 	}
 	bih.imp.ImportDecodedBlock(block)
-	filter := idb.UpdateFilter{StartRound: int64(block.Block.Round) - 1}
+	filter := idb.UpdateFilter{StartRound: int64(block.Block.Round)}
 	importer.UpdateAccounting(bih.db, filter, logger)
 	dt := time.Now().Sub(start)
 	if len(block.Block.Payset) == 0 {

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -180,9 +180,10 @@ func (bih *blockImporterHandler) HandleBlock(block *types.EncodedBlockCert) {
 	if len(block.Block.Payset) == 0 {
 		// accounting won't have updated the round state, so we do it here
 		state, err := db.GetImportState()
+		maybeFail(err, "failed to get import state")
 		state.AccountRound = int64(block.Block.Round)
 		err = db.SetImportState(state)
-		logger.WithError(err).Errorf("failed to set import state")
+		maybeFail(err, "failed to set import state")
 	}
 	logger.Infof("round r=%d (%d txn) imported in %s", block.Block.Round, len(block.Block.Payset), dt.String())
 	bih.round = uint64(block.Block.Round)

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -108,6 +108,7 @@ func init() {
 
 	rootCmd.AddCommand(importCmd)
 	rootCmd.AddCommand(daemonCmd)
+	rootCmd.AddCommand(reindexCmd)
 
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "loglevel", "l", "info", "verbosity of logs: [error, warn, info, debug, trace]")
 	rootCmd.PersistentFlags().StringVarP(&logFile, "logfile", "f", "", "file to write logs to, if unset logs are written to standard out")

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -22,7 +22,7 @@ func maybeFail(err error, errfmt string, params ...interface{}) {
 	if err == nil {
 		return
 	}
-	logger.Errorf(errfmt, params...)
+	logger.WithError(err).Errorf(errfmt, params...)
 	os.Exit(1)
 }
 

--- a/cmd/algorand-indexer/reindexer.go
+++ b/cmd/algorand-indexer/reindexer.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/algorand/go-algorand-sdk/types"
+	"github.com/spf13/cobra"
+
+	"github.com/algorand/indexer/config"
+	"github.com/algorand/indexer/idb"
+	"github.com/algorand/indexer/importer"
+)
+
+var (
+	reindexAccount string
+)
+
+var reindexCmd = &cobra.Command{
+	Use:   "reindex",
+	Short: "reindex a single account",
+	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		config.BindFlags(cmd)
+		err = configureLogger()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to configure logger: %v", err)
+			os.Exit(1)
+		}
+
+		opts := idb.IndexerDbOptions{}
+		db := globalIndexerDb(&opts)
+
+		addr, err := types.DecodeAddress(reindexAccount)
+		maybeFail(err, "unable to decode address: %s", reindexAccount)
+
+		accounts := db.GetAccounts(context.Background(), idb.AccountQueryOptions{
+			EqualToAddress: addr[:],
+		})
+
+		num := 0
+		var createdAt int64
+		for acct := range accounts {
+			num++
+			createdAt = int64(*acct.Account.CreatedAtRound)
+		}
+
+		if num != 0 {
+			logger.Errorf("expected one account but found %d for address: %s", num, addr.String())
+		}
+
+		filter := idb.UpdateFilter{Address: &addr, StartRound: createdAt}
+		importer.UpdateAccounting(db, filter, logger)
+	},
+}
+
+func init() {
+	reindexCmd.Flags().StringVarP(&reindexAccount, "account", "a", "", "account which should be re-indexed")
+	reindexCmd.MarkFlagRequired("account")
+	reindexCmd.Hidden = true
+}

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -139,6 +139,7 @@ func (bot *fetcherImpl) Run() {
 	if bot.wg != nil {
 		defer bot.wg.Done()
 	}
+
 	for true {
 		if bot.isDone() {
 			return

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -237,7 +237,6 @@ type IndexerDb interface {
 
 	CommitRoundAccounting(updates RoundUpdates, round, rewardsBase uint64) (err error)
 
-
 	GetBlock(round uint64) (block types.Block, err error)
 
 	Transactions(ctx context.Context, tf TransactionFilter) <-chan TxnRow
@@ -272,9 +271,13 @@ const (
 	TypeEnumApplication   = 6
 )
 
+// Order is used to specify how transactions are sorted.
 type Order string
 const (
+	// OrderAsc will sort results in ascending order.
 	OrderAsc Order = "ASC"
+
+	// OrderDesc will sort results in descending order.
 	OrderDesc Order = "DESC"
 )
 
@@ -561,6 +564,7 @@ func (ru *RoundUpdates) Clear() {
 	ru.AppLocalDeltas = nil
 }
 
+// UpdateFilter is used by some functions to filter how an update is done.
 type UpdateFilter struct {
 	StartRound int64
 	RoundLimit *int

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -566,8 +566,13 @@ func (ru *RoundUpdates) Clear() {
 
 // UpdateFilter is used by some functions to filter how an update is done.
 type UpdateFilter struct {
+	// StartRound only include transactions confirmed at this round or later.
 	StartRound int64
+
+	// RoundLimit only process this many rounds of transactions.
 	RoundLimit *int
+
+	// Address only process transactions which modify this account.
 	Address    *types.Address
 }
 

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -546,11 +546,6 @@ type RoundUpdates struct {
 
 // Clear is used to set a RoundUpdates object back to it's default values.
 func (ru *RoundUpdates) Clear() {
-	//ru.AlgoUpdates = nil
-	//ru.AccountTypes = nil
-	//ru.AccountDataUpdates = nil
-	//ru.AssetUpdates = nil
-
 	ru.AlgoUpdates = make(map[[32]byte]*AlgoUpdate)
 	ru.AccountTypes = make(map[[32]byte]string)
 	ru.AccountDataUpdates = make(map[[32]byte]map[string]interface{})
@@ -596,20 +591,23 @@ func (ru *RoundUpdates) Filter(filter UpdateFilter) RoundUpdates {
 		response.AccountDataUpdates[addrBytes] = val
 	}
 
+	/*
+	// Do not include asset configuration. Note: in the future that would be supported with an AssetID filter.
 	for _, update := range ru.AcfgUpdates {
 		if update.Creator == *filter.Address {
 			response.AcfgUpdates = append(response.AcfgUpdates, update)
 		}
 	}
+	 */
 
-	// TODO: Somehow figure out if this is an asset owned by filter.Address
 	/*
+	// I think TxnAssetUpdates is dead code.
 	for _, update := range ru.TxnAssetUpdates {
 		if update.AssetID == *filter.Address {
 			response.AssetUpdates = append(response.AssetUpdates, update)
 		}
 	}
-	*/
+	 */
 
 	if val, ok := ru.AssetUpdates[addrBytes]; ok {
 		response.AssetUpdates[addrBytes] = val
@@ -626,23 +624,27 @@ func (ru *RoundUpdates) Filter(filter UpdateFilter) RoundUpdates {
 			response.AssetCloses = append(response.AssetCloses, update)
 		}
 	}
-	// TODO: Somehow figure out if this is an asset owned by filter.Address
 	/*
+	// Do not include asset configuration. Note: in the future that would be supported with an AssetID filter.
 	for _, update := range ru.AssetDestroys {
 		if update.Sender == *filter.Address || update.CloseTo == *filter.Address {
 			response.AssetDestroys = append(response.AssetCloses, update)
 		}
 	}
 	 */
+
+	/*
+	// Do not include app global changes. Note: in the future that would be supported with an AppID filter.
 	for _, update := range ru.AppGlobalDeltas {
 		if bytes.Equal(update.Address, addrBytes[:]) || bytes.Equal(update.Creator, addrBytes[:]) {
 			response.AppGlobalDeltas = append(response.AppGlobalDeltas, update)
 		}
 	}
+	 */
 
-	for _, update := range ru.AppGlobalDeltas {
+	for _, update := range ru.AppLocalDeltas {
 		if bytes.Equal(update.Address, addrBytes[:]) || bytes.Equal(update.Creator, addrBytes[:]) {
-			response.AppGlobalDeltas = append(response.AppGlobalDeltas, update)
+			response.AppLocalDeltas = append(response.AppLocalDeltas, update)
 		}
 	}
 

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -81,6 +81,16 @@ func (db *dummyIndexerDb) SetMetastate(key, jsonStrValue string) (err error) {
 	return nil
 }
 
+// GetMetastate is part of idb.IndexerDB
+func (db *dummyIndexerDb) GetImportState() (is ImportState, err error) {
+	return ImportState{}, nil
+}
+
+// SetMetastate is part of idb.IndexerDB
+func (db *dummyIndexerDb) SetImportState(is ImportState) (err error) {
+	return nil
+}
+
 // GetMaxRound is part of idb.IndexerDB
 func (db *dummyIndexerDb) GetMaxRound() (round uint64, err error) {
 	return 0, nil
@@ -212,6 +222,8 @@ type IndexerDb interface {
 
 	GetMetastate(key string) (jsonStrValue string, err error)
 	SetMetastate(key, jsonStrValue string) (err error)
+	GetImportState() (is ImportState, err error)
+	SetImportState(ImportState) (err error)
 	GetMaxRound() (round uint64, err error)
 	GetSpecialAccounts() (SpecialAccounts, error)
 
@@ -219,6 +231,7 @@ type IndexerDb interface {
 	YieldTxns(ctx context.Context, prevRound int64) <-chan TxnRow
 
 	CommitRoundAccounting(updates RoundUpdates, round, rewardsBase uint64) (err error)
+
 
 	GetBlock(round uint64) (block types.Block, err error)
 
@@ -529,6 +542,22 @@ func (ru *RoundUpdates) Clear() {
 	ru.AppLocalDeltas = nil
 }
 
+type UpdateFilter struct {
+	StartRound int64
+	Address    *types.Address
+}
+
+// Filter is used to get a RoundUpdates copy containing only particular RoundUpdates.
+func (ru *RoundUpdates) Filter(filter UpdateFilter) RoundUpdates {
+	if filter.Address == nil {
+		return *ru
+	}
+
+	var response RoundUpdates
+
+	return response
+}
+
 // AppDelta used by the accounting and IndexerDb implementations to share modifications in a block.
 type AppDelta struct {
 	AppIndex     int64
@@ -622,4 +651,9 @@ type Health struct {
 type SpecialAccounts struct {
 	FeeSink     types.Address
 	RewardsPool types.Address
+}
+
+// ImportState is some metadata kept around to help the import helper.
+type ImportState struct {
+	AccountRound int64 `codec:"account_round"`
 }

--- a/idb/mocks/IndexerDb.go
+++ b/idb/mocks/IndexerDb.go
@@ -166,6 +166,27 @@ func (_m *IndexerDb) GetBlock(round uint64) (types.Block, error) {
 	return r0, r1
 }
 
+// GetImportState provides a mock function with given fields:
+func (_m *IndexerDb) GetImportState() (idb.ImportState, error) {
+	ret := _m.Called()
+
+	var r0 idb.ImportState
+	if rf, ok := ret.Get(0).(func() idb.ImportState); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(idb.ImportState)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetMaxRound provides a mock function with given fields:
 func (_m *IndexerDb) GetMaxRound() (uint64, error) {
 	ret := _m.Called()
@@ -292,6 +313,20 @@ func (_m *IndexerDb) MarkImported(path string) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(string) error); ok {
 		r0 = rf(path)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetImportState provides a mock function with given fields: _a0
+func (_m *IndexerDb) SetImportState(_a0 idb.ImportState) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(idb.ImportState) error); ok {
+		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/idb/mocks/IndexerDb.go
+++ b/idb/mocks/IndexerDb.go
@@ -5,7 +5,9 @@ package mocks
 import (
 	context "context"
 
+	go_algorand_sdktypes "github.com/algorand/go-algorand-sdk/types"
 	generated "github.com/algorand/indexer/api/generated/v2"
+
 	idb "github.com/algorand/indexer/idb"
 
 	mock "github.com/stretchr/testify/mock"
@@ -122,6 +124,20 @@ func (_m *IndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round uint6
 	var r0 error
 	if rf, ok := ret.Get(0).(func(idb.RoundUpdates, uint64, uint64) error); ok {
 		r0 = rf(updates, round, rewardsBase)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeleteAccount provides a mock function with given fields: account
+func (_m *IndexerDb) DeleteAccount(account go_algorand_sdktypes.Address) error {
+	ret := _m.Called(account)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(go_algorand_sdktypes.Address) error); ok {
+		r0 = rf(account)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -363,7 +363,7 @@ func (db *IndexerDb) SetMetastate(key, jsonStrValue string) (err error) {
 	return
 }
 
-// GetMetastate is part of idb.IndexerDB
+// GetImportState is part of idb.IndexerDB
 func (db *IndexerDb) GetImportState() (state idb.ImportState, err error) {
 	var importStateJSON string
 	importStateJSON, err = db.GetMetastate(stateMetastateKey)

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -196,7 +196,7 @@ func (db *IndexerDb) CommitBlock(round uint64, timestamp int64, rewardslevel uin
 					ntxr[i] = v
 				}
 			}
-			db.log.Printf("txr %#v", ntxr)
+			db.log.Tracef("txr %#v", ntxr)
 		}
 		return fmt.Errorf("COPY txn Exec() %v", err)
 	}
@@ -215,7 +215,7 @@ func (db *IndexerDb) CommitBlock(round uint64, timestamp int64, rewardslevel uin
 		if err != nil {
 			//return err
 			for _, er := range db.txprows[:i+1] {
-				db.log.Printf("%s %d %d", base64.StdEncoding.EncodeToString(er[0].([]byte)), er[1], er[2])
+				db.log.Debugf("%s %d %d", base64.StdEncoding.EncodeToString(er[0].([]byte)), er[1], er[2])
 			}
 			return fmt.Errorf("%v, around txp row %#v", err, txpr)
 		}
@@ -308,7 +308,7 @@ func (db *IndexerDb) LoadGenesis(genesis types.Genesis) (err error) {
 		}
 	}
 	err = tx.Commit()
-	db.log.Printf("genesis %d accounts %d microalgos, err=%v", len(genesis.Allocation), total, err)
+	db.log.Infof("genesis %d accounts %d microalgos, err=%v", len(genesis.Allocation), total, err)
 	return err
 
 }
@@ -1211,7 +1211,7 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 		}
 	}
 	if !any {
-		db.log.Printf("empty round %d", round)
+		db.log.Debugf("empty round %d", round)
 	}
 	var istate idb.ImportState
 	staterow := tx.QueryRow(`SELECT v FROM metastate WHERE k = 'state'`)

--- a/importer/helper.go
+++ b/importer/helper.go
@@ -84,7 +84,7 @@ func (h *ImportHelper) Import(db idb.IndexerDb, args []string) {
 	initialImport := InitialImport(db, h.GenesisJSONPath, h.Log)
 	maybeFail(err, h.Log, "problem getting the max round")
 	filter := idb.UpdateFilter{
-		StartRound: -1,
+		StartRound: 0,
 	}
 	if h.NumRoundsLimit != 0 {
 		filter.RoundLimit = &h.NumRoundsLimit
@@ -249,7 +249,7 @@ func InitialImport(db idb.IndexerDb, genesisJSONPath string, l *log.Logger) bool
 // allTransactionsFor is a helper to iterate through all of the transactions
 func allTransactionsFor(db idb.IndexerDb, filter idb.UpdateFilter) <-chan idb.TxnRow {
 	if filter.Address == nil {
-		return db.YieldTxns(context.Background(), filter.StartRound)
+		return db.YieldTxns(context.Background(), filter.StartRound - 1)
 	}
 
 	result := make(chan idb.TxnRow)
@@ -285,7 +285,7 @@ func UpdateAccounting(db idb.IndexerDb, filter idb.UpdateFilter, l *log.Logger) 
 }
 
 func updateAccounting(db idb.IndexerDb, filter idb.UpdateFilter, l *log.Logger) (rounds, txnCount int) {
-	l.Infof("will start from round %d", filter.StartRound + 1)
+	l.Infof("will start from round %d", filter.StartRound)
 
 	rounds = 0
 	txnCount = 0

--- a/importer/helper.go
+++ b/importer/helper.go
@@ -85,7 +85,9 @@ func (h *ImportHelper) Import(db idb.IndexerDb, args []string) {
 	maybeFail(err, h.Log, "problem getting the max round")
 	filter := idb.UpdateFilter{
 		StartRound: -1,
-		RoundLimit: &h.NumRoundsLimit,
+	}
+	if h.NumRoundsLimit != 0 {
+		filter.RoundLimit = &h.NumRoundsLimit
 	}
 	if !initialImport {
 		state, err := db.GetImportState()

--- a/importer/helper.go
+++ b/importer/helper.go
@@ -224,7 +224,7 @@ func loadGenesis(db idb.IndexerDb, in io.Reader) (err error) {
 	return db.LoadGenesis(genesis)
 }
 
-// InititialImport imports the genesis block if needed. Returns true if the initial import occurred.
+// InitialImport imports the genesis block if needed. Returns true if the initial import occurred.
 func InitialImport(db idb.IndexerDb, genesisJSONPath string, l *log.Logger) bool {
 	stateJSONStr, err := db.GetMetastate("state")
 	maybeFail(err, l, "getting import state, %v", err)
@@ -238,11 +238,10 @@ func InitialImport(db idb.IndexerDb, genesisJSONPath string, l *log.Logger) bool
 			err = loadGenesis(db, gf)
 			maybeFail(err, l, "%s: could not load genesis json, %v", genesisJSONPath, err)
 			return true
-		} else {
-			l.Errorf("no import state recorded; need --genesis genesis.json file to get started")
-			os.Exit(1)
-			return false
 		}
+		l.Errorf("no import state recorded; need --genesis genesis.json file to get started")
+		os.Exit(1)
+		return false
 	}
 	return false
 }

--- a/test/common.sh
+++ b/test/common.sh
@@ -7,6 +7,7 @@ NET=localhost:8981
 CURL_TEMPFILE=curl_out.txt
 PIDFILE=testindexerpidfile
 CONNECTION_STRING="host=localhost user=algorand password=algorand dbname=DB_NAME_HERE port=5434 sslmode=disable"
+MAX_TIME=20
 
 ###################
 ## Print Helpers ##
@@ -78,7 +79,7 @@ function sql_test {
   done
 
   local ELAPSED=$(($SECONDS - $START))
-  if [ $ELAPSED -gt $MAX_TIME ]; then
+  if [[ $ELAPSED -gt $MAX_TIME ]]; then
     fail_and_exit "$DESCRIPTION" "$QUERY" "query duration too long, $ELAPSED > $MAX_TIME"
   fi
 
@@ -134,7 +135,7 @@ function rest_test {
   fi
 
   local ELAPSED=$(($SECONDS - $START))
-  if [ $ELAPSED -gt $MAX_TIME ]; then
+  if [[ $ELAPSED -gt $MAX_TIME ]]; then
     fail_and_exit "$DESCRIPTION" "$QUERY" "query duration too long, $ELAPSED > $MAX_TIME"
   fi
 
@@ -200,7 +201,7 @@ function start_indexer_with_blocks() {
   tar -xf "$2" -C $TEMPDIR
 
   if [ ! -z $3 ]; then
-    echo "Start args 'import -P \"${CONNECTION_STRING/DB_NAME_HERE/$1}\" --genesis \"$TEMPDIR/algod/genesis.json\" $TEMPDIR/blocktars/*"
+    echo "Start args 'import -P \"${CONNECTION_STRING/DB_NAME_HERE/$1}\" --genesis \"$TEMPDIR/algod/genesis.json\" $TEMPDIR/blocktars/*'"
     sleep infinity
   fi
   ALGORAND_DATA= ../cmd/algorand-indexer/algorand-indexer import \


### PR DESCRIPTION
# **This issue is deprecated, but contains some refactoring which should be pulled into a new PR.**

## Summary

Refactor `UpdateAccounting`:
- Move the init code to a separate function
- New "Filter" parameters for StartRound, RoundLimit, and a new Address filter. 
     - Use by `YieldTxns` wrapper, there is a different algorithm when there is an account filter.
     - `RoundUpdates` has a new `Filter` function, it is a no-op unless there is an address filter.

IndexerDb changes:
- Added `GetImportState` / `SetImportState` functions because ImportState is used outside of the postgres package.
- Added `DeleteAccount` function because the re-index algorithm needs a way to ensure the account is deleted before starting a re-index.
- Added an option to `Transactions` to configure whether the sort order is ascending or descending. It is not exposed in the API, I just needed it for fetching account transactions oldest to newest.

Reindex account subcommand:
- With the above changes this is little more than a wrapper to the `UpdateAccounting` function with an address filter.

## Test Plan

So far I'm using `Sandbox` to test, I'll use some of our e2e data archives next.