### PR TITLE
Fix a bug: rekeying to our own address should reset the spending key

### DIFF
--- a/accounting/accounting.go
+++ b/accounting/accounting.go
@@ -128,7 +128,7 @@ func (accounting *State) updateAccountData(addr types.Address, key string, field
 		au = make(map[string]idb.AccountDataUpdate)
 		accounting.AccountDataUpdates[addr] = au
 	}
-	au[key] = idb.AccountDataUpdate{true, field}
+	au[key] = idb.AccountDataUpdate{false, field}
 }
 
 func (accounting *State) removeAccountData(addr types.Address, key string) {
@@ -137,7 +137,7 @@ func (accounting *State) removeAccountData(addr types.Address, key string) {
 		au = make(map[string]idb.AccountDataUpdate)
 		accounting.AccountDataUpdates[addr] = au
 	}
-	au[key] = idb.AccountDataUpdate{false, struct{}{}}
+	au[key] = idb.AccountDataUpdate{true, struct{}{}}
 }
 
 func (accounting *State) updateAsset(addr types.Address, assetID uint64, add, sub uint64) {

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -494,8 +494,8 @@ type AlgoUpdate struct {
 
 // AccountDataUpdate encodes an update or remove operation on an account_data json key.
 type AccountDataUpdate struct {
-	Update bool // true if update, false if delete
-	Value interface{} // value to write if `update` is true
+	Update bool        // true if update, false if delete
+	Value  interface{} // value to write if `update` is true
 }
 
 // RoundUpdates is used by the accounting and IndexerDb implementations to share modifications in a block.

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -495,7 +495,7 @@ type AlgoUpdate struct {
 // AccountDataUpdate encodes an update or remove operation on an account_data json key.
 type AccountDataUpdate struct {
 	Delete bool        // false if update, true if delete
-	Value  interface{} // value to write if `update` is true
+	Value  interface{} // value to write if `Delete` is false
 }
 
 // RoundUpdates is used by the accounting and IndexerDb implementations to share modifications in a block.

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -445,17 +445,6 @@ func IndexerDbByName(name, arg string, opts *IndexerDbOptions, log *log.Logger) 
 	return nil, fmt.Errorf("no IndexerDb factory for %s", name)
 }
 
-// AccountDataUpdate is used by the accounting and IndexerDb implementations to share modifications in a block.
-type AccountDataUpdate struct {
-	Addr            types.Address
-	Status          int // {Offline:0, Online:1, NotParticipating: 2}
-	VoteID          [32]byte
-	SelectionID     [32]byte
-	VoteFirstValid  uint64
-	VoteLastValid   uint64
-	VoteKeyDilution uint64
-}
-
 // AssetUpdate is used by the accounting and IndexerDb implementations to share modifications in a block.
 type AssetUpdate struct {
 	AssetID       uint64
@@ -503,6 +492,11 @@ type AlgoUpdate struct {
 	Closed bool
 }
 
+type AccountDataUpdate struct {
+	Update bool // true if update, false if delete
+	Value interface{} // value to write if `update` is true
+}
+
 // RoundUpdates is used by the accounting and IndexerDb implementations to share modifications in a block.
 type RoundUpdates struct {
 	AlgoUpdates  map[[32]byte]*AlgoUpdate
@@ -516,7 +510,7 @@ type RoundUpdates struct {
 	// zero value. A 0 value may need to be sent to the database
 	// to overlay onto a JSON struct there and replace a value
 	// with a 0 value.
-	AccountDataUpdates map[[32]byte]map[string]interface{}
+	AccountDataUpdates map[[32]byte]map[string]AccountDataUpdate
 
 	// AssetUpdates is more complicated than AlgoUpdates because there
 	// are no apply data values to work with in the event of a close.
@@ -541,7 +535,7 @@ type RoundUpdates struct {
 func (ru *RoundUpdates) Clear() {
 	ru.AlgoUpdates = make(map[[32]byte]*AlgoUpdate)
 	ru.AccountTypes = make(map[[32]byte]string)
-	ru.AccountDataUpdates = make(map[[32]byte]map[string]interface{})
+	ru.AccountDataUpdates = make(map[[32]byte]map[string]AccountDataUpdate)
 	ru.AssetUpdates = nil
 	ru.AssetUpdates = append(ru.AssetUpdates, make(map[[32]byte][]AssetUpdate, 0))
 	ru.AssetDestroys = nil

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -492,7 +492,7 @@ type AlgoUpdate struct {
 	Closed bool
 }
 
-// Encodes an update or remove operation on an account_data json key.
+// AccountDataUpdate encodes an update or remove operation on an account_data json key.
 type AccountDataUpdate struct {
 	Update bool // true if update, false if delete
 	Value interface{} // value to write if `update` is true

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -492,6 +492,7 @@ type AlgoUpdate struct {
 	Closed bool
 }
 
+// Encodes an update or remove operation on an account_data json key.
 type AccountDataUpdate struct {
 	Update bool // true if update, false if delete
 	Value interface{} // value to write if `update` is true

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -494,7 +494,7 @@ type AlgoUpdate struct {
 
 // AccountDataUpdate encodes an update or remove operation on an account_data json key.
 type AccountDataUpdate struct {
-	Update bool        // true if update, false if delete
+	Delete bool        // false if update, true if delete
 	Value  interface{} // value to write if `update` is true
 }
 

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -869,7 +869,7 @@ func (db *IndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round uint6
 			set := make(map[string]interface{})
 
 			for key, acctDataUpdate := range acctDataUpdates {
-				if acctDataUpdate.Update {
+				if acctDataUpdate.Delete {
 					set[key] = acctDataUpdate.Value
 				} else {
 					_, err = delad.Exec(key, addr[:])

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -870,12 +870,12 @@ func (db *IndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round uint6
 
 			for key, acctDataUpdate := range acctDataUpdates {
 				if acctDataUpdate.Delete {
-					set[key] = acctDataUpdate.Value
-				} else {
 					_, err = delad.Exec(key, addr[:])
 					if err != nil {
 						return fmt.Errorf("delete key in account data, %v", err)
 					}
+				} else {
+					set[key] = acctDataUpdate.Value
 				}
 			}
 

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -379,7 +379,7 @@ func TestMultipleWriters(t *testing.T) {
 	// Given // Send amt to AccountA
 	///////////
 	_, payAccountA := test.MakePayTxnRowOrPanic(test.Round, 1000, amt, 0, 0, 0, 0, test.AccountD,
-																							test.AccountA, types.ZeroAddress, types.ZeroAddress)
+		test.AccountA, types.ZeroAddress, types.ZeroAddress)
 
 	cache, err := pdb.GetDefaultFrozen()
 	assert.NoError(t, err)
@@ -535,15 +535,15 @@ func TestRekeyToItself(t *testing.T) {
 		assert.NoError(t, err, "failed to commit")
 	}
 	{
-		_, txnRow := test.MakePayTxnRowOrPanic(test.Round + 1, 1000, 0, 0, 0, 0, 0, test.AccountA,
+		_, txnRow := test.MakePayTxnRowOrPanic(test.Round+1, 1000, 0, 0, 0, 0, 0, test.AccountA,
 			test.AccountA, types.ZeroAddress, test.AccountA)
 
 		cache, err := pdb.GetDefaultFrozen()
 		assert.NoError(t, err)
-		state := getAccounting(test.Round + 1, cache)
+		state := getAccounting(test.Round+1, cache)
 		state.AddTransaction(txnRow)
 
-		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round + 1, &itypes.Block{})
+		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round+1, &itypes.Block{})
 		assert.NoError(t, err, "failed to commit")
 	}
 

--- a/util/test/account_testutil.go
+++ b/util/test/account_testutil.go
@@ -37,9 +37,11 @@ var (
 )
 
 func init() {
-	OpenMainStxn, OpenMain = MakePayTxnRowOrPanic(Round, 1000, 10234, 0, 111, 1111, 0, AccountC, AccountA, types.ZeroAddress)
+	OpenMainStxn, OpenMain = MakePayTxnRowOrPanic(Round, 1000, 10234, 0, 111, 1111, 0, AccountC,
+		AccountA, types.ZeroAddress, types.ZeroAddress)
 	// CloseMainToBCStxn and CloseMainToBC are premade transactions which may be useful in tests.
-	CloseMainToBCStxn, CloseMainToBC = MakePayTxnRowOrPanic(Round, 1000, 1234, 9111, 0, 111, 111, AccountA, AccountC, AccountB)
+	CloseMainToBCStxn, CloseMainToBC = MakePayTxnRowOrPanic(Round, 1000, 1234, 9111, 0, 111, 111,
+		AccountA, AccountC, AccountB, types.ZeroAddress)
 }
 
 // DecodeAddressOrPanic is a helper to ensure addresses are initialized.
@@ -160,7 +162,9 @@ func MakeAssetTxnOrPanic(round, assetid, amt uint64, sender, receiver, close typ
 }
 
 // MakePayTxnRowOrPanic is a helper to ensure test asset transactions are initialized.
-func MakePayTxnRowOrPanic(round, fee, amt, closeAmt, sendRewards, receiveRewards, closeRewards uint64, sender, receiver, close types.Address) (*types.SignedTxnWithAD, *idb.TxnRow) {
+func MakePayTxnRowOrPanic(round, fee, amt, closeAmt, sendRewards, receiveRewards,
+	closeRewards uint64, sender, receiver, close, rekeyTo types.Address) (*types.SignedTxnWithAD,
+	*idb.TxnRow) {
 	txn := types.SignedTxnWithAD{
 		SignedTxn: types.SignedTxn{
 			Txn: types.Transaction{
@@ -170,6 +174,7 @@ func MakePayTxnRowOrPanic(round, fee, amt, closeAmt, sendRewards, receiveRewards
 					Fee:        types.MicroAlgos(fee),
 					FirstValid: types.Round(round),
 					LastValid:  types.Round(round),
+					RekeyTo:    rekeyTo,
 				},
 				PaymentTxnFields: types.PaymentTxnFields{
 					Receiver:         receiver,


### PR DESCRIPTION
## Summary
Fixes #337. This modifies the database creation logic. If we rekey to our own address, remove the spending key from the account_data json field in the account table.

## Test Plan
Added two integration tests. One tests the basic rekey functionality. The other checks that rekeying to our own address removes the spending key.