### PR TITLE
Attempt to fix mlock error when running in docker

### DIFF
--- a/docker/Dockerfile.mule
+++ b/docker/Dockerfile.mule
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y apt-transport-https awscli ca-certifica
     mkdir -p $HOME/go/src/github.com/algorand/indexer
 
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && apt-get install -y postgresql-12 libpq-dev python3 python3-dev python3-psycopg2 python3-pip sudo && \
     pip3 install boto3 markdown2 "msgpack >=1" py-algorand-sdk
 

--- a/docker/Dockerfile.mule
+++ b/docker/Dockerfile.mule
@@ -1,7 +1,7 @@
 # This Dockerfile is used by Jenkins.
-FROM ubuntu:18.04
+FROM ubuntu:latest
 
-ARG GO_VERSION=1.14
+ARG GO_VERSION=1.15
 ENV DEBIAN_FRONTEND noninteractive
 ENV USER root
 ENV GOROOT=/usr/local/go


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

An mlock error may be returned occasionally when running golang in Docker, due to kernel version.

To mitigate this, golang was updated to 1.15, which handles this error better than 1.14.

## Test Plan

Verify Travis tests pass repeatedly.
