### PR TITLE
GetMaxRound use metastate account_round instead of max block header.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
 - make lint
 - make
 - make integration
-- make test
+- make test -B
 #- ./test/perf.sh "$TEST_CONNECTION_STRING_1" && ./test/perf.sh "$TEST_CONNECTION_STRING_2"
 - make fakepackage
 - docker build -t e2e_tests -f docker/Dockerfile.mule .

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ idb/postgres/setup_postgres_sql.go:	idb/postgres/setup_postgres.sql
 types/protocols_json.go:	types/protocols.json types/consensus.go
 	cd types && go generate
 
-mocks:
+idb/mocks/IndexerDb.go:	idb/dummy.go
 	go get github.com/vektra/mockery/.../
 	cd idb && mockery -name=IndexerDb
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ idb/postgres/setup_postgres_sql.go:	idb/postgres/setup_postgres.sql
 types/protocols_json.go:	types/protocols.json types/consensus.go
 	cd types && go generate
 
-idb/mocks/IndexerDb.go:	idb/dummy.go
+mocks:
 	go get github.com/vektra/mockery/.../
 	cd idb && mockery -name=IndexerDb
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -102,7 +102,7 @@ func (si *ServerImplementation) LookupAccountByID(ctx echo.Context, accountID st
 		return indexerError(ctx, fmt.Sprintf("%s: %s", errMultipleAccounts, accountID))
 	}
 
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -157,7 +157,7 @@ func (si *ServerImplementation) SearchForAccounts(ctx echo.Context, params gener
 		return indexerError(ctx, fmt.Sprintf("%s: %v", errFailedSearchingAccount, err))
 	}
 
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -215,7 +215,7 @@ func (si *ServerImplementation) LookupAccountTransactions(ctx echo.Context, acco
 // (GET /v2/applications)
 func (si *ServerImplementation) SearchForApplications(ctx echo.Context, params generated.SearchForApplicationsParams) error {
 	results := si.db.Applications(ctx.Request().Context(), &params)
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -246,7 +246,7 @@ func (si *ServerImplementation) LookupApplicationByID(ctx echo.Context, applicat
 	var params generated.SearchForApplicationsParams
 	params.ApplicationId = &applicationID
 	results := si.db.Applications(ctx.Request().Context(), &params)
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -288,7 +288,7 @@ func (si *ServerImplementation) LookupAssetByID(ctx echo.Context, assetID uint64
 		return indexerError(ctx, fmt.Sprintf("%s: %d", errMultipleAssets, assetID))
 	}
 
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -322,7 +322,7 @@ func (si *ServerImplementation) LookupAssetBalances(ctx echo.Context, assetID ui
 		indexerError(ctx, err.Error())
 	}
 
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -380,7 +380,7 @@ func (si *ServerImplementation) SearchForAssets(ctx echo.Context, params generat
 		return indexerError(ctx, err.Error())
 	}
 
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -439,7 +439,7 @@ func (si *ServerImplementation) LookupTransactions(ctx echo.Context, txid string
 		return indexerError(ctx, fmt.Sprintf("%s: %s", errMultipleTransactions, txid))
 	}
 
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -466,7 +466,7 @@ func (si *ServerImplementation) SearchForTransactions(ctx echo.Context, params g
 		return indexerError(ctx, fmt.Sprintf("%s: %v", errTransactionSearch, err))
 	}
 
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -79,10 +79,10 @@ var daemonCmd = &cobra.Command{
 		}
 		if bot != nil {
 			logger.Info("Initializing block import handler.")
-			maxRound, err := db.GetMaxRound()
+			maxRound, err := db.GetMaxRoundLoaded()
 			maybeFail(err, "failed to get max round, %v", err)
 			if maxRound != 0 {
-				bot.SetNextRound(maxRound)
+				bot.SetNextRound(maxRound + 1)
 			}
 			cache, err := db.GetDefaultFrozen()
 			maybeFail(err, "failed to get default frozen cache")

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -82,7 +82,7 @@ var daemonCmd = &cobra.Command{
 			maxRound, err := db.GetMaxRound()
 			maybeFail(err, "failed to get max round, %v", err)
 			if maxRound != 0 {
-				bot.SetNextRound(maxRound + 1)
+				bot.SetNextRound(maxRound)
 			}
 			cache, err := db.GetDefaultFrozen()
 			maybeFail(err, "failed to get default frozen cache")

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -81,8 +81,13 @@ func (db *dummyIndexerDb) SetMetastate(key, jsonStrValue string) (err error) {
 	return nil
 }
 
-// GetMaxRound is part of idb.IndexerDB
-func (db *dummyIndexerDb) GetMaxRound() (round uint64, err error) {
+// GetMaxRoundAccounted is part of idb.IndexerDB
+func (db *dummyIndexerDb) GetMaxRoundAccounted() (round uint64, err error) {
+	return 0, nil
+}
+
+// GetMaxRoundLoaded is part of idb.IndexerDB
+func (db *dummyIndexerDb) GetMaxRoundLoaded() (round uint64, err error) {
 	return 0, nil
 }
 
@@ -217,7 +222,8 @@ type IndexerDb interface {
 
 	GetMetastate(key string) (jsonStrValue string, err error)
 	SetMetastate(key, jsonStrValue string) (err error)
-	GetMaxRound() (round uint64, err error)
+	GetMaxRoundAccounted() (round uint64, err error)
+	GetMaxRoundLoaded() (round uint64, err error)
 	GetSpecialAccounts() (SpecialAccounts, error)
 	GetDefaultFrozen() (defaultFrozen map[uint64]bool, err error)
 

--- a/idb/mocks/IndexerDb.go
+++ b/idb/mocks/IndexerDb.go
@@ -189,8 +189,29 @@ func (_m *IndexerDb) GetDefaultFrozen() (map[uint64]bool, error) {
 	return r0, r1
 }
 
-// GetMaxRound provides a mock function with given fields:
-func (_m *IndexerDb) GetMaxRound() (uint64, error) {
+// GetMaxRoundAccounted provides a mock function with given fields:
+func (_m *IndexerDb) GetMaxRoundAccounted() (uint64, error) {
+	ret := _m.Called()
+
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func() uint64); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetMaxRoundLoaded provides a mock function with given fields:
+func (_m *IndexerDb) GetMaxRoundLoaded() (uint64, error) {
 	ret := _m.Called()
 
 	var r0 uint64

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -398,13 +398,13 @@ func (db *IndexerDb) SetMetastate(key, jsonStrValue string) (err error) {
 
 // GetMaxRound is part of idb.IndexerDB
 func (db *IndexerDb) GetMaxRound() (round uint64, err error) {
-	var nullableRound sql.NullInt64
-	round = 0
-	row := db.db.QueryRow(`SELECT max(round) FROM block_header`)
-	err = row.Scan(&nullableRound)
+	//var round uint64
+	row := db.db.QueryRow(`select coalesce((v->>'account_round')::bigint, 0) from metastate where k = 'state'`)
+	err = row.Scan(&round)
 
-	if err == nil && nullableRound.Valid {
-		round = uint64(nullableRound.Int64)
+	if err == sql.ErrNoRows {
+		err = nil
+		round = 0
 	}
 
 	return

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -396,8 +396,8 @@ func (db *IndexerDb) SetMetastate(key, jsonStrValue string) (err error) {
 	return
 }
 
-// GetMaxRound is part of idb.IndexerDB
-func (db *IndexerDb) GetMaxRound() (round uint64, err error) {
+// GetMaxRoundAccounted is part of idb.IndexerDB
+func (db *IndexerDb) GetMaxRoundAccounted() (round uint64, err error) {
 	//var round uint64
 	row := db.db.QueryRow(`select coalesce((v->>'account_round')::bigint, 0) from metastate where k = 'state'`)
 	err = row.Scan(&round)
@@ -405,6 +405,19 @@ func (db *IndexerDb) GetMaxRound() (round uint64, err error) {
 	if err == sql.ErrNoRows {
 		err = nil
 		round = 0
+	}
+
+	return
+}
+
+// GetMaxRoundLoaded is part of idb.IndexerDB
+func (db *IndexerDb) GetMaxRoundLoaded() (round uint64, err error) {
+	var nullableRound sql.NullInt64
+	round = 0
+	row := db.db.QueryRow(`SELECT max(round) FROM block_header`)
+	err = row.Scan(&nullableRound)
+	if err == nil && nullableRound.Valid {
+		round = uint64(nullableRound.Int64)
 	}
 
 	return
@@ -2702,7 +2715,7 @@ func (db *IndexerDb) Health() (idb.Health, error) {
 
 	data["migration-required"] = migrationRequired
 
-	round, err := db.GetMaxRound()
+	round, err := db.GetMaxRoundAccounted()
 	return idb.Health{
 		Data:        &data,
 		Round:       round,

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -358,7 +358,7 @@ func m3acfgFixAsyncInner(db *IndexerDb, state *MigrationState, assetIds []int64)
 // m5RewardsAndDatesPart1 adds the new rewards_total column to the account table.
 func m5RewardsAndDatesPart1(db *IndexerDb, state *MigrationState) error {
 	// Cache the round in the migration metastate
-	round, err := db.GetMaxRound()
+	round, err := db.GetMaxRoundAccounted()
 	if err != nil {
 		db.log.WithError(err).Errorf("%s: problem caching max round: %v", rewardsCreateCloseUpdateErr, err)
 		return err


### PR DESCRIPTION
## Summary

Modify GetMaxRound to return the accounting_round instead of the max block round.

## Test Plan

New unit tests.