### PR TITLE
always send json to PostgreSQL as a Go string not []byte

### DIFF
--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/algorand/go-algorand-sdk/encoding/json"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -185,7 +184,7 @@ func (bih *blockImporterHandler) HandleBlock(block *types.EncodedBlockCert) {
 			}
 		}
 		state.AccountRound = int64(block.Block.Round)
-		stateJSONStr = string(json.Encode(state))
+		stateJSONStr = idb.JSONOneLine(state)
 		err = db.SetMetastate("state", stateJSONStr)
 		if err != nil {
 			logger.WithError(err).Errorf("failed to save import state")

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -143,7 +143,7 @@ func (db *IndexerDb) StartBlock() (err error) {
 }
 
 // For App apply data, convert "string" keys which are secretly []byte blobs to their base64 representation so that JSON systems that require strings to be utf8 don't panic.
-func stxnToJSON(txn types.SignedTxnWithAD) []byte {
+func stxnToJSON(txn types.SignedTxnWithAD) string {
 	jt := txn
 	if len(jt.EvalDelta.GlobalDelta) > 0 {
 		gd := make(map[string]types.ValueDelta, len(jt.EvalDelta.GlobalDelta))
@@ -171,7 +171,7 @@ func (db *IndexerDb) AddTransaction(round uint64, intra int, txtypeenum int, ass
 	txnbytes := msgpack.Encode(txn)
 	jsonbytes := stxnToJSON(txn)
 	txid := crypto.TransactionIDString(txn.Txn)
-	tx := []interface{}{round, intra, txtypeenum, assetid, txid[:], txnbytes, string(jsonbytes)}
+	tx := []interface{}{round, intra, txtypeenum, assetid, txid[:], txnbytes, jsonbytes}
 	db.txrows = append(db.txrows, tx)
 	for _, paddr := range participation {
 		seen := false
@@ -257,8 +257,8 @@ func (db *IndexerDb) CommitBlock(round uint64, timestamp int64, rewardslevel uin
 	if err != nil {
 		return fmt.Errorf("decode header %v", err)
 	}
-	headerjson := json.Encode(block)
-	_, err = tx.Exec(`INSERT INTO block_header (round, realtime, rewardslevel, header) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`, round, time.Unix(timestamp, 0).UTC(), rewardslevel, string(headerjson))
+	headerjson := idb.JSONOneLine(block)
+	_, err = tx.Exec(`INSERT INTO block_header (round, realtime, rewardslevel, header) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`, round, time.Unix(timestamp, 0).UTC(), rewardslevel, headerjson)
 	if err != nil {
 		return fmt.Errorf("put block_header %v", err)
 	}
@@ -323,7 +323,7 @@ func (db *IndexerDb) LoadGenesis(genesis types.Genesis) (err error) {
 		if len(alloc.State.AssetParams) > 0 || len(alloc.State.Assets) > 0 {
 			return fmt.Errorf("genesis account[%d] has unhandled asset", ai)
 		}
-		_, err = setAccount.Exec(addr[:], alloc.State.MicroAlgos, string(idb.JSONOneLine(alloc.State)), 0)
+		_, err = setAccount.Exec(addr[:], alloc.State.MicroAlgos, idb.JSONOneLine(alloc.State), 0)
 		total += uint64(alloc.State.MicroAlgos)
 		if err != nil {
 			return fmt.Errorf("error setting genesis account[%d], %v", ai, err)
@@ -337,7 +337,7 @@ func (db *IndexerDb) LoadGenesis(genesis types.Genesis) (err error) {
 
 // SetProto is part of idb.IndexerDB
 func (db *IndexerDb) SetProto(version string, proto types.ConsensusParams) (err error) {
-	pj := string(idb.JSONOneLine(proto))
+	pj := idb.JSONOneLine(proto)
 	if err != nil {
 		return err
 	}
@@ -524,7 +524,7 @@ func b64(addr []byte) string {
 }
 
 func obs(x interface{}) string {
-	return string(idb.JSONOneLine(x))
+	return idb.JSONOneLine(x)
 }
 
 // StateSchema like go-algorand data/basics/teal.go
@@ -648,7 +648,7 @@ func (tkv *TealKeyValue) delete(key []byte) {
 
 // MarshalJSON wraps idb.JSONOneLine
 func (tkv TealKeyValue) MarshalJSON() ([]byte, error) {
-	return idb.JSONOneLine(tkv.They), nil
+	return []byte(idb.JSONOneLine(tkv.They)), nil
 }
 
 // UnmarshalJSON wraps json.Decode
@@ -810,7 +810,7 @@ func (db *IndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round, rewa
 		}
 		defer setkeyreg.Close()
 		for addr, adu := range updates.AccountDataUpdates {
-			jb := string(idb.JSONOneLine(adu))
+			jb := idb.JSONOneLine(adu)
 			_, err = setkeyreg.Exec(jb, addr[:])
 			if err != nil {
 				return fmt.Errorf("update keyreg, %v", err)
@@ -835,7 +835,7 @@ func (db *IndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round, rewa
 			}
 			var outparams string
 			if au.IsNew {
-				outparams = string(idb.JSONOneLine(au.Params))
+				outparams = idb.JSONOneLine(au.Params)
 			} else {
 				row := getacfg.QueryRow(au.AssetID)
 				var paramjson []byte
@@ -849,7 +849,7 @@ func (db *IndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round, rewa
 					return fmt.Errorf("bad acgf json %d, %v", au.AssetID, err)
 				}
 				np := types.MergeAssetConfig(old, au.Params)
-				outparams = string(idb.JSONOneLine(np))
+				outparams = idb.JSONOneLine(np)
 			}
 			_, err = setacfg.Exec(au.AssetID, au.Creator[:], outparams, round)
 			if err != nil {
@@ -1061,7 +1061,7 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 					return fmt.Errorf("app delta apply err r=%d i=%d app=%d, %v", adelta.Round, adelta.Intra, adelta.AppIndex, err)
 				}
 			}
-			reverseDeltas = append(reverseDeltas, []interface{}{string(idb.JSONOneLine(reverseDelta)), adelta.Round, adelta.Intra})
+			reverseDeltas = append(reverseDeltas, []interface{}{idb.JSONOneLine(reverseDelta), adelta.Round, adelta.Intra})
 			if adelta.OnCompletion == atypes.DeleteApplicationOC {
 				// clear content but leave row recording that it existed
 				state = AppParams{}
@@ -1101,7 +1101,7 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 				Valid: destroy[appid],
 			}
 			creator := appCreators[appid]
-			paramjson := string(idb.JSONOneLine(params))
+			paramjson := idb.JSONOneLine(params)
 			_, err = putglobal.Exec(appid, creator, paramjson, round, closedAt, destroy[appid])
 			if err != nil {
 				return fmt.Errorf("app global put pj=%v, %v", string(paramjson), err)
@@ -1159,7 +1159,7 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 				}
 			}
 			dirty = setDirtyAppLocalState(dirty, localstate)
-			reverseDeltas = append(reverseDeltas, []interface{}{string(idb.JSONOneLine(reverseDelta)), ald.Round, ald.Intra})
+			reverseDeltas = append(reverseDeltas, []interface{}{idb.JSONOneLine(reverseDelta), ald.Round, ald.Intra})
 		}
 
 		// update txns with reverse deltas
@@ -1186,7 +1186,7 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 			}
 			defer putglobal.Close()
 			for _, ld := range dirty {
-				_, err = putglobal.Exec(ld.address, ld.appIndex, string(idb.JSONOneLine(ld.AppLocalState)), round)
+				_, err = putglobal.Exec(ld.address, ld.appIndex, idb.JSONOneLine(ld.AppLocalState), round)
 				if err != nil {
 					return fmt.Errorf("app local put, %v", err)
 				}
@@ -1225,7 +1225,7 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 		}
 	}
 	istate.AccountRound = int64(round)
-	sjs := string(idb.JSONOneLine(istate))
+	sjs := idb.JSONOneLine(istate)
 	_, err = tx.Exec(setMetastateUpsert, stateMetastateKey, sjs)
 	if err != nil {
 		return
@@ -2698,7 +2698,7 @@ func (db *IndexerDb) GetSpecialAccounts() (accounts idb.SpecialAccounts, err err
 			RewardsPool: block.RewardsPool,
 		}
 
-		cache := string(idb.JSONOneLine(accounts))
+		cache := idb.JSONOneLine(accounts)
 		err = db.SetMetastate(specialAccountsMetastateKey, cache)
 		if err != nil {
 			return idb.SpecialAccounts{}, fmt.Errorf("problem saving metastate: %v", err)

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -171,7 +171,7 @@ func (db *IndexerDb) AddTransaction(round uint64, intra int, txtypeenum int, ass
 	txnbytes := msgpack.Encode(txn)
 	jsonbytes := stxnToJSON(txn)
 	txid := crypto.TransactionIDString(txn.Txn)
-	tx := []interface{}{round, intra, txtypeenum, assetid, txid[:], txnbytes, jsonbytes}
+	tx := []interface{}{round, intra, txtypeenum, assetid, txid[:], txnbytes, string(jsonbytes)}
 	db.txrows = append(db.txrows, tx)
 	for _, paddr := range participation {
 		seen := false
@@ -323,7 +323,7 @@ func (db *IndexerDb) LoadGenesis(genesis types.Genesis) (err error) {
 		if len(alloc.State.AssetParams) > 0 || len(alloc.State.Assets) > 0 {
 			return fmt.Errorf("genesis account[%d] has unhandled asset", ai)
 		}
-		_, err = setAccount.Exec(addr[:], alloc.State.MicroAlgos, string(json.Encode(alloc.State)), 0)
+		_, err = setAccount.Exec(addr[:], alloc.State.MicroAlgos, string(idb.JSONOneLine(alloc.State)), 0)
 		total += uint64(alloc.State.MicroAlgos)
 		if err != nil {
 			return fmt.Errorf("error setting genesis account[%d], %v", ai, err)
@@ -337,7 +337,7 @@ func (db *IndexerDb) LoadGenesis(genesis types.Genesis) (err error) {
 
 // SetProto is part of idb.IndexerDB
 func (db *IndexerDb) SetProto(version string, proto types.ConsensusParams) (err error) {
-	pj := json.Encode(proto)
+	pj := string(idb.JSONOneLine(proto))
 	if err != nil {
 		return err
 	}
@@ -524,7 +524,7 @@ func b64(addr []byte) string {
 }
 
 func obs(x interface{}) string {
-	return string(json.Encode(x))
+	return string(idb.JSONOneLine(x))
 }
 
 // StateSchema like go-algorand data/basics/teal.go
@@ -646,9 +646,9 @@ func (tkv *TealKeyValue) delete(key []byte) {
 	}
 }
 
-// MarshalJSON wraps json.Encode
+// MarshalJSON wraps idb.JSONOneLine
 func (tkv TealKeyValue) MarshalJSON() ([]byte, error) {
-	return json.Encode(tkv.They), nil
+	return idb.JSONOneLine(tkv.They), nil
 }
 
 // UnmarshalJSON wraps json.Decode
@@ -810,7 +810,7 @@ func (db *IndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round, rewa
 		}
 		defer setkeyreg.Close()
 		for addr, adu := range updates.AccountDataUpdates {
-			jb := json.Encode(adu)
+			jb := string(idb.JSONOneLine(adu))
 			_, err = setkeyreg.Exec(jb, addr[:])
 			if err != nil {
 				return fmt.Errorf("update keyreg, %v", err)
@@ -835,7 +835,7 @@ func (db *IndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round, rewa
 			}
 			var outparams string
 			if au.IsNew {
-				outparams = string(json.Encode(au.Params))
+				outparams = string(idb.JSONOneLine(au.Params))
 			} else {
 				row := getacfg.QueryRow(au.AssetID)
 				var paramjson []byte
@@ -849,7 +849,7 @@ func (db *IndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round, rewa
 					return fmt.Errorf("bad acgf json %d, %v", au.AssetID, err)
 				}
 				np := types.MergeAssetConfig(old, au.Params)
-				outparams = string(json.Encode(np))
+				outparams = string(idb.JSONOneLine(np))
 			}
 			_, err = setacfg.Exec(au.AssetID, au.Creator[:], outparams, round)
 			if err != nil {
@@ -901,7 +901,6 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 			return fmt.Errorf("prepare asset close2, %v", err)
 		}
 		defer acd.Close()
-
 
 		for _, subround := range updates.AssetUpdates {
 			for addr, aulist := range subround {
@@ -1062,7 +1061,7 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 					return fmt.Errorf("app delta apply err r=%d i=%d app=%d, %v", adelta.Round, adelta.Intra, adelta.AppIndex, err)
 				}
 			}
-			reverseDeltas = append(reverseDeltas, []interface{}{json.Encode(reverseDelta), adelta.Round, adelta.Intra})
+			reverseDeltas = append(reverseDeltas, []interface{}{string(idb.JSONOneLine(reverseDelta)), adelta.Round, adelta.Intra})
 			if adelta.OnCompletion == atypes.DeleteApplicationOC {
 				// clear content but leave row recording that it existed
 				state = AppParams{}
@@ -1102,7 +1101,7 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 				Valid: destroy[appid],
 			}
 			creator := appCreators[appid]
-			paramjson := json.Encode(params)
+			paramjson := string(idb.JSONOneLine(params))
 			_, err = putglobal.Exec(appid, creator, paramjson, round, closedAt, destroy[appid])
 			if err != nil {
 				return fmt.Errorf("app global put pj=%v, %v", string(paramjson), err)
@@ -1160,7 +1159,7 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 				}
 			}
 			dirty = setDirtyAppLocalState(dirty, localstate)
-			reverseDeltas = append(reverseDeltas, []interface{}{json.Encode(reverseDelta), ald.Round, ald.Intra})
+			reverseDeltas = append(reverseDeltas, []interface{}{string(idb.JSONOneLine(reverseDelta)), ald.Round, ald.Intra})
 		}
 
 		// update txns with reverse deltas
@@ -1187,7 +1186,7 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 			}
 			defer putglobal.Close()
 			for _, ld := range dirty {
-				_, err = putglobal.Exec(ld.address, ld.appIndex, json.Encode(ld.AppLocalState), round)
+				_, err = putglobal.Exec(ld.address, ld.appIndex, string(idb.JSONOneLine(ld.AppLocalState)), round)
 				if err != nil {
 					return fmt.Errorf("app local put, %v", err)
 				}
@@ -1226,7 +1225,7 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 		}
 	}
 	istate.AccountRound = int64(round)
-	sjs := string(json.Encode(istate))
+	sjs := string(idb.JSONOneLine(istate))
 	_, err = tx.Exec(setMetastateUpsert, stateMetastateKey, sjs)
 	if err != nil {
 		return
@@ -1824,7 +1823,7 @@ func (db *IndexerDb) yieldAccountsThread(req *getAccountsRequest) {
 				break
 			}
 
-			if len(hamounts) != len(haids) || len(hfrozen) != len(haids) || len(holdingCreated) != len(haids) || len(holdingClosed) != len(haids) || len(holdingDeleted) != len(haids){
+			if len(hamounts) != len(haids) || len(hfrozen) != len(haids) || len(holdingCreated) != len(haids) || len(holdingClosed) != len(haids) || len(holdingDeleted) != len(haids) {
 				err = fmt.Errorf("account asset holding unpacking, all should be %d:  %d amounts, %d frozen, %d created, %d closed, %d deleted",
 					len(haids), len(hamounts), len(hfrozen), len(holdingCreated), len(holdingClosed), len(holdingDeleted))
 				req.out <- idb.AccountRow{Error: err}
@@ -2699,7 +2698,7 @@ func (db *IndexerDb) GetSpecialAccounts() (accounts idb.SpecialAccounts, err err
 			RewardsPool: block.RewardsPool,
 		}
 
-		cache := string(json.Encode(accounts))
+		cache := string(idb.JSONOneLine(accounts))
 		err = db.SetMetastate(specialAccountsMetastateKey, cache)
 		if err != nil {
 			return idb.SpecialAccounts{}, fmt.Errorf("problem saving metastate: %v", err)

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -145,7 +145,7 @@ func (db *IndexerDb) markMigrationsAsDone() (err error) {
 	state := MigrationState{
 		NextMigration: len(migrations),
 	}
-	migrationStateJSON := string(json.Encode(state))
+	migrationStateJSON := idb.JSONOneLine(state)
 	return db.SetMetastate(migrationMetastateKey, migrationStateJSON)
 }
 
@@ -292,7 +292,7 @@ func m3acfgFixAsyncInner(db *IndexerDb, state *MigrationState, assetIds []int64)
 		if now.Sub(lastlog) > (5 * time.Second) {
 			db.log.Printf("acfg fix next=%d", aid)
 			state.NextAssetID = aid
-			migrationStateJSON := json.Encode(state)
+			migrationStateJSON := idb.JSONOneLine(state)
 			_, err = tx.Exec(setMetastateUpsert, migrationMetastateKey, migrationStateJSON)
 			if err != nil {
 				db.log.WithError(err).Errorf("acfg fix migration %d meta err", state.NextMigration)
@@ -332,7 +332,7 @@ func m3acfgFixAsyncInner(db *IndexerDb, state *MigrationState, assetIds []int64)
 				params = types.MergeAssetConfig(params, stxn.Txn.AssetParams)
 			}
 		}
-		outparams := json.Encode(params)
+		outparams := idb.JSONOneLine(params)
 		_, err = setacfg.Exec(aid, creator[:], outparams)
 		if err != nil {
 			db.log.WithError(err).Errorf("acfg fix asset update")
@@ -341,7 +341,7 @@ func m3acfgFixAsyncInner(db *IndexerDb, state *MigrationState, assetIds []int64)
 	}
 	state.NextAssetID = 0
 	state.NextMigration++
-	migrationStateJSON := json.Encode(state)
+	migrationStateJSON := idb.JSONOneLine(state)
 	_, err = tx.Exec(setMetastateUpsert, migrationMetastateKey, migrationStateJSON)
 	if err != nil {
 		db.log.WithError(err).Errorf("acfg fix migration %d meta err", state.NextMigration)
@@ -500,7 +500,7 @@ func updateClose(cc *createClose, value uint64) *createClose {
 			},
 			deleted: sql.NullBool{
 				Valid: true,
-				Bool: true,
+				Bool:  true,
 			},
 		}
 	}
@@ -529,7 +529,7 @@ func updateCreate(cc *createClose, value uint64) *createClose {
 			},
 			deleted: sql.NullBool{
 				Valid: true,
-				Bool: false,
+				Bool:  false,
 			},
 		}
 	}
@@ -838,7 +838,7 @@ func m5RewardsAndDatesPart2UpdateAccounts(db *IndexerDb, state *MigrationState, 
 	} else {
 		state.NextAccount = finalAddress[:]
 	}
-	migrationStateJSON := json.Encode(state)
+	migrationStateJSON := idb.JSONOneLine(state)
 	_, err = tx.Exec(setMetastateUpsert, migrationMetastateKey, migrationStateJSON)
 	if err != nil {
 		return fmt.Errorf("%s: failed to update migration checkpoint: %v", rewardsCreateCloseUpdateErr, err)
@@ -870,7 +870,7 @@ func sqlMigration(db *IndexerDb, state *MigrationState, sqlLines []string) error
 		}
 	}
 	state.NextMigration++
-	migrationStateJSON := json.Encode(state)
+	migrationStateJSON := idb.JSONOneLine(state)
 	_, err = tx.Exec(setMetastateUpsert, migrationMetastateKey, migrationStateJSON)
 	if err != nil {
 		db.log.WithError(err).Errorf("migration %d meta err", thisMigration)
@@ -959,7 +959,7 @@ func (mtxid *txidFiuxpMigrationContext) asyncTxidFixup() (err error) {
 	// all done, mark migration state
 	state.NextMigration++
 	state.NextRound = 0
-	migrationStateJSON := string(json.Encode(state))
+	migrationStateJSON := idb.JSONOneLine(state)
 	err = db.SetMetastate(migrationMetastateKey, migrationStateJSON)
 	if err != nil {
 		db.log.WithError(err).Errorf("%s, error setting final migration state", txidMigrationErrMsg)
@@ -1080,7 +1080,7 @@ func (mtxid *txidFiuxpMigrationContext) putTxidFixupBatch(batch []idb.TxnRow) er
 		return err
 	}
 	txstate.NextRound = int64(maxRound + 1)
-	migrationStateJSON := json.Encode(txstate)
+	migrationStateJSON := idb.JSONOneLine(txstate)
 	_, err = tx.Exec(setMetastateUpsert, migrationMetastateKey, migrationStateJSON)
 	if err != nil {
 		db.log.WithError(err).Errorf("%s, set metastate err", txidMigrationErrMsg)

--- a/idb/transcode.go
+++ b/idb/transcode.go
@@ -3,8 +3,6 @@ package idb
 import (
 	"fmt"
 
-	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
-
 	"github.com/algorand/go-codec/codec"
 )
 
@@ -38,22 +36,12 @@ func stringifyMap(ob map[interface{}]interface{}) map[interface{}]interface{} {
 	return out
 }
 
-// MsgpackToJSON converts a messagepack object into JSON
-func MsgpackToJSON(msgp []byte) (js []byte, err error) {
-	var ob map[interface{}]interface{}
-	err = msgpack.Decode(msgp, &ob)
-	if err != nil {
-		return
-	}
-	return JSONOneLine(Stringify(ob)), nil
-}
-
 // JSONOneLine converts an object into JSON
-func JSONOneLine(obj interface{}) []byte {
+func JSONOneLine(obj interface{}) string {
 	var b []byte
 	enc := codec.NewEncoderBytes(&b, oneLineJSONCodecHandle)
 	enc.MustEncode(obj)
-	return b
+	return string(b)
 }
 
 var oneLineJSONCodecHandle *codec.JsonHandle


### PR DESCRIPTION
## Summary

`lib/pq` can choke on sending json as []byte where it works as string.

## Test Plan

This worked locally on e2elive.py with extended data to exercise a seen bug.