### PR TITLE
Add a round accounting lock to synchronize background migrations.

### DIFF
--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -2071,8 +2071,6 @@ func (db *IndexerDb) yieldAccountsThread(req *getAccountsRequest) {
 			}
 
 			var apps []AppParams
-			str := string(appParams)
-			fmt.Println(str)
 			err = json.Decode(appParams, &apps)
 			if err != nil {
 				err = fmt.Errorf("parsing json appparams, %v", err)

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -17,6 +17,7 @@ import (
 	"math/big"
 	"os"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -102,6 +103,8 @@ type IndexerDb struct {
 	protoCache map[string]types.ConsensusParams
 
 	migration *migration.Migration
+
+	accountingLock sync.Mutex
 }
 
 func (db *IndexerDb) init() (err error) {
@@ -797,6 +800,9 @@ func setDirtyAppLocalState(dirty []inmemAppLocalState, x inmemAppLocalState) []i
 
 // CommitRoundAccounting is part of idb.IndexerDB
 func (db *IndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round uint64, blockPtr *types.Block) (err error) {
+	db.accountingLock.Lock()
+	defer db.accountingLock.Unlock()
+
 	any := false
 	tx, err := db.db.BeginTx(context.Background(), &serializable)
 	if err != nil {

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -738,6 +738,10 @@ func m5RewardsAndDatesPart2UpdateAccounts(db *IndexerDb, state *MigrationState, 
 		accountData[address] = result
 	}
 
+	// Make sure round accounting doesn't interfere with updating these accounts.
+	db.accountingLock.Lock()
+	defer db.accountingLock.Unlock()
+
 	// Open a postgres transaction and submit results for each account.
 	tx, err := db.db.BeginTx(context.Background(), &serializable)
 	if err != nil {


### PR DESCRIPTION
## Summary

A quick fix that should allow migrations to synchronize themselves with CommitRoundAccounting.

## Test Plan

No functional changes, existing tests.