### PR TITLE
Support databases behind loadbalancers (API handlers)

### DIFF
--- a/accounting/rewind.go
+++ b/accounting/rewind.go
@@ -12,6 +12,14 @@ import (
 	"github.com/algorand/indexer/types"
 )
 
+type ConsistencyError struct {
+	msg string
+}
+
+func (e ConsistencyError) Error() string {
+	return e.msg
+}
+
 func assetUpdate(account *models.Account, assetid uint64, add, sub uint64) {
 	if account.Assets == nil {
 		account.Assets = new([]models.AssetHolding)
@@ -92,7 +100,7 @@ func AccountAtRound(account models.Account, round uint64, db idb.IndexerDb) (acc
 	}
 	txns, r := db.Transactions(context.Background(), tf)
 	if r < account.Round {
-		err = fmt.Errorf("queried round r: %d < account.Round: %d", r, account.Round)
+		err = ConsistencyError{fmt.Sprintf("queried round r: %d < account.Round: %d", r, account.Round)}
 		return
 	}
 	txcount := 0
@@ -170,7 +178,8 @@ func AccountAtRound(account models.Account, round uint64, db idb.IndexerDb) (acc
 		tf.Limit = 1
 		txns, r = db.Transactions(context.Background(), tf)
 		if r < round {
-			err = fmt.Errorf("queried round r: %d < requested round round: %d", r, round)
+			err = ConsistencyError{
+				fmt.Sprintf("queried round r: %d < requested round round: %d", r, round)}
 			return
 		}
 		for txnrow := range txns {

--- a/accounting/rewind.go
+++ b/accounting/rewind.go
@@ -89,7 +89,11 @@ func AccountAtRound(account models.Account, round uint64, db idb.IndexerDb) (acc
 		MinRound: round + 1,
 		MaxRound: account.Round,
 	}
-	txns := db.Transactions(context.Background(), tf)
+	txns, r := db.Transactions(context.Background(), tf)
+	if r < account.Round {
+		err = fmt.Errorf("queried round r: %d < account.Round: %d", r, account.Round)
+		return
+	}
 	txcount := 0
 	for txnrow := range txns {
 		if txnrow.Error != nil {
@@ -163,7 +167,11 @@ func AccountAtRound(account models.Account, round uint64, db idb.IndexerDb) (acc
 		tf.MaxRound = round
 		tf.MinRound = 0
 		tf.Limit = 1
-		txns = db.Transactions(context.Background(), tf)
+		txns, r = db.Transactions(context.Background(), tf)
+		if r < round {
+			err = fmt.Errorf("queried round r: %d < requested round round: %d", r, round)
+			return
+		}
 		for txnrow := range txns {
 			if txnrow.Error != nil {
 				err = txnrow.Error

--- a/accounting/rewind.go
+++ b/accounting/rewind.go
@@ -12,6 +12,7 @@ import (
 	"github.com/algorand/indexer/types"
 )
 
+// ConsistencyError is returned when the database returns inconsistent (stale) results.
 type ConsistencyError struct {
 	msg string
 }

--- a/accounting/rewind.go
+++ b/accounting/rewind.go
@@ -55,6 +55,7 @@ var specialAccounts *idb.SpecialAccounts
 
 // AccountAtRound queries the idb.IndexerDb object for transactions and rewinds most fields of the account back to
 // their values at the requested round.
+// `round` must be <= `account.Round`
 func AccountAtRound(account models.Account, round uint64, db idb.IndexerDb) (acct models.Account, err error) {
 	// Make sure special accounts cache has been initialized.
 	if specialAccounts == nil {

--- a/accounting/rewind_test.go
+++ b/accounting/rewind_test.go
@@ -18,10 +18,10 @@ func TestBasic(t *testing.T) {
 	a[0] = 'a'
 
 	account := models.Account{
-		Address: a.String(),
-		Amount: 100,
+		Address:                     a.String(),
+		Amount:                      100,
 		AmountWithoutPendingRewards: 100,
-		Round: 8,
+		Round:                       8,
 	}
 
 	txnBytes := msgpack.Encode(types.SignedTxnWithAD{
@@ -36,7 +36,7 @@ func TestBasic(t *testing.T) {
 		},
 	})
 	txnRow := idb.TxnRow{
-		Round: 7,
+		Round:    7,
 		TxnBytes: txnBytes,
 	}
 
@@ -74,9 +74,9 @@ func TestStaleTransactions1(t *testing.T) {
 // Test that when idb.Transactions() returns stale data the second time, we return an error.
 func TestStaleTransactions2(t *testing.T) {
 	account := models.Account{
-		Amount: 100,
+		Amount:                      100,
 		AmountWithoutPendingRewards: 100,
-		Round: 8,
+		Round:                       8,
 	}
 
 	txnBytes := msgpack.Encode(types.SignedTxnWithAD{
@@ -87,7 +87,7 @@ func TestStaleTransactions2(t *testing.T) {
 		},
 	})
 	txnRow := idb.TxnRow{
-		Round: 7,
+		Round:    7,
 		TxnBytes: txnBytes,
 	}
 

--- a/accounting/rewind_test.go
+++ b/accounting/rewind_test.go
@@ -1,0 +1,106 @@
+package accounting
+
+import (
+	"testing"
+
+	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
+	"github.com/algorand/go-algorand-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	models "github.com/algorand/indexer/api/generated/v2"
+	"github.com/algorand/indexer/idb"
+	"github.com/algorand/indexer/idb/mocks"
+)
+
+func TestBasic(t *testing.T) {
+	var a types.Address
+	a[0] = 'a'
+
+	account := models.Account{
+		Address: a.String(),
+		Amount: 100,
+		AmountWithoutPendingRewards: 100,
+		Round: 8,
+	}
+
+	txnBytes := msgpack.Encode(types.SignedTxnWithAD{
+		SignedTxn: types.SignedTxn{
+			Txn: types.Transaction{
+				Type: types.PaymentTx,
+				PaymentTxnFields: types.PaymentTxnFields{
+					Receiver: a,
+					Amount:   2,
+				},
+			},
+		},
+	})
+	txnRow := idb.TxnRow{
+		Round: 7,
+		TxnBytes: txnBytes,
+	}
+
+	ch := make(chan idb.TxnRow, 1)
+	ch <- txnRow
+	close(ch)
+	var outCh <-chan idb.TxnRow = ch
+
+	db := &mocks.IndexerDb{}
+	db.On("GetSpecialAccounts").Return(idb.SpecialAccounts{}, nil)
+	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(8))
+
+	account, err := AccountAtRound(account, 6, db)
+	assert.NoError(t, err)
+
+	assert.Equal(t, uint64(98), account.Amount)
+}
+
+// Test that when idb.Transactions() returns stale data the first time, we return an error.
+func TestStaleTransactions1(t *testing.T) {
+	account := models.Account{
+		Round: 8,
+	}
+
+	var outCh <-chan idb.TxnRow
+
+	db := &mocks.IndexerDb{}
+	db.On("GetSpecialAccounts").Return(idb.SpecialAccounts{}, nil)
+	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(7)).Once()
+
+	account, err := AccountAtRound(account, 6, db)
+	assert.Error(t, err)
+}
+
+// Test that when idb.Transactions() returns stale data the second time, we return an error.
+func TestStaleTransactions2(t *testing.T) {
+	account := models.Account{
+		Amount: 100,
+		AmountWithoutPendingRewards: 100,
+		Round: 8,
+	}
+
+	txnBytes := msgpack.Encode(types.SignedTxnWithAD{
+		SignedTxn: types.SignedTxn{
+			Txn: types.Transaction{
+				Type: types.PaymentTx,
+			},
+		},
+	})
+	txnRow := idb.TxnRow{
+		Round: 7,
+		TxnBytes: txnBytes,
+	}
+
+	ch := make(chan idb.TxnRow, 1)
+	ch <- txnRow
+	close(ch)
+	var outCh <-chan idb.TxnRow = ch
+
+	db := &mocks.IndexerDb{}
+	db.On("GetSpecialAccounts").Return(idb.SpecialAccounts{}, nil)
+	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(8)).Once()
+	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(5)).Once()
+
+	account, err := AccountAtRound(account, 6, db)
+	assert.Error(t, err)
+}

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -112,8 +112,7 @@ func (si *ServerImplementation) LookupAccountByID(ctx echo.Context, accountID st
 		IncludeDeleted:       boolOrDefault(params.IncludeAll),
 	}
 
-	accounts, err := si.fetchAccounts(ctx.Request().Context(), options, params.Round)
-
+	accounts, round, err := si.fetchAccounts(ctx.Request().Context(), options, params.Round)
 	if err != nil {
 		return indexerError(ctx, fmt.Sprintf("%s: %v", errFailedSearchingAccount, err))
 	}
@@ -124,11 +123,6 @@ func (si *ServerImplementation) LookupAccountByID(ctx echo.Context, accountID st
 
 	if len(accounts) > 1 {
 		return indexerError(ctx, fmt.Sprintf("%s: %s", errMultipleAccounts, accountID))
-	}
-
-	round, err := si.db.GetMaxRoundAccounted()
-	if err != nil {
-		return indexerError(ctx, err.Error())
 	}
 
 	return ctx.JSON(http.StatusOK, generated.AccountResponse{
@@ -176,15 +170,10 @@ func (si *ServerImplementation) SearchForAccounts(ctx echo.Context, params gener
 		options.GreaterThanAddress = addr[:]
 	}
 
-	accounts, err := si.fetchAccounts(ctx.Request().Context(), options, params.Round)
+	accounts, round, err := si.fetchAccounts(ctx.Request().Context(), options, params.Round)
 
 	if err != nil {
 		return indexerError(ctx, fmt.Sprintf("%s: %v", errFailedSearchingAccount, err))
-	}
-
-	round, err := si.db.GetMaxRoundAccounted()
-	if err != nil {
-		return indexerError(ctx, err.Error())
 	}
 
 	var next *string
@@ -239,11 +228,7 @@ func (si *ServerImplementation) LookupAccountTransactions(ctx echo.Context, acco
 // SearchForApplications returns applications for the provided parameters.
 // (GET /v2/applications)
 func (si *ServerImplementation) SearchForApplications(ctx echo.Context, params generated.SearchForApplicationsParams) error {
-	results := si.db.Applications(ctx.Request().Context(), &params)
-	round, err := si.db.GetMaxRoundAccounted()
-	if err != nil {
-		return indexerError(ctx, err.Error())
-	}
+	results, round := si.db.Applications(ctx.Request().Context(), &params)
 	apps := make([]generated.Application, 0)
 	for result := range results {
 		if result.Error != nil {
@@ -272,11 +257,7 @@ func (si *ServerImplementation) LookupApplicationByID(ctx echo.Context, applicat
 		ApplicationId: &applicationID,
 		IncludeAll:    params.IncludeAll,
 	}
-	results := si.db.Applications(ctx.Request().Context(), p)
-	round, err := si.db.GetMaxRoundAccounted()
-	if err != nil {
-		return indexerError(ctx, err.Error())
-	}
+	results, round := si.db.Applications(ctx.Request().Context(), p)
 	out := generated.ApplicationResponse{
 		CurrentRound: round,
 	}
@@ -303,7 +284,7 @@ func (si *ServerImplementation) LookupAssetByID(ctx echo.Context, assetID uint64
 		return badRequest(ctx, err.Error())
 	}
 
-	assets, err := si.fetchAssets(ctx.Request().Context(), options)
+	assets, round, err := si.fetchAssets(ctx.Request().Context(), options)
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -314,11 +295,6 @@ func (si *ServerImplementation) LookupAssetByID(ctx echo.Context, assetID uint64
 
 	if len(assets) > 1 {
 		return indexerError(ctx, fmt.Sprintf("%s: %d", errMultipleAssets, assetID))
-	}
-
-	round, err := si.db.GetMaxRoundAccounted()
-	if err != nil {
-		return indexerError(ctx, err.Error())
 	}
 
 	return ctx.JSON(http.StatusOK, generated.AssetResponse{
@@ -346,14 +322,9 @@ func (si *ServerImplementation) LookupAssetBalances(ctx echo.Context, assetID ui
 		query.PrevAddress = addr[:]
 	}
 
-	balances, err := si.fetchAssetBalances(ctx.Request().Context(), query)
+	balances, round, err := si.fetchAssetBalances(ctx.Request().Context(), query)
 	if err != nil {
 		indexerError(ctx, err.Error())
-	}
-
-	round, err := si.db.GetMaxRoundAccounted()
-	if err != nil {
-		return indexerError(ctx, err.Error())
 	}
 
 	var next *string
@@ -404,12 +375,7 @@ func (si *ServerImplementation) SearchForAssets(ctx echo.Context, params generat
 		return badRequest(ctx, err.Error())
 	}
 
-	assets, err := si.fetchAssets(ctx.Request().Context(), options)
-	if err != nil {
-		return indexerError(ctx, err.Error())
-	}
-
-	round, err := si.db.GetMaxRoundAccounted()
+	assets, round, err := si.fetchAssets(ctx.Request().Context(), options)
 	if err != nil {
 		return indexerError(ctx, err.Error())
 	}
@@ -447,7 +413,7 @@ func (si *ServerImplementation) LookupTransactions(ctx echo.Context, txid string
 	}
 
 	// Fetch the transactions
-	txns, _, err := si.fetchTransactions(ctx.Request().Context(), filter)
+	txns, _, round, err := si.fetchTransactions(ctx.Request().Context(), filter)
 	if err != nil {
 		return indexerError(ctx, fmt.Sprintf("%s: %v", errTransactionSearch, err))
 	}
@@ -458,11 +424,6 @@ func (si *ServerImplementation) LookupTransactions(ctx echo.Context, txid string
 
 	if len(txns) > 1 {
 		return indexerError(ctx, fmt.Sprintf("%s: %s", errMultipleTransactions, txid))
-	}
-
-	round, err := si.db.GetMaxRoundAccounted()
-	if err != nil {
-		return indexerError(ctx, err.Error())
 	}
 
 	response := generated.TransactionResponse{
@@ -482,14 +443,9 @@ func (si *ServerImplementation) SearchForTransactions(ctx echo.Context, params g
 	}
 
 	// Fetch the transactions
-	txns, next, err := si.fetchTransactions(ctx.Request().Context(), filter)
+	txns, next, round, err := si.fetchTransactions(ctx.Request().Context(), filter)
 	if err != nil {
 		return indexerError(ctx, fmt.Sprintf("%s: %v", errTransactionSearch, err))
-	}
-
-	round, err := si.db.GetMaxRoundAccounted()
-	if err != nil {
-		return indexerError(ctx, err.Error())
 	}
 
 	response := generated.TransactionsResponse{
@@ -531,17 +487,18 @@ func notFound(ctx echo.Context, err string) error {
 ///////////////////////
 
 // fetchAssets fetches all results and converts them into generated.Asset objects
-func (si *ServerImplementation) fetchAssets(ctx context.Context, options idb.AssetsQuery) ([]generated.Asset, error) {
-	assetchan := si.db.Assets(ctx, options)
+func (si *ServerImplementation) fetchAssets(ctx context.Context,
+	options idb.AssetsQuery) ([]generated.Asset, uint64, error) {
+	assetchan, round := si.db.Assets(ctx, options)
 	assets := make([]generated.Asset, 0)
 	for row := range assetchan {
 		if row.Error != nil {
-			return nil, row.Error
+			return nil, round, row.Error
 		}
 
 		creator := types.Address{}
 		if len(row.Creator) != len(creator) {
-			return nil, fmt.Errorf(errInvalidCreatorAddress)
+			return nil, round, fmt.Errorf(errInvalidCreatorAddress)
 		}
 		copy(creator[:], row.Creator[:])
 
@@ -568,22 +525,23 @@ func (si *ServerImplementation) fetchAssets(ctx context.Context, options idb.Ass
 
 		assets = append(assets, asset)
 	}
-	return assets, nil
+	return assets, round, nil
 }
 
 // fetchAssetBalances fetches all balances from a query and converts them into
 // generated.MiniAssetHolding objects
-func (si *ServerImplementation) fetchAssetBalances(ctx context.Context, options idb.AssetBalanceQuery) ([]generated.MiniAssetHolding, error) {
-	assetbalchan := si.db.AssetBalances(ctx, options)
+func (si *ServerImplementation) fetchAssetBalances(ctx context.Context,
+	options idb.AssetBalanceQuery) ([]generated.MiniAssetHolding, uint64, error) {
+	assetbalchan, round := si.db.AssetBalances(ctx, options)
 	balances := make([]generated.MiniAssetHolding, 0)
 	for row := range assetbalchan {
 		if row.Error != nil {
-			return nil, row.Error
+			return nil, round, row.Error
 		}
 
 		addr := types.Address{}
 		if len(row.Address) != len(addr) {
-			return nil, fmt.Errorf(errInvalidCreatorAddress)
+			return nil, round, fmt.Errorf(errInvalidCreatorAddress)
 		}
 		copy(addr[:], row.Address[:])
 
@@ -599,7 +557,7 @@ func (si *ServerImplementation) fetchAssetBalances(ctx context.Context, options 
 		balances = append(balances, bal)
 	}
 
-	return balances, nil
+	return balances, round, nil
 }
 
 // fetchBlock looks up a block and converts it into a generated.Block object
@@ -665,19 +623,20 @@ func (si *ServerImplementation) fetchBlock(ctx context.Context, round uint64) (g
 
 // fetchAccounts queries for accounts and converts them into generated.Account
 // objects, optionally rewinding their value back to a particular round.
-func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.AccountQueryOptions, atRound *uint64) ([]generated.Account, error) {
-	accountchan := si.db.GetAccounts(ctx, options)
+func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.AccountQueryOptions,
+	atRound *uint64) ([]generated.Account, uint64, error) {
+	accountchan, round := si.db.GetAccounts(ctx, options)
 
 	accounts := make([]generated.Account, 0)
 	for row := range accountchan {
 		if row.Error != nil {
-			return nil, row.Error
+			return nil, round, row.Error
 		}
 
 		// Check if it's a special account, if so, skip. We don't want it in our results.
 		isSpecialAccount, err := si.isSpecialAccount(row.Account.Address)
 		if err != nil {
-			return nil, err
+			return nil, round, err
 		}
 
 		if isSpecialAccount {
@@ -692,7 +651,7 @@ func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.A
 				// Ignore the error if this is an account search rewind error
 				_, isSpecialAccountRewindError := err.(*accounting.SpecialAccountRewindError)
 				if len(options.EqualToAddress) != 0 || !isSpecialAccountRewindError {
-					return nil, fmt.Errorf("%s: %v", errRewindingAccount, err)
+					return nil, round, fmt.Errorf("%s: %v", errRewindingAccount, err)
 				}
 				// If we didn't return, continue to the next account
 				continue
@@ -707,24 +666,25 @@ func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.A
 		accounts = append(accounts, account)
 	}
 
-	return accounts, nil
+	return accounts, round, nil
 }
 
 // fetchTransactions is used to query the backend for transactions, and compute the next token
-func (si *ServerImplementation) fetchTransactions(ctx context.Context, filter idb.TransactionFilter) ([]generated.Transaction, string, error) {
+func (si *ServerImplementation) fetchTransactions(ctx context.Context,
+	filter idb.TransactionFilter) ([]generated.Transaction, string, uint64, error) {
 	results := make([]generated.Transaction, 0)
-	txchan := si.db.Transactions(ctx, filter)
+	txchan, round := si.db.Transactions(ctx, filter)
 	nextToken := ""
 	for txrow := range txchan {
 		tx, err := txnRowToTransaction(txrow)
 		if err != nil {
-			return nil, "", err
+			return nil, "", round, err
 		}
 		results = append(results, tx)
 		nextToken = txrow.Next()
 	}
 
-	return results, nextToken, nil
+	return results, nextToken, round, nil
 }
 
 //////////////////////

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -487,7 +487,7 @@ func notFound(ctx echo.Context, err string) error {
 ///////////////////////
 
 // fetchAssets fetches all results and converts them into generated.Asset objects
-func (si *ServerImplementation) fetchAssets(ctx context.Context, options idb.AssetsQuery) ([]generated.Asset, uint64, error) {
+func (si *ServerImplementation) fetchAssets(ctx context.Context, options idb.AssetsQuery) ([]generated.Asset, /*round*/ uint64, error) {
 	assetchan, round := si.db.Assets(ctx, options)
 	assets := make([]generated.Asset, 0)
 	for row := range assetchan {
@@ -529,7 +529,7 @@ func (si *ServerImplementation) fetchAssets(ctx context.Context, options idb.Ass
 
 // fetchAssetBalances fetches all balances from a query and converts them into
 // generated.MiniAssetHolding objects
-func (si *ServerImplementation) fetchAssetBalances(ctx context.Context, options idb.AssetBalanceQuery) ([]generated.MiniAssetHolding, uint64, error) {
+func (si *ServerImplementation) fetchAssetBalances(ctx context.Context, options idb.AssetBalanceQuery) ([]generated.MiniAssetHolding, /*round*/ uint64, error) {
 	assetbalchan, round := si.db.AssetBalances(ctx, options)
 	balances := make([]generated.MiniAssetHolding, 0)
 	for row := range assetbalchan {
@@ -621,7 +621,7 @@ func (si *ServerImplementation) fetchBlock(ctx context.Context, round uint64) (g
 
 // fetchAccounts queries for accounts and converts them into generated.Account
 // objects, optionally rewinding their value back to a particular round.
-func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.AccountQueryOptions, atRound *uint64) ([]generated.Account, uint64, error) {
+func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.AccountQueryOptions, atRound *uint64) ([]generated.Account, /*round*/ uint64, error) {
 	accountchan, round := si.db.GetAccounts(ctx, options)
 
 	accounts := make([]generated.Account, 0)
@@ -667,7 +667,7 @@ func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.A
 }
 
 // fetchTransactions is used to query the backend for transactions, and compute the next token
-func (si *ServerImplementation) fetchTransactions(ctx context.Context, filter idb.TransactionFilter) ([]generated.Transaction, string, uint64, error) {
+func (si *ServerImplementation) fetchTransactions(ctx context.Context, filter idb.TransactionFilter) ([]generated.Transaction, string, /*round*/ uint64, error) {
 	results := make([]generated.Transaction, 0)
 	txchan, round := si.db.Transactions(ctx, filter)
 	nextToken := ""

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -487,7 +487,7 @@ func notFound(ctx echo.Context, err string) error {
 ///////////////////////
 
 // fetchAssets fetches all results and converts them into generated.Asset objects
-func (si *ServerImplementation) fetchAssets(ctx context.Context, options idb.AssetsQuery) ([]generated.Asset, /*round*/ uint64, error) {
+func (si *ServerImplementation) fetchAssets(ctx context.Context, options idb.AssetsQuery) ([]generated.Asset, uint64 /*round*/, error) {
 	assetchan, round := si.db.Assets(ctx, options)
 	assets := make([]generated.Asset, 0)
 	for row := range assetchan {
@@ -529,7 +529,7 @@ func (si *ServerImplementation) fetchAssets(ctx context.Context, options idb.Ass
 
 // fetchAssetBalances fetches all balances from a query and converts them into
 // generated.MiniAssetHolding objects
-func (si *ServerImplementation) fetchAssetBalances(ctx context.Context, options idb.AssetBalanceQuery) ([]generated.MiniAssetHolding, /*round*/ uint64, error) {
+func (si *ServerImplementation) fetchAssetBalances(ctx context.Context, options idb.AssetBalanceQuery) ([]generated.MiniAssetHolding, uint64 /*round*/, error) {
 	assetbalchan, round := si.db.AssetBalances(ctx, options)
 	balances := make([]generated.MiniAssetHolding, 0)
 	for row := range assetbalchan {
@@ -621,7 +621,7 @@ func (si *ServerImplementation) fetchBlock(ctx context.Context, round uint64) (g
 
 // fetchAccounts queries for accounts and converts them into generated.Account
 // objects, optionally rewinding their value back to a particular round.
-func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.AccountQueryOptions, atRound *uint64) ([]generated.Account, /*round*/ uint64, error) {
+func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.AccountQueryOptions, atRound *uint64) ([]generated.Account, uint64 /*round*/, error) {
 	accountchan, round := si.db.GetAccounts(ctx, options)
 
 	accounts := make([]generated.Account, 0)
@@ -667,7 +667,7 @@ func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.A
 }
 
 // fetchTransactions is used to query the backend for transactions, and compute the next token
-func (si *ServerImplementation) fetchTransactions(ctx context.Context, filter idb.TransactionFilter) ([]generated.Transaction, string, /*round*/ uint64, error) {
+func (si *ServerImplementation) fetchTransactions(ctx context.Context, filter idb.TransactionFilter) ([]generated.Transaction, string, uint64 /*round*/, error) {
 	results := make([]generated.Transaction, 0)
 	txchan, round := si.db.Transactions(ctx, filter)
 	nextToken := ""

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -487,7 +487,7 @@ func notFound(ctx echo.Context, err string) error {
 ///////////////////////
 
 // fetchAssets fetches all results and converts them into generated.Asset objects
-func (si *ServerImplementation) fetchAssets(ctx context.Context options idb.AssetsQuery) ([]generated.Asset, uint64, error) {
+func (si *ServerImplementation) fetchAssets(ctx context.Context, options idb.AssetsQuery) ([]generated.Asset, uint64, error) {
 	assetchan, round := si.db.Assets(ctx, options)
 	assets := make([]generated.Asset, 0)
 	for row := range assetchan {

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -645,7 +645,7 @@ func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.A
 
 		// Compute for a given round if requested.
 		var account generated.Account
-		if atRound != nil {
+		if (atRound != nil) && (*atRound < row.Account.Round) {
 			acct, err := accounting.AccountAtRound(row.Account, *atRound, si.db)
 			if err != nil {
 				// Ignore the error if this is an account search rewind error

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -487,8 +487,7 @@ func notFound(ctx echo.Context, err string) error {
 ///////////////////////
 
 // fetchAssets fetches all results and converts them into generated.Asset objects
-func (si *ServerImplementation) fetchAssets(ctx context.Context,
-	options idb.AssetsQuery) ([]generated.Asset, uint64, error) {
+func (si *ServerImplementation) fetchAssets(ctx context.Context options idb.AssetsQuery) ([]generated.Asset, uint64, error) {
 	assetchan, round := si.db.Assets(ctx, options)
 	assets := make([]generated.Asset, 0)
 	for row := range assetchan {
@@ -530,8 +529,7 @@ func (si *ServerImplementation) fetchAssets(ctx context.Context,
 
 // fetchAssetBalances fetches all balances from a query and converts them into
 // generated.MiniAssetHolding objects
-func (si *ServerImplementation) fetchAssetBalances(ctx context.Context,
-	options idb.AssetBalanceQuery) ([]generated.MiniAssetHolding, uint64, error) {
+func (si *ServerImplementation) fetchAssetBalances(ctx context.Context, options idb.AssetBalanceQuery) ([]generated.MiniAssetHolding, uint64, error) {
 	assetbalchan, round := si.db.AssetBalances(ctx, options)
 	balances := make([]generated.MiniAssetHolding, 0)
 	for row := range assetbalchan {
@@ -623,8 +621,7 @@ func (si *ServerImplementation) fetchBlock(ctx context.Context, round uint64) (g
 
 // fetchAccounts queries for accounts and converts them into generated.Account
 // objects, optionally rewinding their value back to a particular round.
-func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.AccountQueryOptions,
-	atRound *uint64) ([]generated.Account, uint64, error) {
+func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.AccountQueryOptions, atRound *uint64) ([]generated.Account, uint64, error) {
 	accountchan, round := si.db.GetAccounts(ctx, options)
 
 	accounts := make([]generated.Account, 0)
@@ -670,8 +667,7 @@ func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.A
 }
 
 // fetchTransactions is used to query the backend for transactions, and compute the next token
-func (si *ServerImplementation) fetchTransactions(ctx context.Context,
-	filter idb.TransactionFilter) ([]generated.Transaction, string, uint64, error) {
+func (si *ServerImplementation) fetchTransactions(ctx context.Context, filter idb.TransactionFilter) ([]generated.Transaction, string, uint64, error) {
 	results := make([]generated.Transaction, 0)
 	txchan, round := si.db.Transactions(ctx, filter)
 	nextToken := ""

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -452,10 +452,11 @@ func TestFetchTransactions(t *testing.T) {
 
 			close(ch)
 			var outCh <-chan idb.TxnRow = ch
-			mockIndexer.On("Transactions", mock.Anything, mock.Anything).Return(outCh)
+			var round uint64 = 1
+			mockIndexer.On("Transactions", mock.Anything, mock.Anything).Return(outCh, round)
 
 			// Call the function
-			results, _, err := si.fetchTransactions(context.Background(), idb.TransactionFilter{})
+			results, _, _, err := si.fetchTransactions(context.Background(), idb.TransactionFilter{})
 			assert.NoError(t, err)
 
 			// Automatically print it out when writing the test.

--- a/cmd/e2equeries/main.go
+++ b/cmd/e2equeries/main.go
@@ -48,7 +48,7 @@ func main() {
 	rekeyTxnQuery := idb.TransactionFilter{RekeyTo: &truev, Limit: 1}
 	printTxnQuery(db, rekeyTxnQuery)
 
-	rowchan := db.Transactions(context.Background(), rekeyTxnQuery)
+	rowchan, _ := db.Transactions(context.Background(), rekeyTxnQuery)
 	var rekeyTo atypes.Address
 	for txnrow := range rowchan {
 		maybeFail(txnrow.Error, "err rekey txn %v\n", txnrow.Error)
@@ -62,7 +62,8 @@ func main() {
 
 	// find an asset with > 1 account
 	countByAssetID := make(map[uint64]uint64)
-	for abr := range db.AssetBalances(context.Background(), idb.AssetBalanceQuery{}) {
+	assetchan, _ := db.AssetBalances(context.Background(), idb.AssetBalanceQuery{})
+	for abr := range assetchan {
 		countByAssetID[abr.AssetID] = countByAssetID[abr.AssetID] + 1
 	}
 	var bestid uint64

--- a/cmd/idbtest/idbtest.go
+++ b/cmd/idbtest/idbtest.go
@@ -57,7 +57,7 @@ type roundIntra struct {
 func testTxnPaging(db idb.IndexerDb, q idb.TransactionFilter) {
 	q.Limit = 1000
 	all := make([]roundIntra, 0, q.Limit)
-	rowchan := db.Transactions(context.Background(), q)
+	rowchan, _ := db.Transactions(context.Background(), q)
 	for txnrow := range rowchan {
 		var ri roundIntra
 		ri.Round = txnrow.Round
@@ -72,7 +72,7 @@ func testTxnPaging(db idb.IndexerDb, q idb.TransactionFilter) {
 	any := true
 	for any {
 		any = false
-		rowchan := db.Transactions(context.Background(), q)
+		rowchan, _ := db.Transactions(context.Background(), q)
 		next := ""
 		for txnrow := range rowchan {
 			any = true
@@ -106,7 +106,7 @@ func testTxnPaging(db idb.IndexerDb, q idb.TransactionFilter) {
 }
 
 func printAssetBalanceQuery(db idb.IndexerDb, assetID uint64) {
-	rows := db.AssetBalances(context.Background(), idb.AssetBalanceQuery{AssetID: assetID})
+	rows, _ := db.AssetBalances(context.Background(), idb.AssetBalanceQuery{AssetID: assetID})
 	count := 0
 	for row := range rows {
 		maybeFail(row.Error, "err %v\n", row.Error)
@@ -119,7 +119,9 @@ func printAssetBalanceQuery(db idb.IndexerDb, assetID uint64) {
 }
 
 func getAccount(db idb.IndexerDb, addr []byte) (account models.Account, err error) {
-	for ar := range db.GetAccounts(context.Background(), idb.AccountQueryOptions{EqualToAddress: addr}) {
+	accountchan, _ :=
+		db.GetAccounts(context.Background(), idb.AccountQueryOptions{EqualToAddress: addr})
+	for ar := range accountchan {
 		return ar.Account, ar.Error
 	}
 	return models.Account{}, nil

--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,6 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
 	github.com/valyala/fasttemplate v1.2.0 // indirect
+	github.com/vektra/mockery v1.1.2 // indirect
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -449,6 +449,8 @@ github.com/valyala/fasttemplate v1.1.0 h1:RZqt0yGBsps8NGvLSGW804QQqCUYYLsaOjTVHy
 github.com/valyala/fasttemplate v1.1.0/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.0 h1:y3yXRCoDvC2HTtIHvL2cc7Zd+bqA+zqDO6oQzsJO07E=
 github.com/valyala/fasttemplate v1.2.0/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
+github.com/vektra/mockery v1.1.2 h1:uc0Yn67rJpjt8U/mAZimdCKn9AeA97BOkjpmtBSlfP4=
+github.com/vektra/mockery v1.1.2/go.mod h1:VcfZjKaFOPO+MpN4ZvwPjs4c48lkq1o3Ym8yHZJu0jU=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
@@ -681,6 +683,7 @@ golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
+golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200423205358-59e73619c742 h1:9OGWpORUXvk8AsaBJlpzzDx7Srv/rSK6rvjcsJq4rJo=
 golang.org/x/tools v0.0.0-20200423205358-59e73619c742/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -117,28 +117,33 @@ func (db *dummyIndexerDb) GetBlock(ctx context.Context, round uint64, options Ge
 }
 
 // Transactions is part of idb.IndexerDB
-func (db *dummyIndexerDb) Transactions(ctx context.Context, tf TransactionFilter) <-chan TxnRow {
-	return nil
+func (db *dummyIndexerDb) Transactions(ctx context.Context,
+	tf TransactionFilter) (<-chan TxnRow, uint64) {
+	return nil, 0
 }
 
 // GetAccounts is part of idb.IndexerDB
-func (db *dummyIndexerDb) GetAccounts(ctx context.Context, opts AccountQueryOptions) <-chan AccountRow {
-	return nil
+func (db *dummyIndexerDb) GetAccounts(ctx context.Context,
+	opts AccountQueryOptions) (<-chan AccountRow, uint64) {
+	return nil, 0
 }
 
 // Assets is part of idb.IndexerDB
-func (db *dummyIndexerDb) Assets(ctx context.Context, filter AssetsQuery) <-chan AssetRow {
-	return nil
+func (db *dummyIndexerDb) Assets(ctx context.Context,
+	filter AssetsQuery) (<-chan AssetRow, uint64) {
+	return nil, 0
 }
 
 // AssetBalances is part of idb.IndexerDB
-func (db *dummyIndexerDb) AssetBalances(ctx context.Context, abq AssetBalanceQuery) <-chan AssetBalanceRow {
-	return nil
+func (db *dummyIndexerDb) AssetBalances(ctx context.Context,
+	abq AssetBalanceQuery) (<-chan AssetBalanceRow, uint64) {
+	return nil, 0
 }
 
 // Applications is part of idb.IndexerDB
-func (db *dummyIndexerDb) Applications(ctx context.Context, filter *models.SearchForApplicationsParams) <-chan ApplicationRow {
-	return nil
+func (db *dummyIndexerDb) Applications(ctx context.Context,
+	filter *models.SearchForApplicationsParams) (<-chan ApplicationRow, uint64) {
+	return nil, 0
 }
 
 // Health is part of idb.IndexerDB
@@ -233,11 +238,12 @@ type IndexerDb interface {
 
 	GetBlock(ctx context.Context, round uint64, options GetBlockOptions) (block types.Block, transactions []TxnRow, err error)
 
-	Transactions(ctx context.Context, tf TransactionFilter) <-chan TxnRow
-	GetAccounts(ctx context.Context, opts AccountQueryOptions) <-chan AccountRow
-	Assets(ctx context.Context, filter AssetsQuery) <-chan AssetRow
-	AssetBalances(ctx context.Context, abq AssetBalanceQuery) <-chan AssetBalanceRow
-	Applications(ctx context.Context, filter *models.SearchForApplicationsParams) <-chan ApplicationRow
+	Transactions(ctx context.Context, tf TransactionFilter) (<-chan TxnRow, uint64)
+	GetAccounts(ctx context.Context, opts AccountQueryOptions) (<-chan AccountRow, uint64)
+	Assets(ctx context.Context, filter AssetsQuery) (<-chan AssetRow, uint64)
+	AssetBalances(ctx context.Context, abq AssetBalanceQuery) (<-chan AssetBalanceRow, uint64)
+	Applications(ctx context.Context,
+		filter *models.SearchForApplicationsParams) (<-chan ApplicationRow, uint64)
 
 	Health() (status Health, err error)
 }

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -233,6 +233,8 @@ type IndexerDb interface {
 
 	GetBlock(ctx context.Context, round uint64, options GetBlockOptions) (block types.Block, transactions []TxnRow, err error)
 
+	// The next multiple functions return a channel with results as well as the latest round
+	// accounted.
 	Transactions(ctx context.Context, tf TransactionFilter) (<-chan TxnRow, uint64)
 	GetAccounts(ctx context.Context, opts AccountQueryOptions) (<-chan AccountRow, uint64)
 	Assets(ctx context.Context, filter AssetsQuery) (<-chan AssetRow, uint64)

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -117,32 +117,27 @@ func (db *dummyIndexerDb) GetBlock(ctx context.Context, round uint64, options Ge
 }
 
 // Transactions is part of idb.IndexerDB
-func (db *dummyIndexerDb) Transactions(ctx context.Context,
-	tf TransactionFilter) (<-chan TxnRow, uint64) {
+func (db *dummyIndexerDb) Transactions(ctx context.Context, tf TransactionFilter) (<-chan TxnRow, uint64) {
 	return nil, 0
 }
 
 // GetAccounts is part of idb.IndexerDB
-func (db *dummyIndexerDb) GetAccounts(ctx context.Context,
-	opts AccountQueryOptions) (<-chan AccountRow, uint64) {
+func (db *dummyIndexerDb) GetAccounts(ctx context.Context, opts AccountQueryOptions) (<-chan AccountRow, uint64) {
 	return nil, 0
 }
 
 // Assets is part of idb.IndexerDB
-func (db *dummyIndexerDb) Assets(ctx context.Context,
-	filter AssetsQuery) (<-chan AssetRow, uint64) {
+func (db *dummyIndexerDb) Assets(ctx context.Context, filter AssetsQuery) (<-chan AssetRow, uint64) {
 	return nil, 0
 }
 
 // AssetBalances is part of idb.IndexerDB
-func (db *dummyIndexerDb) AssetBalances(ctx context.Context,
-	abq AssetBalanceQuery) (<-chan AssetBalanceRow, uint64) {
+func (db *dummyIndexerDb) AssetBalances(ctx context.Context, abq AssetBalanceQuery) (<-chan AssetBalanceRow, uint64) {
 	return nil, 0
 }
 
 // Applications is part of idb.IndexerDB
-func (db *dummyIndexerDb) Applications(ctx context.Context,
-	filter *models.SearchForApplicationsParams) (<-chan ApplicationRow, uint64) {
+func (db *dummyIndexerDb) Applications(ctx context.Context, filter *models.SearchForApplicationsParams) (<-chan ApplicationRow, uint64) {
 	return nil, 0
 }
 
@@ -242,8 +237,7 @@ type IndexerDb interface {
 	GetAccounts(ctx context.Context, opts AccountQueryOptions) (<-chan AccountRow, uint64)
 	Assets(ctx context.Context, filter AssetsQuery) (<-chan AssetRow, uint64)
 	AssetBalances(ctx context.Context, abq AssetBalanceQuery) (<-chan AssetBalanceRow, uint64)
-	Applications(ctx context.Context,
-		filter *models.SearchForApplicationsParams) (<-chan ApplicationRow, uint64)
+	Applications(ctx context.Context, filter *models.SearchForApplicationsParams) (<-chan ApplicationRow, uint64)
 
 	Health() (status Health, err error)
 }

--- a/idb/mocks/IndexerDb.go
+++ b/idb/mocks/IndexerDb.go
@@ -54,7 +54,7 @@ func (_m *IndexerDb) AlreadyImported(path string) (bool, error) {
 }
 
 // Applications provides a mock function with given fields: ctx, filter
-func (_m *IndexerDb) Applications(ctx context.Context, filter *generated.SearchForApplicationsParams) <-chan idb.ApplicationRow {
+func (_m *IndexerDb) Applications(ctx context.Context, filter *generated.SearchForApplicationsParams) (<-chan idb.ApplicationRow, uint64) {
 	ret := _m.Called(ctx, filter)
 
 	var r0 <-chan idb.ApplicationRow
@@ -66,11 +66,18 @@ func (_m *IndexerDb) Applications(ctx context.Context, filter *generated.SearchF
 		}
 	}
 
-	return r0
+	var r1 uint64
+	if rf, ok := ret.Get(1).(func(context.Context, *generated.SearchForApplicationsParams) uint64); ok {
+		r1 = rf(ctx, filter)
+	} else {
+		r1 = ret.Get(1).(uint64)
+	}
+
+	return r0, r1
 }
 
 // AssetBalances provides a mock function with given fields: ctx, abq
-func (_m *IndexerDb) AssetBalances(ctx context.Context, abq idb.AssetBalanceQuery) <-chan idb.AssetBalanceRow {
+func (_m *IndexerDb) AssetBalances(ctx context.Context, abq idb.AssetBalanceQuery) (<-chan idb.AssetBalanceRow, uint64) {
 	ret := _m.Called(ctx, abq)
 
 	var r0 <-chan idb.AssetBalanceRow
@@ -82,11 +89,18 @@ func (_m *IndexerDb) AssetBalances(ctx context.Context, abq idb.AssetBalanceQuer
 		}
 	}
 
-	return r0
+	var r1 uint64
+	if rf, ok := ret.Get(1).(func(context.Context, idb.AssetBalanceQuery) uint64); ok {
+		r1 = rf(ctx, abq)
+	} else {
+		r1 = ret.Get(1).(uint64)
+	}
+
+	return r0, r1
 }
 
 // Assets provides a mock function with given fields: ctx, filter
-func (_m *IndexerDb) Assets(ctx context.Context, filter idb.AssetsQuery) <-chan idb.AssetRow {
+func (_m *IndexerDb) Assets(ctx context.Context, filter idb.AssetsQuery) (<-chan idb.AssetRow, uint64) {
 	ret := _m.Called(ctx, filter)
 
 	var r0 <-chan idb.AssetRow
@@ -98,7 +112,14 @@ func (_m *IndexerDb) Assets(ctx context.Context, filter idb.AssetsQuery) <-chan 
 		}
 	}
 
-	return r0
+	var r1 uint64
+	if rf, ok := ret.Get(1).(func(context.Context, idb.AssetsQuery) uint64); ok {
+		r1 = rf(ctx, filter)
+	} else {
+		r1 = ret.Get(1).(uint64)
+	}
+
+	return r0, r1
 }
 
 // CommitBlock provides a mock function with given fields: round, timestamp, rewardslevel, headerbytes
@@ -130,7 +151,7 @@ func (_m *IndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round uint6
 }
 
 // GetAccounts provides a mock function with given fields: ctx, opts
-func (_m *IndexerDb) GetAccounts(ctx context.Context, opts idb.AccountQueryOptions) <-chan idb.AccountRow {
+func (_m *IndexerDb) GetAccounts(ctx context.Context, opts idb.AccountQueryOptions) (<-chan idb.AccountRow, uint64) {
 	ret := _m.Called(ctx, opts)
 
 	var r0 <-chan idb.AccountRow
@@ -142,7 +163,14 @@ func (_m *IndexerDb) GetAccounts(ctx context.Context, opts idb.AccountQueryOptio
 		}
 	}
 
-	return r0
+	var r1 uint64
+	if rf, ok := ret.Get(1).(func(context.Context, idb.AccountQueryOptions) uint64); ok {
+		r1 = rf(ctx, opts)
+	} else {
+		r1 = ret.Get(1).(uint64)
+	}
+
+	return r0, r1
 }
 
 // GetBlock provides a mock function with given fields: ctx, round, options
@@ -397,7 +425,7 @@ func (_m *IndexerDb) StartBlock() error {
 }
 
 // Transactions provides a mock function with given fields: ctx, tf
-func (_m *IndexerDb) Transactions(ctx context.Context, tf idb.TransactionFilter) <-chan idb.TxnRow {
+func (_m *IndexerDb) Transactions(ctx context.Context, tf idb.TransactionFilter) (<-chan idb.TxnRow, uint64) {
 	ret := _m.Called(ctx, tf)
 
 	var r0 <-chan idb.TxnRow
@@ -409,7 +437,14 @@ func (_m *IndexerDb) Transactions(ctx context.Context, tf idb.TransactionFilter)
 		}
 	}
 
-	return r0
+	var r1 uint64
+	if rf, ok := ret.Get(1).(func(context.Context, idb.TransactionFilter) uint64); ok {
+		r1 = rf(ctx, tf)
+	} else {
+		r1 = ret.Get(1).(uint64)
+	}
+
+	return r0, r1
 }
 
 // YieldTxns provides a mock function with given fields: ctx, prevRound

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -1559,8 +1559,7 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 }
 
 // Transactions is part of idb.IndexerDB
-func (db *IndexerDb) Transactions(ctx context.Context,
-	tf idb.TransactionFilter) (<-chan idb.TxnRow, uint64) {
+func (db *IndexerDb) Transactions(ctx context.Context, tf idb.TransactionFilter) (<-chan idb.TxnRow, uint64) {
 	out := make(chan idb.TxnRow, 1)
 
 	tx, err := db.db.BeginTx(ctx, &readonlySerializable)
@@ -1628,8 +1627,7 @@ func (db *IndexerDb) txTransactions(tx *sql.Tx, tf idb.TransactionFilter) <-chan
 	return out
 }
 
-func (db *IndexerDb) txnsWithNext(ctx context.Context, tx *sql.Tx, tf idb.TransactionFilter,
-	out chan<- idb.TxnRow) {
+func (db *IndexerDb) txnsWithNext(ctx context.Context, tx *sql.Tx, tf idb.TransactionFilter, out chan<- idb.TxnRow) {
 	nextround, nextintra32, err := idb.DecodeTxnRowNext(tf.NextToken)
 	nextintra := uint64(nextintra32)
 	if err != nil {
@@ -2342,8 +2340,7 @@ type getAccountsRequest struct {
 }
 
 // GetAccounts is part of idb.IndexerDB
-func (db *IndexerDb) GetAccounts(ctx context.Context,
-	opts idb.AccountQueryOptions) (<-chan idb.AccountRow, uint64) {
+func (db *IndexerDb) GetAccounts(ctx context.Context, opts idb.AccountQueryOptions) (<-chan idb.AccountRow, uint64) {
 	out := make(chan idb.AccountRow, 1)
 
 	if opts.HasAssetID != 0 {
@@ -2543,8 +2540,7 @@ func (db *IndexerDb) buildAccountQuery(opts idb.AccountQueryOptions) (query stri
 }
 
 // Assets is part of idb.IndexerDB
-func (db *IndexerDb) Assets(ctx context.Context,
-	filter idb.AssetsQuery) (<-chan idb.AssetRow, uint64) {
+func (db *IndexerDb) Assets(ctx context.Context, filter idb.AssetsQuery) (<-chan idb.AssetRow, uint64) {
 	query := `SELECT index, creator_addr, params, created_at, closed_at, deleted FROM asset a`
 	const maxWhereParts = 14
 	whereParts := make([]string, 0, maxWhereParts)
@@ -2660,8 +2656,7 @@ func (db *IndexerDb) yieldAssetsThread(ctx context.Context, filter idb.AssetsQue
 }
 
 // AssetBalances is part of idb.IndexerDB
-func (db *IndexerDb) AssetBalances(ctx context.Context,
-	abq idb.AssetBalanceQuery) (<-chan idb.AssetBalanceRow, uint64) {
+func (db *IndexerDb) AssetBalances(ctx context.Context, abq idb.AssetBalanceQuery) (<-chan idb.AssetBalanceRow, uint64) {
 	const maxWhereParts = 14
 	whereParts := make([]string, 0, maxWhereParts)
 	whereArgs := make([]interface{}, 0, maxWhereParts)

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -459,7 +459,7 @@ func TestBlockWithTransactions(t *testing.T) {
 	_, blockTxn, err := pdb.GetBlock(context.Background(), test.Round, idb.GetBlockOptions{Transactions: true})
 	assert.NoError(t, err)
 	round := test.Round
-	txnRow := pdb.Transactions(context.Background(), idb.TransactionFilter{Round: &round})
+	txnRow, _ := pdb.Transactions(context.Background(), idb.TransactionFilter{Round: &round})
 	transactionsTxn := make([]idb.TxnRow, 0)
 	for row := range txnRow {
 		transactionsTxn = append(transactionsTxn, row)

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -459,7 +459,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 	}
 	options.IncludeDeleted = true
 
-	accountChan := db.GetAccounts(context.Background(), options)
+	accountChan, _ := db.GetAccounts(context.Background(), options)
 
 	batchSize := 500
 	batchNumber := 1
@@ -598,7 +598,7 @@ func initM5AccountData() *m5AccountData {
 func processAccountTransactionsWithRetry(db *IndexerDb, addressStr string, address types.Address, nextRound uint64, retries int) (results *m5AccountData, err error) {
 	for i := 0; i < retries; i++ {
 		// Query transactions for the account
-		txnrows := db.Transactions(context.Background(), idb.TransactionFilter{
+		txnrows, _ := db.Transactions(context.Background(), idb.TransactionFilter{
 			Address:  address[:],
 			MaxRound: nextRound,
 		})

--- a/util/test/testutil.go
+++ b/util/test/testutil.go
@@ -56,7 +56,8 @@ func myStackTrace() {
 // PrintAssetQuery prints information about an asset query.
 func PrintAssetQuery(db idb.IndexerDb, q idb.AssetsQuery) {
 	count := uint64(0)
-	for ar := range db.Assets(context.Background(), q) {
+	assetchan, _ := db.Assets(context.Background(), q)
+	for ar := range assetchan {
 		MaybeFail(ar.Error, "asset query %v\n", ar.Error)
 		pjs, err := json.Marshal(ar.Params)
 		MaybeFail(err, "json.Marshal params %v\n", err)
@@ -75,7 +76,7 @@ func PrintAssetQuery(db idb.IndexerDb, q idb.AssetsQuery) {
 
 // PrintAccountQuery prints information about an account query.
 func PrintAccountQuery(db idb.IndexerDb, q idb.AccountQueryOptions) {
-	accountchan := db.GetAccounts(context.Background(), q)
+	accountchan, _ := db.GetAccounts(context.Background(), q)
 	count := uint64(0)
 	for ar := range accountchan {
 		MaybeFail(ar.Error, "GetAccounts err %v\n", ar.Error)
@@ -95,7 +96,7 @@ func PrintAccountQuery(db idb.IndexerDb, q idb.AccountQueryOptions) {
 
 // PrintTxnQuery prints information about a transaction query.
 func PrintTxnQuery(db idb.IndexerDb, q idb.TransactionFilter) {
-	rowchan := db.Transactions(context.Background(), q)
+	rowchan, _ := db.Transactions(context.Background(), q)
 	count := uint64(0)
 	for txnrow := range rowchan {
 		MaybeFail(txnrow.Error, "err %v\n", txnrow.Error)


### PR DESCRIPTION
## Summary

Some work towards fixing #351. Rewinding can return an error if the database returns stale transaction list. Accounting when importing a block still needs to be fixed. 

## Test Plan

Unit tests for rewind.go. All other changes are trivial.