### PR TITLE
Fix block header for protocol upgrade.

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -139,18 +139,19 @@ type (
 		// are a multiple of ConsensusParams.CompactCertRounds.  For blocks
 		// that are not a multiple of ConsensusParams.CompactCertRounds,
 		// this value is zero.
-		CompactCertVoters Digest `codec:"ccv"`
+		CompactCertVoters Digest `codec:"v"`
 
 		// CompactCertVotersTotal is the total number of microalgos held by
 		// the accounts in CompactCertVoters (or zero, if the merkle root is
 		// zero).  This is intended for computing the threshold of votes to
 		// expect from CompactCertVoters.
-		CompactCertVotersTotal MicroAlgos `codec:"ccvt"`
+		CompactCertVotersTotal MicroAlgos `codec:"t"`
 
 		// CompactCertNextRound is the next round for which we will accept
 		// a CompactCert transaction.
-		CompactCertNextRound Round `codec:"ccn"`
+		CompactCertNextRound Round `codec:"n"`
 	}
+
 	// RewardsState represents the global parameters controlling the rate
 	// at which accounts accrue rewards.
 	RewardsState struct {

--- a/types/types.go
+++ b/types/types.go
@@ -127,7 +127,7 @@ type (
 		// CompactCert tracks the state of compact certs, potentially
 		// for multiple types of certs.
 		//msgp:sort protocol.CompactCertType protocol.SortCompactCertType
-		CompactCert map[CompactCertType]CompactCertState `codec:"cc,allocbound=protocol.NumCompactCertTypes"`
+		CompactCert map[CompactCertType]CompactCertState `codec:"cc"`
 	}
 
 	CompactCertType uint64

--- a/types/types.go
+++ b/types/types.go
@@ -124,6 +124,15 @@ type (
 		// started being supported).
 		TxnCounter uint64 `codec:"tc"`
 
+		// CompactCert tracks the state of compact certs, potentially
+		// for multiple types of certs.
+		//msgp:sort protocol.CompactCertType protocol.SortCompactCertType
+		CompactCert map[CompactCertType]CompactCertState `codec:"cc,allocbound=protocol.NumCompactCertTypes"`
+	}
+
+	CompactCertType uint64
+
+	CompactCertState struct {
 		// CompactCertVoters is the root of a Merkle tree containing the
 		// online accounts that will help sign a compact certificate.  The
 		// Merkle root, and the compact certificate, happen on blocks that

--- a/types/types.go
+++ b/types/types.go
@@ -130,8 +130,10 @@ type (
 		CompactCert map[CompactCertType]CompactCertState `codec:"cc"`
 	}
 
+	// CompactCertType identifies a particular configuration of compact certs.
 	CompactCertType uint64
 
+	// CompactCertState tracks the state of compact certificates.
 	CompactCertState struct {
 		// CompactCertVoters is the root of a Merkle tree containing the
 		// online accounts that will help sign a compact certificate.  The


### PR DESCRIPTION
## Summary

Some of the new compact cert fields were changed since we added them. I'm not sure why the tests don't catch this, they may use the stable channel. I found them due to an incompatibility with one of the sandbox configurations.

## Test Plan

I started a private network with the nightly channel and connected indexer built from this branch, I see that it is now able to process blocks.