### PR TITLE
Will/prevent concurrent update

### DIFF
--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -1223,7 +1223,7 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 			return
 		}
 	}
-	tx.Exec(`SET TRANSACTION READ UNCOMMITTED`)
+	//tx.Exec(`SET TRANSACTION READ UNCOMMITTED`)
 	istate.AccountRound = int64(round)
 	sjs := string(json.Encode(istate))
 	result, err := tx.Exec(`INSERT INTO metastate (k, v) VALUES ($1, $2) ON CONFLICT (k) DO UPDATE SET v = EXCLUDED.v WHERE (v->>'account_round')::int < $3`, stateMetastateKey, sjs, istate.AccountRound)

--- a/importer/helper.go
+++ b/importer/helper.go
@@ -117,7 +117,7 @@ func maybeFail(err error, l *log.Logger, errfmt string, params ...interface{}) {
 	if err == nil {
 		return
 	}
-	l.Errorf(errfmt, params...)
+	l.WithError(err).Errorf(errfmt, params...)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
## Summary

This seems to fix the multiple writer issue.

## Test Plan

I have a version of sandbox which launches multiple sandbox instances. Without this fix it reliably double-counts transactions. With this fix things are correct.