### PR TITLE
(release branch) GetMaxRound use metastate account_round instead of max block header.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
 - make lint
 - make
 - make integration
-- make test
+- make test -B
 #- ./test/perf.sh "$TEST_CONNECTION_STRING_1" && ./test/perf.sh "$TEST_CONNECTION_STRING_2"
 - make fakepackage
 - docker build -t e2e_tests -f docker/Dockerfile.mule .

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
     - python3-setuptools
     - python3-wheel
 script:
+- echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 - make lint
 - make
 - make integration

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ idb/postgres/setup_postgres_sql.go:	idb/postgres/setup_postgres.sql
 types/protocols_json.go:	types/protocols.json types/consensus.go
 	cd types && go generate
 
-idb/mocks/IndexerDb.go:	idb/dummy.go
+mocks:
 	go get github.com/vektra/mockery/.../
 	cd idb && mockery -name=IndexerDb
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -102,7 +102,7 @@ func (si *ServerImplementation) LookupAccountByID(ctx echo.Context, accountID st
 		return indexerError(ctx, fmt.Sprintf("%s: %s", errMultipleAccounts, accountID))
 	}
 
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -157,7 +157,7 @@ func (si *ServerImplementation) SearchForAccounts(ctx echo.Context, params gener
 		return indexerError(ctx, fmt.Sprintf("%s: %v", errFailedSearchingAccount, err))
 	}
 
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -215,7 +215,7 @@ func (si *ServerImplementation) LookupAccountTransactions(ctx echo.Context, acco
 // (GET /v2/applications)
 func (si *ServerImplementation) SearchForApplications(ctx echo.Context, params generated.SearchForApplicationsParams) error {
 	results := si.db.Applications(ctx.Request().Context(), &params)
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -246,7 +246,7 @@ func (si *ServerImplementation) LookupApplicationByID(ctx echo.Context, applicat
 	var params generated.SearchForApplicationsParams
 	params.ApplicationId = &applicationID
 	results := si.db.Applications(ctx.Request().Context(), &params)
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -288,7 +288,7 @@ func (si *ServerImplementation) LookupAssetByID(ctx echo.Context, assetID uint64
 		return indexerError(ctx, fmt.Sprintf("%s: %d", errMultipleAssets, assetID))
 	}
 
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -322,7 +322,7 @@ func (si *ServerImplementation) LookupAssetBalances(ctx echo.Context, assetID ui
 		indexerError(ctx, err.Error())
 	}
 
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -380,7 +380,7 @@ func (si *ServerImplementation) SearchForAssets(ctx echo.Context, params generat
 		return indexerError(ctx, err.Error())
 	}
 
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -439,7 +439,7 @@ func (si *ServerImplementation) LookupTransactions(ctx echo.Context, txid string
 		return indexerError(ctx, fmt.Sprintf("%s: %s", errMultipleTransactions, txid))
 	}
 
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -466,7 +466,7 @@ func (si *ServerImplementation) SearchForTransactions(ctx echo.Context, params g
 		return indexerError(ctx, fmt.Sprintf("%s: %v", errTransactionSearch, err))
 	}
 
-	round, err := si.db.GetMaxRound()
+	round, err := si.db.GetMaxRoundAccounted()
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -79,10 +79,10 @@ var daemonCmd = &cobra.Command{
 		}
 		if bot != nil {
 			logger.Info("Initializing block import handler.")
-			maxRound, err := db.GetMaxRound()
+			maxRound, err := db.GetMaxRoundLoaded()
 			maybeFail(err, "failed to get max round, %v", err)
 			if maxRound != 0 {
-				bot.SetNextRound(maxRound)
+				bot.SetNextRound(maxRound + 1)
 			}
 			bih := blockImporterHandler{
 				imp:   importer.NewDBImporter(db),

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -82,7 +82,7 @@ var daemonCmd = &cobra.Command{
 			maxRound, err := db.GetMaxRound()
 			maybeFail(err, "failed to get max round, %v", err)
 			if maxRound != 0 {
-				bot.SetNextRound(maxRound + 1)
+				bot.SetNextRound(maxRound)
 			}
 			bih := blockImporterHandler{
 				imp:   importer.NewDBImporter(db),

--- a/docker/Dockerfile.mule
+++ b/docker/Dockerfile.mule
@@ -8,7 +8,7 @@ ENV GOROOT=/usr/local/go
 ENV GOPATH=$HOME/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
-RUN apt-get update && apt-get install -y apt-transport-https awscli ca-certificates build-essential curl git software-properties-common gnupg2  && \
+RUN apt-get update && apt-get install -y apt-transport-https awscli ca-certificates build-essential curl git software-properties-common gnupg2 && \
     curl https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz | tar xzf - && \
     mv go /usr/local && \
     export PATH=/usr/local/go/bin:$PATH && \
@@ -18,8 +18,6 @@ RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" && \
     apt-get update && apt-get install -y postgresql-12 libpq-dev python3 python3-dev python3-psycopg2 python3-pip sudo && \
     pip3 install boto3 markdown2 "msgpack >=1" py-algorand-sdk
-
-RUN go get github.com/vektra/mockery/.../
 
 COPY ./ $HOME/go/src/github.com/algorand/indexer/
 WORKDIR $HOME/go/src/github.com/algorand/indexer/

--- a/docker/Dockerfile.mule
+++ b/docker/Dockerfile.mule
@@ -19,6 +19,11 @@ RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update && apt-get install -y postgresql-12 libpq-dev python3 python3-dev python3-psycopg2 python3-pip sudo && \
     pip3 install boto3 markdown2 "msgpack >=1" py-algorand-sdk
 
+ADD https://github.com/vektra/mockery/releases/download/v2.5.1/mockery_2.5.1_Linux_x86_64.tar.gz /tmp/
+RUN tar -xzf /tmp/mockery_2.5.1_Linux_x86_64.tar.gz -C /tmp mockery && \
+    mv /tmp/mockery /usr/local/bin && \
+    rm /tmp/mockery_2.5.1_Linux_x86_64.tar.gz
+
 COPY ./ $HOME/go/src/github.com/algorand/indexer/
 WORKDIR $HOME/go/src/github.com/algorand/indexer/
 CMD ["/bin/bash"]

--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,6 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
 	github.com/valyala/fasttemplate v1.2.0 // indirect
+	github.com/vektra/mockery v1.1.2 // indirect
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -449,6 +449,8 @@ github.com/valyala/fasttemplate v1.1.0 h1:RZqt0yGBsps8NGvLSGW804QQqCUYYLsaOjTVHy
 github.com/valyala/fasttemplate v1.1.0/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.0 h1:y3yXRCoDvC2HTtIHvL2cc7Zd+bqA+zqDO6oQzsJO07E=
 github.com/valyala/fasttemplate v1.2.0/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
+github.com/vektra/mockery v1.1.2 h1:uc0Yn67rJpjt8U/mAZimdCKn9AeA97BOkjpmtBSlfP4=
+github.com/vektra/mockery v1.1.2/go.mod h1:VcfZjKaFOPO+MpN4ZvwPjs4c48lkq1o3Ym8yHZJu0jU=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
@@ -681,6 +683,7 @@ golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
+golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200423205358-59e73619c742 h1:9OGWpORUXvk8AsaBJlpzzDx7Srv/rSK6rvjcsJq4rJo=
 golang.org/x/tools v0.0.0-20200423205358-59e73619c742/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -81,8 +81,13 @@ func (db *dummyIndexerDb) SetMetastate(key, jsonStrValue string) (err error) {
 	return nil
 }
 
-// GetMaxRound is part of idb.IndexerDB
-func (db *dummyIndexerDb) GetMaxRound() (round uint64, err error) {
+// GetMaxRoundAccounted is part of idb.IndexerDB
+func (db *dummyIndexerDb) GetMaxRoundAccounted() (round uint64, err error) {
+	return 0, nil
+}
+
+// GetMaxRoundLoaded is part of idb.IndexerDB
+func (db *dummyIndexerDb) GetMaxRoundLoaded() (round uint64, err error) {
 	return 0, nil
 }
 
@@ -212,7 +217,8 @@ type IndexerDb interface {
 
 	GetMetastate(key string) (jsonStrValue string, err error)
 	SetMetastate(key, jsonStrValue string) (err error)
-	GetMaxRound() (round uint64, err error)
+	GetMaxRoundAccounted() (round uint64, err error)
+	GetMaxRoundLoaded() (round uint64, err error)
 	GetSpecialAccounts() (SpecialAccounts, error)
 
 	// YieldTxns returns a channel that produces the whole transaction stream after some round forward

--- a/idb/mocks/IndexerDb.go
+++ b/idb/mocks/IndexerDb.go
@@ -166,8 +166,52 @@ func (_m *IndexerDb) GetBlock(round uint64) (types.Block, error) {
 	return r0, r1
 }
 
-// GetMaxRound provides a mock function with given fields:
-func (_m *IndexerDb) GetMaxRound() (uint64, error) {
+// GetDefaultFrozen provides a mock function with given fields:
+func (_m *IndexerDb) GetDefaultFrozen() (map[uint64]bool, error) {
+	ret := _m.Called()
+
+	var r0 map[uint64]bool
+	if rf, ok := ret.Get(0).(func() map[uint64]bool); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[uint64]bool)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetMaxRoundAccounted provides a mock function with given fields:
+func (_m *IndexerDb) GetMaxRoundAccounted() (uint64, error) {
+	ret := _m.Called()
+
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func() uint64); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetMaxRoundLoaded provides a mock function with given fields:
+func (_m *IndexerDb) GetMaxRoundLoaded() (uint64, error) {
 	ret := _m.Called()
 
 	var r0 uint64

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -395,8 +395,8 @@ func (db *IndexerDb) SetMetastate(key, jsonStrValue string) (err error) {
 	return
 }
 
-// GetMaxRound is part of idb.IndexerDB
-func (db *IndexerDb) GetMaxRound() (round uint64, err error) {
+// GetMaxRoundAccounted is part of idb.IndexerDB
+func (db *IndexerDb) GetMaxRoundAccounted() (round uint64, err error) {
 	//var round uint64
 	row := db.db.QueryRow(`select coalesce((v->>'account_round')::bigint, 0) from metastate where k = 'state'`)
 	err = row.Scan(&round)
@@ -404,6 +404,19 @@ func (db *IndexerDb) GetMaxRound() (round uint64, err error) {
 	if err == sql.ErrNoRows {
 		err = nil
 		round = 0
+	}
+
+	return
+}
+
+// GetMaxRoundLoaded is part of idb.IndexerDB
+func (db *IndexerDb) GetMaxRoundLoaded() (round uint64, err error) {
+	var nullableRound sql.NullInt64
+	round = 0
+	row := db.db.QueryRow(`SELECT max(round) FROM block_header`)
+	err = row.Scan(&nullableRound)
+	if err == nil && nullableRound.Valid {
+		round = uint64(nullableRound.Int64)
 	}
 
 	return
@@ -2687,7 +2700,7 @@ func (db *IndexerDb) Health() (idb.Health, error) {
 
 	data["migration-required"] = migrationRequired
 
-	round, err := db.GetMaxRound()
+	round, err := db.GetMaxRoundAccounted()
 	return idb.Health{
 		Data:        &data,
 		Round:       round,

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -397,13 +397,13 @@ func (db *IndexerDb) SetMetastate(key, jsonStrValue string) (err error) {
 
 // GetMaxRound is part of idb.IndexerDB
 func (db *IndexerDb) GetMaxRound() (round uint64, err error) {
-	var nullableRound sql.NullInt64
-	round = 0
-	row := db.db.QueryRow(`SELECT max(round) FROM block_header`)
-	err = row.Scan(&nullableRound)
+	//var round uint64
+	row := db.db.QueryRow(`select coalesce((v->>'account_round')::bigint, 0) from metastate where k = 'state'`)
+	err = row.Scan(&round)
 
-	if err == nil && nullableRound.Valid {
-		round = uint64(nullableRound.Int64)
+	if err == sql.ErrNoRows {
+		err = nil
+		round = 0
 	}
 
 	return

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -11,15 +11,17 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/algorand/go-algorand-sdk/types"
+
 	"github.com/algorand/indexer/accounting"
 	"github.com/algorand/indexer/idb"
+	itypes "github.com/algorand/indexer/types"
 	"github.com/algorand/indexer/util/test"
 )
 
 // getAccounting initializes the ac counting state for testing.
-func getAccounting() *accounting.State {
+func getAccounting(round uint64, cache map[uint64]bool) *accounting.State {
 	accountingState := accounting.New()
-	accountingState.InitRoundParts(test.Round, test.FeeAddr, test.RewardAddr, 0)
+	accountingState.InitRoundParts(round, test.FeeAddr, test.RewardAddr, 0)
 	return accountingState
 }
 
@@ -74,52 +76,6 @@ func TestMaxRoundOnUninitializedDB(t *testing.T) {
 	assert.Equal(t, uint64(0), round)
 }
 
-// TestMaxRoundEmptyMetastate makes sure we return 0 when the metastate is empty.
-func TestMaxRoundEmptyMetastate(t *testing.T) {
-	pg, connStr, shutdownFunc := setupPostgres(t)
-	defer shutdownFunc()
-	///////////
-	// Given // The database has the metastate set but the account_round is missing.
-	///////////
-	db, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
-	assert.NoError(t, err)
-	pg.Exec(`INSERT INTO metastate (k, v) values ('state', '{}')`)
-
-	//////////
-	// When // We request the max round.
-	//////////
-	round, err := db.GetMaxRound()
-
-	//////////
-	// Then // There should be no error and we return that there are zero rounds.
-	//////////
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(0), round)
-}
-
-// TestMaxRound the happy path.
-func TestMaxRound(t *testing.T) {
-	db, connStr, shutdownFunc := setupPostgres(t)
-	defer shutdownFunc()
-	///////////
-	// Given // The database has the metastate set normally.
-	///////////
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
-	assert.NoError(t, err)
-	db.Exec(`INSERT INTO metastate (k, v) values ($1, $2)`, "state", "{\"account_round\":123454321}")
-
-	//////////
-	// When // We request the max round.
-	//////////
-	round, err := pdb.GetMaxRound()
-
-	//////////
-	// Then // There should be no error and we return that there are zero rounds.
-	//////////
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(123454321), round)
-}
-
 func assertAccountAsset(t *testing.T, db *sql.DB, addr types.Address, assetid uint64, frozen bool, amount uint64) {
 	var row *sql.Row
 	var f bool
@@ -142,16 +98,19 @@ func TestAssetCloseReopenTransfer(t *testing.T) {
 
 	assetid := uint64(2222)
 	amt := uint64(10000)
+	total := uint64(1000000)
 
 	///////////
 	// Given // A round scenario requiring subround accounting: AccountA is funded, closed, opts back, and funded again.
 	///////////
+	_, createAsset := test.MakeAssetConfigOrPanic(test.Round, assetid, total, uint64(6), false, "icicles", "frozen coin", "http://antarctica.com", test.AccountD)
 	_, fundMain := test.MakeAssetTxnOrPanic(test.Round, assetid, amt, test.AccountD, test.AccountA, types.ZeroAddress)
 	_, closeMain := test.MakeAssetTxnOrPanic(test.Round, assetid, 1000, test.AccountA, test.AccountB, test.AccountC)
 	_, optinMain := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountA, test.AccountA, types.ZeroAddress)
 	_, payMain := test.MakeAssetTxnOrPanic(test.Round, assetid, amt, test.AccountD, test.AccountA, types.ZeroAddress)
 
-	state := getAccounting()
+	state := getAccounting(test.Round, nil)
+	state.AddTransaction(createAsset)
 	state.AddTransaction(fundMain)
 	state.AddTransaction(closeMain)
 	state.AddTransaction(optinMain)
@@ -160,35 +119,19 @@ func TestAssetCloseReopenTransfer(t *testing.T) {
 	//////////
 	// When // We commit the round accounting to the database.
 	//////////
-	pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, nil)
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+	assert.NoError(t, err, "failed to commit")
 
 	//////////
 	// Then // Accounts A, B, C and D have the correct balances.
 	//////////
-	var resultBalance int
-	var row *sql.Row
-
-	// AccountA should contain the final payment.
-	row = db.QueryRow(`SELECT amount FROM account_asset WHERE account_asset.assetid = $1 AND account_asset.addr = $2`, assetid, test.AccountA[:])
-	err = row.Scan(&resultBalance)
-	assert.NoError(t, err, "checking balance")
-	assert.Equal(t, int(amt), resultBalance)
-
-	// AccountB should have the asset close amount of 1000
-	row = db.QueryRow(`SELECT amount FROM account_asset WHERE account_asset.assetid = $1 AND account_asset.addr = $2`, assetid, test.AccountB[:])
-	err = row.Scan(&resultBalance)
-	assert.NoError(t, err, "checking balance")
-	assert.Equal(t, 1000, resultBalance)
-
-	// AccountC should have the remaining 9000
-	row = db.QueryRow(`SELECT amount FROM account_asset WHERE account_asset.assetid = $1 AND account_asset.addr = $2`, assetid, test.AccountC[:])
-	err = row.Scan(&resultBalance)
-	assert.NoError(t, err, "checking balance")
-	assert.Equal(t, 9000, resultBalance)
-
-	// The funding account, AccountD, should have -20000, it sent funds without ever being funded.
-	row = db.QueryRow(`SELECT amount FROM account_asset WHERE account_asset.assetid = $1 AND account_asset.addr = $2`, assetid, test.AccountD[:])
-	err = row.Scan(&resultBalance)
-	assert.NoError(t, err, "checking balance")
-	assert.Equal(t, int(amt)*-2, resultBalance)
+	// A has the final payment after being closed out
+	assertAccountAsset(t, db, test.AccountA, assetid, false, amt)
+	// B has the closing transfer amount
+	assertAccountAsset(t, db, test.AccountB, assetid, false, 1000)
+	// C has the close-to remainder
+	assertAccountAsset(t, db, test.AccountC, assetid, false, 9000)
+	// D has the total minus both payments to A
+	assertAccountAsset(t, db, test.AccountD, assetid, false, total - 2 * amt)
 }
+

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -67,13 +67,66 @@ func TestMaxRoundOnUninitializedDB(t *testing.T) {
 	//////////
 	// When // We request the max round.
 	//////////
-	round, err := db.GetMaxRound()
+	roundA, err := db.GetMaxRoundAccounted()
+	assert.NoError(t, err)
+	roundL, err := db.GetMaxRoundLoaded()
+	assert.NoError(t, err)
 
 	//////////
 	// Then // There should be no error and we return that there are zero rounds.
 	//////////
+	assert.Equal(t, uint64(0), roundA)
+	assert.Equal(t, uint64(0), roundL)
+}
+
+// TestMaxRoundEmptyMetastate makes sure we return 0 when the metastate is empty.
+func TestMaxRoundEmptyMetastate(t *testing.T) {
+	pg, connStr, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+	///////////
+	// Given // The database has the metastate set but the account_round is missing.
+	///////////
+	db, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
 	assert.NoError(t, err)
+	pg.Exec(`INSERT INTO metastate (k, v) values ('state', '{}')`)
+
+	//////////
+	// When // We request the max round.
+	//////////
+	round, err := db.GetMaxRoundAccounted()
+	assert.NoError(t, err)
+
+	//////////
+	// Then // There should be no error and we return that there are zero rounds.
+	//////////
 	assert.Equal(t, uint64(0), round)
+}
+
+// TestMaxRound the happy path.
+func TestMaxRound(t *testing.T) {
+	db, connStr, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+	///////////
+	// Given // The database has the metastate set normally.
+	///////////
+	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	assert.NoError(t, err)
+	db.Exec(`INSERT INTO metastate (k, v) values ($1, $2)`, "state", "{\"account_round\":123454321}")
+	db.Exec(`INSERT INTO block_header (round, realtime, rewardslevel, header) VALUES ($1, NOW(), 0, '{}') ON CONFLICT DO NOTHING`, 543212345)
+
+	//////////
+	// When // We request the max round.
+	//////////
+	roundA, err := pdb.GetMaxRoundAccounted()
+	assert.NoError(t, err)
+	roundL, err := pdb.GetMaxRoundLoaded()
+	assert.NoError(t, err)
+
+	//////////
+	// Then // There should be no error and we return that there are zero rounds.
+	//////////
+	assert.Equal(t, uint64(123454321), roundA)
+	assert.Equal(t, uint64(543212345), roundL)
 }
 
 func assertAccountAsset(t *testing.T, db *sql.DB, addr types.Address, assetid uint64, frozen bool, amount uint64) {

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -74,6 +74,64 @@ func TestMaxRoundOnUninitializedDB(t *testing.T) {
 	assert.Equal(t, uint64(0), round)
 }
 
+// TestMaxRoundEmptyMetastate makes sure we return 0 when the metastate is empty.
+func TestMaxRoundEmptyMetastate(t *testing.T) {
+	pg, connStr, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+	///////////
+	// Given // The database has the metastate set but the account_round is missing.
+	///////////
+	db, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	assert.NoError(t, err)
+	pg.Exec(`INSERT INTO metastate (k, v) values ('state', '{}')`)
+
+	//////////
+	// When // We request the max round.
+	//////////
+	round, err := db.GetMaxRound()
+
+	//////////
+	// Then // There should be no error and we return that there are zero rounds.
+	//////////
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), round)
+}
+
+// TestMaxRound the happy path.
+func TestMaxRound(t *testing.T) {
+	db, connStr, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+	///////////
+	// Given // The database has the metastate set normally.
+	///////////
+	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	assert.NoError(t, err)
+	db.Exec(`INSERT INTO metastate (k, v) values ($1, $2)`, "state", "{\"account_round\":123454321}")
+
+	//////////
+	// When // We request the max round.
+	//////////
+	round, err := pdb.GetMaxRound()
+
+	//////////
+	// Then // There should be no error and we return that there are zero rounds.
+	//////////
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(123454321), round)
+}
+
+func assertAccountAsset(t *testing.T, db *sql.DB, addr types.Address, assetid uint64, frozen bool, amount uint64) {
+	var row *sql.Row
+	var f bool
+	var a uint64
+
+	row = db.QueryRow(`SELECT frozen, amount FROM account_asset as a WHERE a.addr = $1 AND assetid = $2`, addr[:], assetid)
+	err := row.Scan(&f, &a)
+	assert.NoError(t, err, "failed looking up AccountA.")
+	assert.Equal(t, frozen, f)
+	assert.Equal(t, amount, a)
+}
+
 // TestAssetCloseReopenTransfer tests a scenario that requires asset subround accounting
 func TestAssetCloseReopenTransfer(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -358,7 +358,7 @@ func m3acfgFixAsyncInner(db *IndexerDb, state *MigrationState, assetIds []int64)
 // m5RewardsAndDatesPart1 adds the new rewards_total column to the account table.
 func m5RewardsAndDatesPart1(db *IndexerDb, state *MigrationState) error {
 	// Cache the round in the migration metastate
-	round, err := db.GetMaxRound()
+	round, err := db.GetMaxRoundAccounted()
 	if err != nil {
 		db.log.WithError(err).Errorf("%s: problem caching max round: %v", rewardsCreateCloseUpdateErr, err)
 		return err

--- a/util/test/account_testutil.go
+++ b/util/test/account_testutil.go
@@ -55,6 +55,47 @@ func DecodeAddressOrPanic(addr string) types.Address {
 	return result
 }
 
+// MakeAssetConfigOrPanic is a helper to ensure test asset config are initialized.
+func MakeAssetConfigOrPanic(round, assetid, total, decimals uint64, defaultFrozen bool, unitName, assetName, url string, addr types.Address) (*types.SignedTxnWithAD, *idb.TxnRow) {
+	txn := types.SignedTxnWithAD{
+		SignedTxn: types.SignedTxn{
+			Txn: types.Transaction{
+				Type: "acfg",
+				Header: types.Header{
+					Sender:     addr,
+					Fee:        types.MicroAlgos(1000),
+					FirstValid: types.Round(round),
+					LastValid:  types.Round(round),
+				},
+				AssetConfigTxnFields: types.AssetConfigTxnFields{
+					ConfigAsset: 0,
+					AssetParams: types.AssetParams{
+						Total:         total,
+						Decimals:      uint32(decimals),
+						DefaultFrozen: defaultFrozen,
+						UnitName:      unitName,
+						AssetName:     assetName,
+						URL:           url,
+						MetadataHash:  [32]byte{},
+						Manager:       addr,
+						Reserve:       addr,
+						Freeze:        addr,
+						Clawback:      addr,
+					},
+				},
+			},
+		},
+	}
+
+	txnRow := idb.TxnRow{
+		Round:    uint64(txn.Txn.FirstValid),
+		TxnBytes: msgpack.Encode(txn),
+		AssetID:  assetid,
+	}
+
+	return &txn, &txnRow
+}
+
 // MakeAssetTxnOrPanic is a helper to ensure test asset transactions are initialized.
 func MakeAssetTxnOrPanic(round, assetid, amt uint64, sender, receiver, close types.Address) (*types.SignedTxnWithAD, *idb.TxnRow) {
 	txn := types.SignedTxnWithAD{


### PR DESCRIPTION
## Summary

Modify GetMaxRound to return the accounting_round instead of the max block round.

## Test Plan

New unit tests.