### PR TITLE
Print health output when integration tests fail.

### DIFF
--- a/misc/e2elive.py
+++ b/misc/e2elive.py
@@ -87,13 +87,13 @@ def main():
     indexerurl = 'http://localhost:{}/'.format(aiport)
     healthurl = indexerurl + 'health'
     for attempt in range(20):
-        ok = tryhealthurl(healthurl, args.verbose, waitforround=lastblock)
+        (ok, json) = tryhealthurl(healthurl, args.verbose, waitforround=lastblock)
         if ok:
             logger.debug('health round={} OK'.format(lastblock))
             break
         time.sleep(0.5)
     if not ok:
-        logger.error('could not get indexer health, or did not reach round={}'.format(lastblock))
+        logger.error('could not get indexer health, or did not reach round={}\n{}'.format(lastblock, json))
         sys.stderr.write(indexerout.dump())
         return 1
     try:
@@ -126,18 +126,18 @@ def tryhealthurl(healthurl, verbose=False, waitforround=100):
     try:
         response = urllib.request.urlopen(healthurl)
         if response.code != 200:
-            return False
+            return (False, "")
         raw = response.read()
         logger.debug('health %r', raw)
         ob = json.loads(raw)
         rt = ob.get('message')
         if not rt:
-            return False
-        return int(rt) >= waitforround
+            return (False, raw)
+        return (int(rt) >= waitforround, raw)
     except Exception as e:
         if verbose:
             logging.warning('GET %s %s', healthurl, e)
-        return False
+        return (False, "")
 
 class subslurp:
     # asynchronously accumulate stdout or stderr from a subprocess and hold it for debugging if something goes wrong

--- a/test/common.sh
+++ b/test/common.sh
@@ -17,12 +17,18 @@ function print_alert() {
   printf "\n=====\n===== $1\n=====\n"
 }
 
+function print_health() {
+    curl -q -s "$NET/health?pretty"
+}
+
 ##################
 ## Test Helpers ##
 ##################
 
 function fail_and_exit {
   print_alert "Failed test - $1 ($2): $3"
+  echo ""
+  print_health
   exit 1
 }
 
@@ -248,7 +254,7 @@ function wait_for() {
 
   if [ -z $READY ]; then
     echo "Error: timed out waiting for $1."
-    curl -q -s "$NET/health"
+    print_health
     exit 1
   fi
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Another small quality of life improvement. Since indexer is designed to fail fast, and now puts most error messages in the health output, printing the output of health on a test failure will help figure out what went wrong when integration tests fail to run.

## Test Plan

I manually injected errors to see the error messages in the console output.


Example output
e2elive.py - in this case, we see that the indexer is not processing blocks. Previously there was just an error saying that the ledger doesn't have an expected entry.
```
python3 misc/e2elive.py --connection-string 'host=localhost port=5432 dbname=postgres sslmode=disable user=postgres password=postgres' --indexer-bin cmd/algorand-indexer/algorand-indexer
INFO:util:s3://algorand-testdata/indexer/e2e2/fe340d7e/net_done.tar.bz2 -> /tmp/tmpk8y66nei/net_done.tar.bz2
ERROR:__main__:could not get indexer health, or did not reach round=58
b'{"data":{"migration-required":false,"read-only-node":true},"db-available":true,"is-migrating":false,"message":"0","round":0}\n'
{"level":"info","msg":"Initializing block import handler.","time":"2021-02-19T09:50:35-05:00"}
serving on :13381
{"level":"info","msg":"serving on :13381","time":"2021-02-19T09:50:35-05:00"}
```

bash tests - in this case the test output isn't useful because the REST API never fully started, the health output prints the actual error message.
```
=====
===== Failed test - Ensure migration updated specific account rewards. (/v2/accounts/FZPGVIFCMHCE2HC2LEDD7IZQLKZVHRV5PENSD26Y2AOS3OWCYMKTY33UXI): unexpected HTTP status code expected 200 (actual 500): {"message":"Indexer DB is not available, try again later."}
=====

{
  "data": {
    "migration-error": "error during migration 6 (Compute cumulative account rewards for all accounts.): rewards, create_at, close_at migration error error: problem querying accounts: json decode error [pos 2137]: no matching struct field found when decoding stream map with key UseBuggyProposalLowestOutput",
    "migration-required": false,
    "migration-status": "error during migration 6 (Compute cumulative account rewards for all accounts.): rewards, create_at, close_at migration error error: problem querying accounts: json decode error [pos 2137]: no matching struct field found when decoding stream map with key UseBuggyProposalLowestOutput"
  },
  "db-available": false,
  "is-migrating": false,
  "message": "817",
  "round": 817
}
```
