### PR TITLE
adding line to copy mdhash to prevent overwriting

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -545,6 +545,9 @@ func (si *ServerImplementation) fetchAssets(ctx context.Context, options idb.Ass
 		}
 		copy(creator[:], row.Creator[:])
 
+		mdhash := make([]byte, 32)
+		copy(mdhash, row.Params.MetadataHash[:])
+
 		asset := generated.Asset{
 			Index:            row.AssetID,
 			CreatedAtRound:   row.CreatedRound,
@@ -558,7 +561,7 @@ func (si *ServerImplementation) fetchAssets(ctx context.Context, options idb.Ass
 				Total:         row.Params.Total,
 				Decimals:      uint64(row.Params.Decimals),
 				DefaultFrozen: boolPtr(row.Params.DefaultFrozen),
-				MetadataHash:  bytePtr(row.Params.MetadataHash[:]),
+				MetadataHash:  bytePtr(mdhash),
 				Clawback:      strPtr(row.Params.Clawback.String()),
 				Reserve:       strPtr(row.Params.Reserve.String()),
 				Freeze:        strPtr(row.Params.Freeze.String()),


### PR DESCRIPTION
## Summary
Fix overwritten metadata-hash value in /v2/assets endpoint


## Test Plan
in a clean sandbox create a couple assets with the same name and different metadata hash values
```
./sandbox goal asset create --name rareaf --assetmetadatab64 MQ== --creator FVHHJRDZRZOMOV2T3K3U2L33L7NCKDHGQDN5CXEN4WRXONKROCVEZIH2FQ --total 1
./sandbox goal asset create --name rareaf --assetmetadatab64 Mg== --creator FVHHJRDZRZOMOV2T3K3U2L33L7NCKDHGQDN5CXEN4WRXONKROCVEZIH2FQ --total 1
```

Without patch this will return different metadata-hash values for each asset when queried by ID but the same when queried by name. 
```
echo "By ID"
curl -s "localhost:8980/v2/assets/1" | jq '[.asset.index, .asset.params["metadata-hash"]]'
curl -s "localhost:8980/v2/assets/2" | jq '[.asset.index, .asset.params["metadata-hash"]]'
echo "By name"
curl -s "localhost:8980/v2/assets?name=rareaf&limit=10" | jq '.assets[] | [.index, .params["metadata-hash"]]'
```


I doubt this is the best way to fix this but it demonstrates the issue and a potential fix.