### PR TITLE
A faster implementation for migration m7

### DIFF
--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -450,6 +450,7 @@ type TxnId struct {
 	round uint32
 	intra uint32
 }
+
 func txnIdLess(l TxnId, r TxnId) bool {
 	if l.round < r.round {
 		return true
@@ -823,7 +824,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 			}
 
 			numRows++
-			if numRows % 1000000 == 0 {
+			if numRows%1000000 == 0 {
 				db.log.Printf("read %d transactions (pass 1)\n", numRows)
 			}
 		}

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -799,6 +799,7 @@ func getAccountsFirstUsed(db *IndexerDb, maxRound int64, specialAccounts idb.Spe
 		return nil, fmt.Errorf("%s: unable to query transactions (pass 1): %v",
 			rewardsCreateCloseUpdateErr, err)
 	}
+	defer rows.Close()
 
 	numRows := 0
 	db.log.Print("started reading transactions (pass 1)")
@@ -838,6 +839,9 @@ func getAccountsFirstUsed(db *IndexerDb, maxRound int64, specialAccounts idb.Spe
 		if numRows%1000000 == 0 {
 			db.log.Printf("read %d transactions (pass 1)", numRows)
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("%s: error scanning rows: %v", rewardsCreateCloseUpdateErr, err)
 	}
 	db.log.Print("finished reading transactions (pass 1)")
 
@@ -909,6 +913,7 @@ func updateAccounts(db *IndexerDb, maxRound int64, specialAccounts idb.SpecialAc
 	if err != nil {
 		return fmt.Errorf("%s: unable to query transactions: %v", rewardsCreateCloseUpdateErr, err)
 	}
+	defer rows.Close()
 
 	var writeDuration time.Duration = 0
 
@@ -982,6 +987,9 @@ func updateAccounts(db *IndexerDb, maxRound int64, specialAccounts idb.SpecialAc
 		if numRows%1000000 == 0 {
 			db.log.Printf("m6: read %d transactions (pass 2)", numRows)
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("%s: error scanning rows: %v", rewardsCreateCloseUpdateErr, err)
 	}
 	db.log.Print("m6: finished reading transactions (pass 2)")
 

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -8,13 +8,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
+	"os"
+	"time"
+
 	"github.com/algorand/go-algorand-sdk/crypto"
 	"github.com/algorand/go-algorand-sdk/encoding/json"
 	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
 	sdk_types "github.com/algorand/go-algorand-sdk/types"
-	"math"
-	"os"
-	"time"
 
 	"github.com/algorand/indexer/accounting"
 	"github.com/algorand/indexer/api/generated/v2"

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -474,7 +474,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 	accountCh, _ := db.GetAccounts(context.Background(), options)
 
 	// Read all accounts.
-	accountsWithoutTxn := make(map[sdk_types.Address]bool)
+	accountsWithoutTxn := make(map[sdk_types.Address]struct{})
 	numRows := 0
 	db.log.Print("started reading accounts")
 	for accountRow := range accountCh {
@@ -491,7 +491,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 
 		// Don't update special accounts (m9 fixes this)
 		if address != specialAccounts.FeeSink && address != specialAccounts.RewardsPool {
-			accountsWithoutTxn[address] = true
+			accountsWithoutTxn[address] = struct{}{}
 		}
 
 		numRows++

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -537,7 +537,7 @@ type m7AccountData struct {
 	additional *m7AdditionalAccountData
 }
 
-func initM6AdditionalData() *m7AdditionalAccountData {
+func initM7AdditionalData() *m7AdditionalAccountData {
 	return &m7AdditionalAccountData{
 		asset:    make(map[uint64]createClose),
 		app:      make(map[uint64]createClose),
@@ -545,7 +545,7 @@ func initM6AdditionalData() *m7AdditionalAccountData {
 	}
 }
 
-func initM6AccountData() *m7AccountData {
+func initM7AccountData() *m7AccountData {
 	return &m7AccountData{
 		cumulativeRewards: 0,
 		account:           createClose{},
@@ -555,7 +555,7 @@ func initM6AccountData() *m7AccountData {
 
 func maybeInitializeAdditionalAccountData(accountData *m7AccountData) {
 	if accountData.additional == nil {
-		accountData.additional = initM6AdditionalData()
+		accountData.additional = initM7AdditionalData()
 	}
 }
 
@@ -877,7 +877,7 @@ func getAccountsWithoutTxnData(db *IndexerDb, specialAccounts idb.SpecialAccount
 		// Don't update special accounts (m10 fixes this)
 		if (address != specialAccounts.FeeSink) && (address != specialAccounts.RewardsPool) {
 			if _, ok := accountsFirstUsed[address]; !ok {
-				accountData := initM6AccountData()
+				accountData := initM7AccountData()
 
 				accountData.account.createdValid = true
 				accountData.account.created = 0
@@ -943,7 +943,7 @@ func updateAccounts(db *IndexerDb, maxRound int64, specialAccounts idb.SpecialAc
 			if (address != specialAccounts.RewardsPool) && (address != specialAccounts.FeeSink) {
 				accountData, ok := accountDataMap[address]
 				if !ok {
-					accountData = initM6AccountData()
+					accountData = initM7AccountData()
 					accountDataMap[address] = accountData
 				}
 

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -827,14 +827,17 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 
 			participants := getParticipants(stxn)
 			for _, address := range participants {
-				txnID := txnID{uint32(round), uint32(intra)}
+				// Don't update special accounts (m9 fixes this).
+				if (address != specialAccounts.RewardsPool) && (address != specialAccounts.FeeSink) {
+					txnID := txnID{uint32(round), uint32(intra)}
 
-				storedTxnID, ok := accountsFirstUsed[address]
-				if !ok {
-					accountsFirstUsed[address] = txnID
-				} else {
-					if txnIDLess(txnID, storedTxnID) {
+					storedTxnID, ok := accountsFirstUsed[address]
+					if !ok {
 						accountsFirstUsed[address] = txnID
+					} else {
+						if txnIDLess(txnID, storedTxnID) {
+							accountsFirstUsed[address] = txnID
+						}
 					}
 				}
 			}

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -453,7 +453,7 @@ func getParticipants(stxn types.SignedTxnWithAD) []sdk_types.Address {
 
 // m6RewardsAndDatesPart2 computes the cumulative rewards for each account one at a time.
 func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
-	db.log.Println("m6 account cumulative rewards migration starting")
+	db.log.Print("m6 account cumulative rewards migration starting")
 
 	specialAccounts, err := db.GetSpecialAccounts()
 	if err != nil {
@@ -474,6 +474,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 	// Loop through all accounts and initialize account data for each.
 	accountDataMap := make(map[sdk_types.Address]*m6AccountData)
 	accountsWithoutTxn := make(map[sdk_types.Address]bool)
+	numRows := 0
 	for accountRow := range accountCh {
 		if accountRow.Error != nil {
 			return fmt.Errorf("%s: problem querying accounts: %v",
@@ -491,6 +492,12 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 			accountDataMap[address] = initM6AccountData()
 			accountsWithoutTxn[address] = true
 		}
+
+		numRows++
+
+		if numRows%100000 == 0 {
+			db.log.Printf("m6: read %d accounts", numRows)
+		}
 	}
 	db.log.Print("m6: finished reading accounts")
 
@@ -501,7 +508,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 	}
 
 	// Loop through all transactions and compute account data.
-	numRows := 0
+	numRows = 0
 	for rows.Next() {
 		var round uint64
 		var intra uint64
@@ -537,7 +544,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 
 		numRows++
 
-		if numRows%1000000 == 0 {
+		if numRows%100000 == 0 {
 			db.log.Printf("m6: read %d transactions", numRows)
 		}
 	}

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -581,13 +581,33 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 	sort.Slice(accountDataArr, less)
 
 	{
-		num := 0
+		numAd := 0
+		numAsset := 0
+		numAssetHolding := 0
+		numApp := 0
+		numAppLocal := 0
 		for _, aad := range accountDataArr {
 			if aad.accountData.additional != nil {
-				num++
+				numAd++
+				if len(aad.accountData.additional.asset) > 0 {
+					numAsset++
+				}
+				if len(aad.accountData.additional.assetHolding) > 0 {
+					numAssetHolding++
+				}
+				if len(aad.accountData.additional.app) > 0 {
+					numApp++
+				}
+				if len(aad.accountData.additional.appLocal) > 0 {
+					numAppLocal++
+				}
 			}
 		}
-		db.log.Printf("%d accounts have additional data", num)
+		db.log.Printf("%d accounts have additional data", numAd)
+		db.log.Printf("%d accounts have additional data: asset", numAsset)
+		db.log.Printf("%d accounts have additional data: asset holding", numAssetHolding)
+		db.log.Printf("%d accounts have additional data: app", numApp)
+		db.log.Printf("%d accounts have additional data: app local", numAppLocal)
 	}
 
 	// Loop through all accounts, update them in batches.

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -416,7 +416,7 @@ func m5RewardsAndDatesPart1(db *IndexerDb, state *MigrationState) error {
 const rewardsCreateCloseUpdateMessage = "rewards, create_at, close_at migration error"
 const rewardsCreateCloseUpdateErr = rewardsCreateCloseUpdateMessage + " error"
 
-type AddressAccountData struct {
+type addressAccountData struct {
 	address     sdk_types.Address
 	accountData *m6AccountData
 }
@@ -446,12 +446,12 @@ func getParticipants(stxn types.SignedTxnWithAD) []sdk_types.Address {
 	return res
 }
 
-type TxnId struct {
+type txnId struct {
 	round uint32
 	intra uint32
 }
 
-func txnIdLess(l TxnId, r TxnId) bool {
+func txnIdLess(l txnId, r txnId) bool {
 	if l.round < r.round {
 		return true
 	}
@@ -652,7 +652,7 @@ func updateAccountData(address types.Address, round uint64, assetId uint64, stxn
 // Note: These queries only work if closed_at was reset before the migration is started. That is true
 //       for the initial migration, but if we need to reuse it in the future we'll need to fix the queries
 //       or redo the query.
-func m6RewardsAndDatesPart2UpdateAccounts(db *IndexerDb, accountData []AddressAccountData, maxRound int64) error {
+func m6RewardsAndDatesPart2UpdateAccounts(db *IndexerDb, accountData []addressAccountData, maxRound int64) error {
 	// Make sure round accounting doesn't interfere with updating these accounts.
 	db.accountingLock.Lock()
 	defer db.accountingLock.Unlock()
@@ -782,7 +782,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 	}
 
 	// First pass over all transactions in arbitrary order.
-	accountsFirstUsed := make(map[sdk_types.Address]TxnId)
+	accountsFirstUsed := make(map[sdk_types.Address]txnId)
 	{
 		db.log.Print("querying transactions (pass 1)")
 		query := "SELECT round, intra, txnbytes FROM txn WHERE round <= $1"
@@ -811,7 +811,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 
 			participants := getParticipants(stxn)
 			for _, address := range participants {
-				txnId := TxnId{uint32(round), uint32(intra)}
+				txnId := txnId{uint32(round), uint32(intra)}
 
 				storedTxnId, ok := accountsFirstUsed[address]
 				if !ok {
@@ -834,7 +834,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 	// Set Created, Deleted for accounts with no transactions.
 	// Genesis accounts could have this property.
 	// Query accounts.
-	readyAccountData := []AddressAccountData{}
+	readyAccountData := []addressAccountData{}
 	{
 		options := idb.AccountQueryOptions{}
 		options.IncludeDeleted = true
@@ -867,7 +867,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 					accountData.account.deletedValid = true
 					accountData.account.deleted = false
 
-					readyAccountData = append(readyAccountData, AddressAccountData{address, accountData})
+					readyAccountData = append(readyAccountData, addressAccountData{address, accountData})
 				}
 			}
 
@@ -932,8 +932,8 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 						return fmt.Errorf("%s: accountFirstUsed does not contain address: %v",
 							rewardsCreateCloseUpdateErr, address)
 					}
-					if (TxnId{uint32(round), uint32(intra)}) == firstUsed {
-						readyAccountData = append(readyAccountData, AddressAccountData{address, accountData})
+					if (txnId{uint32(round), uint32(intra)}) == firstUsed {
+						readyAccountData = append(readyAccountData, addressAccountData{address, accountData})
 						delete(accountDataMap, address)
 						delete(accountsFirstUsed, address)
 

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -584,7 +584,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 				return err
 			}
 
-			if batchNumber%1000 == 0 {
+			if batchNumber%100 == 0 {
 				db.log.Printf("m6: written %.2f%% accounts; batch %d, next account %s",
 					float64(100*batchSize*batchNumber)/float64(numAccounts), batchNumber,
 					accountDataArr[0].address)

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -912,19 +912,19 @@ func m6RewardsAndDatesPart2UpdateAccounts(db *IndexerDb, accountData []AddressAc
 			return fmt.Errorf("%s: failed to update %s with create/close: %v", rewardsCreateCloseUpdateErr, addressStr, err)
 		}
 
+		// 4. setCreateCloseAssetHolding - (upsert) set the accounts asset holding create/close rounds.
+		err = executeForEachCreatable(setCreateCloseAssetHolding, ad.address[:],
+			ad.accountData.assetHolding)
+		if err != nil {
+			return fmt.Errorf("%s: failed to update %s with asset holding create/close: %v", rewardsCreateCloseUpdateErr, addressStr, err)
+		}
+
 		if ad.accountData.additional != nil {
 			// 3. setCreateCloseAsset        - set the accounts created assets create/close rounds.
 			err = executeForEachCreatable(setCreateCloseAsset, ad.address[:],
 				ad.accountData.additional.asset)
 			if err != nil {
 				return fmt.Errorf("%s: failed to update %s with asset create/close: %v", rewardsCreateCloseUpdateErr, addressStr, err)
-			}
-
-			// 4. setCreateCloseAssetHolding - (upsert) set the accounts asset holding create/close rounds.
-			err = executeForEachCreatable(setCreateCloseAssetHolding, ad.address[:],
-				ad.accountData.assetHolding)
-			if err != nil {
-				return fmt.Errorf("%s: failed to update %s with asset holding create/close: %v", rewardsCreateCloseUpdateErr, addressStr, err)
 			}
 
 			// 5. setCreateCloseApp          - set the accounts created apps create/close rounds.

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -963,8 +963,9 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 
 							numBatches++
 							if numBatches%100 == 0 {
-								db.log.Printf("m6: written %.2f%% accounts; %d batches",
-									float64(100*numAccountsUpdated)/float64(numAccounts), numBatches)
+								db.log.Printf("m6: written %d (%.2f%%) accounts, %d batches",
+									numAccountsUpdated, float64(100*numAccountsUpdated)/float64(numAccounts),
+									numBatches)
 							}
 						}
 					}

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -465,7 +465,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 	if len(state.LastAccount) != 0 {
 		var address sdk_types.Address
 		copy(address[:], state.LastAccount)
-		db.log.Println("after " + address.String())
+		db.log.Print("after " + address.String())
 		options.GreaterThanAddress = state.LastAccount[:]
 	}
 	options.IncludeDeleted = true
@@ -492,6 +492,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 			accountsWithoutTxn[address] = true
 		}
 	}
+	db.log.Print("m6: finished reading accounts")
 
 	query := "SELECT round, intra, txnbytes, asset FROM txn WHERE round <= $1 ORDER BY round DESC, intra DESC"
 	rows, err := db.db.Query(query, state.NextRound)
@@ -540,6 +541,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 			db.log.Printf("m6: read %d transactions", numRows)
 		}
 	}
+	db.log.Print("m6: finished reading transactions")
 
 	// Set Created, Deleted for accounts with no transactions.
 	// Genesis accounts could have this property.
@@ -561,7 +563,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 	}
 	sort.Slice(accountDataArr, less)
 
-	// Loop through all of the accounts, update them in batches.
+	// Loop through all accounts, update them in batches.
 	numAccounts := len(accountDataArr)
 	batchSize := 1000
 	batchNumber := 0
@@ -591,6 +593,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 			}
 		}
 	}
+	db.log.Print("m6: finished updating accounts")
 
 	return nil
 }

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -841,7 +841,7 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 
 			numRows++
 			if numRows%1000000 == 0 {
-				db.log.Printf("read %d transactions (pass 1)\n", numRows)
+				db.log.Printf("read %d transactions (pass 1)", numRows)
 			}
 		}
 		db.log.Print("finished reading transactions (pass 1)")

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -580,6 +580,16 @@ func m6RewardsAndDatesPart2(db *IndexerDb, state *MigrationState) error {
 	}
 	sort.Slice(accountDataArr, less)
 
+	{
+		num := 0
+		for _, aad := range accountDataArr {
+			if aad.accountData.additional != nil {
+				num++
+			}
+		}
+		db.log.Printf("%d accounts have additional data", num)
+	}
+
 	// Loop through all accounts, update them in batches.
 	db.log.Print("started updating accounts")
 	numAccounts := len(accountDataArr)


### PR DESCRIPTION
## Summary

A faster implementation for migration m7 that reads all transactions in one pass and keeps all account data in RAM.
This implementation is not yet correct if the migration aborts.

## Test Plan

Tests already provided.
