### PR TITLE
Fix mlock error in CI tests.

### DIFF
--- a/docker/Dockerfile.mule
+++ b/docker/Dockerfile.mule
@@ -1,7 +1,7 @@
 # This Dockerfile is used by Jenkins.
-FROM ubuntu:18.04
+FROM ubuntu:latest
 
-ARG GO_VERSION=1.14
+ARG GO_VERSION=1.15
 ENV DEBIAN_FRONTEND noninteractive
 ENV USER root
 ENV GOROOT=/usr/local/go


### PR DESCRIPTION
## Summary

This flaky error happens on almost every indexer PR inside the mule test environment:
```
output from 'go' 'run' 'cmd/e2equeries/main.go' '-pg' 'host=localhost port=5432 dbname=e2e_tests sslmode=disable user=root password=root' '-q':
runtime: mlock of signal stack failed: 12
runtime: increase the mlock limit (ulimit -l) or
runtime: update your kernel to 5.3.15+, 5.4.2+, or 5.5+
fatal error: mlock failed
```

Following the error message, I'm updating versions in hopes that the issue is resolved.

## Test Plan

It's a flaky failure, if this doesn't fix it we'll try something else.