### PR TITLE
Only login to docker in travis if env vars are present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 install:
 - go get -u golang.org/x/lint/golint
 - pip3 install -r misc/requirements.txt
-- echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
+- docker login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD"
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 install:
 - go get -u golang.org/x/lint/golint
 - pip3 install -r misc/requirements.txt
-- if [ -n "$DOCKER_PASSWORD" ]; then echo "$DOCKER_PASSWORD" | docker login --u "$DOCKER_USERNAME" --password-stdin ; fi
+- if [ -n "$DOCKER_PASSWORD" ]; then echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin ; fi
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 install:
 - go get -u golang.org/x/lint/golint
 - pip3 install -r misc/requirements.txt
-- docker login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD"
+- if [ -n "$DOCKER_PASSWORD" ]; then echo "$DOCKER_PASSWORD" | docker login --u "$DOCKER_USERNAME" --password-stdin ; fi
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 install:
 - go get -u golang.org/x/lint/golint
 - pip3 install -r misc/requirements.txt
-- echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+- echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
 addons:
   apt:
     packages:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Because sensitive variables are masked in travis, this breaks the docker login. This is a quick fix so that docker login is only called if the variable is set.

This is a quick fix while we consider how to handle sensitive variables and docker container pulls.

## Test Plan

Verified this worked in both a fork and the main repository.
