### PR TITLE
Add index for 10x speed up for account info

### DIFF
--- a/idb/postgres/setup_postgres_sql.go
+++ b/idb/postgres/setup_postgres_sql.go
@@ -83,7 +83,7 @@ CREATE TABLE IF NOT EXISTS asset (
   created_at bigint NOT NULL DEFAULT 0, -- round that the asset was created
   closed_at bigint -- round that the asset was closed. Cannot be recreated because the index is unique
 );
--- TODO: index on creator_addr?
+CREATE INDEX IF NOT EXISTS asset_by_creator_addr ON asset ( creator_addr );
 
 -- subsumes ledger/accountdb.go accounttotals and acctrounds
 -- "state":{online, onlinerewardunits, offline, offlinerewardunits, notparticipating, notparticipatingrewardunits, rewardslevel, round bigint}


### PR DESCRIPTION
## Summary

Due to the recent surge in number of ASAs, account information endpoint started taking between 1 and 2s to answer `/v2/accounts/...`:
```bash
$ time curl -s -X GET ".../v2/accounts/REMF542E5ZFKS7SGSNHTYB255AUITEKHLAATWVPK3CY7TAFPT6GNNCHH6M"
{"account":{"address":"REMF542E5ZFKS7SGSNHTYB255AUITEKHLAATWVPK3CY7TAFPT6GNNCHH6M","amount":50476347078263,"amount-without-pending-rewards":50476296601967,"participation":{"selection-participation-key":"CGMtSQKUBxT0pp7xF6EDVvGYhrkRwVYo6n1ccf9z5bM=","vote-first-valid":8240000,"vote-key-dilution":10000,"vote-last-valid":15200000,"vote-participation-key":"IKAzqRvqPv8lcGr94OC0N7O+4bZJsNtGYDkoDFm9cRw="},"pending-rewards":50476296,"reward-base":176486,"rewards":0,"round":12775325,"sig-type":"msig","status":"Online"},"current-round":12775325}
curl -s -X GET   0.02s user 0.01s system 1% cpu 1.658 total
```
and the log would indicate something like:
```plain
{"level":"warning","msg":"long query 1.271661s: WITH qaccounts AS (SELECT a.addr, a.microalgos, a.rewardsbase, a.keytype, a.account_data FROM account a WHERE a.addr = $1 ORDER BY a.addr ASC LIMIT 1), qaa AS (SELECT xa.addr, json_agg(aa.assetid) as haid, json_agg(aa.amount) as hamt, json_agg(aa.frozen) as hf FROM account_asset aa JOIN qaccounts xa ON aa.addr = xa.addr GROUP BY 1), qap AS (SELECT ya.addr, json_agg(ap.index) as paid, json_agg(ap.params) as pp FROM asset ap JOIN qaccounts ya ON ap.creator_addr = ya.addr GROUP BY 1), qapp AS (SELECT app.creator as addr, json_agg(app.index) as papps, json_agg(app.params) as ppa FROM app JOIN qaccounts ON qaccounts.addr = app.creator GROUP BY 1), qls AS (SELECT la.addr, json_agg(la.app) as lsapps, json_agg(la.localstate) as lsls FROM account_app la JOIN qaccounts ON qaccounts.addr = la.addr GROUP BY 1) SELECT za.addr, za.microalgos, za.rewardsbase, za.keytype, za.account_data, qaa.haid, qaa.hamt, qaa.hf, qap.paid, qap.pp, qapp.papps, qapp.ppa, qls.lsapps, qls.lsls FROM qaccounts za LEFT JOIN qaa ON za.addr = qaa.addr LEFT JOIN qap ON za.addr = qap.addr LEFT JOIN qapp ON za.addr = qapp.addr LEFT JOIN qls ON qls.addr = za.addr ORDER BY za.addr ASC;","time":"2021-03-23T01:20:32Z"}
```

Analyzing the query, it turned out that the reason was a lack of index for `create_account` in the table `asset`:
```plain
EXPLAIN WITH qaccounts AS (SELECT a.addr, a.microalgos, a.rewardsbase, a.keytype, a.account_data FROM account a WHERE a.addr = 'M4TNVJLDZZFAOH2M24BE7IU72KUX3P6M2D4JN4WZXW7WXH3C5QSHULJOU4' ORDER BY a.addr ASC LIMIT 1), qaa AS (SELECT xa.addr, json_agg(aa.assetid) as haid, json_agg(aa.amount) as hamt, json_agg(aa.frozen) as hf FROM account_asset aa JOIN qaccounts xa ON aa.addr = xa.addr GROUP BY 1), qap AS (SELECT ya.addr, json_agg(ap.index) as paid, json_agg(ap.params) as pp FROM asset ap JOIN qaccounts ya ON ap.creator_addr = ya.addr GROUP BY 1), qapp AS (SELECT app.creator as addr, json_agg(app.index) as papps, json_agg(app.params) as ppa FROM app JOIN qaccounts ON qaccounts.addr = app.creator GROUP BY 1), qls AS (SELECT la.addr, json_agg(la.app) as lsapps, json_agg(la.localstate) as lsls FROM account_app la JOIN qaccounts ON qaccounts.addr = la.addr GROUP BY 1) SELECT za.addr, za.microalgos, za.rewardsbase, za.keytype, za.account_data, qaa.haid, qaa.hamt, qaa.hf, qap.paid, qap.pp, qapp.papps, qapp.ppa, qls.lsapps, qls.lsls FROM qaccounts za LEFT JOIN qaa ON za.addr = qaa.addr LEFT JOIN qap ON za.addr = qap.addr LEFT JOIN qapp ON za.addr = qapp.addr LEFT JOIN qls ON qls.addr = za.addr ORDER BY za.addr ASC;
                                                                              QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop Left Join  (cost=259190.91..259192.09 rows=1 width=402)
   Join Filter: (la.addr = za.addr)
   CTE qaccounts
     ->  Limit  (cost=0.56..8.58 rows=1 width=115)
           ->  Index Scan using account_pkey on account a  (cost=0.56..8.58 rows=1 width=115)
                 Index Cond: (addr = '\x4d34544e564a4c445a5a46414f48324d3234424537495537324b55583350364d3244344a4e34575a585737575848334335515348554c4a4f5534'::bytea)
   ->  Nested Loop Left Join  (cost=259178.34..259179.46 rows=1 width=338)
         Join Filter: (za.addr = app.creator)
         ->  Nested Loop Left Join  (cost=259098.01..259099.09 rows=1 width=274)
               Join Filter: (za.addr = ya.addr)
               ->  Merge Left Join  (cost=113.99..114.38 rows=1 width=210)
                     Merge Cond: (za.addr = xa.addr)
                     ->  Sort  (cost=0.03..0.04 rows=1 width=114)
                           Sort Key: za.addr
                           ->  CTE Scan on qaccounts za  (cost=0.00..0.02 rows=1 width=114)
                     ->  GroupAggregate  (cost=113.96..114.32 rows=1 width=128)
                           Group Key: xa.addr
                           ->  Sort  (cost=113.96..114.03 rows=27 width=46)
                                 Sort Key: xa.addr
                                 ->  Nested Loop  (cost=0.56..113.32 rows=27 width=46)
                                       ->  CTE Scan on qaccounts xa  (cost=0.00..0.02 rows=1 width=32)
                                       ->  Index Scan using account_asset_pkey on account_asset aa  (cost=0.56..113.03 rows=27 width=47)
                                             Index Cond: (addr = xa.addr)
               ->  GroupAggregate  (cost=258984.02..258984.69 rows=1 width=96)
                     Group Key: ya.addr
                     ->  Sort  (cost=258984.02..258984.18 rows=65 width=317)
                           Sort Key: ya.addr
                           ->  Hash Join  (cost=0.03..258982.06 rows=65 width=317)
                                 Hash Cond: (ap.creator_addr = ya.addr)
                                 ->  Seq Scan on asset ap  (cost=0.00..242034.55 rows=4519155 width=318)
                                 ->  Hash  (cost=0.02..0.02 rows=1 width=32)
                                       ->  CTE Scan on qaccounts ya  (cost=0.00..0.02 rows=1 width=32)
         ->  GroupAggregate  (cost=80.32..80.35 rows=1 width=97)
               Group Key: app.creator
               ->  Sort  (cost=80.32..80.33 rows=1 width=1536)
                     Sort Key: app.creator
                     ->  Hash Join  (cost=0.03..80.31 rows=1 width=1536)
                           Hash Cond: (app.creator = qaccounts.addr)
                           ->  Seq Scan on app  (cost=0.00..79.65 rows=165 width=1536)
                           ->  Hash  (cost=0.02..0.02 rows=1 width=32)
                                 ->  CTE Scan on qaccounts  (cost=0.00..0.02 rows=1 width=32)
   ->  GroupAggregate  (cost=4.00..4.03 rows=1 width=97)
         Group Key: la.addr
         ->  Sort  (cost=4.00..4.01 rows=1 width=236)
               Sort Key: la.addr
               ->  Hash Join  (cost=0.03..3.99 rows=1 width=236)
                     Hash Cond: (la.addr = qaccounts_1.addr)
                     ->  Seq Scan on account_app la  (cost=0.00..3.69 rows=69 width=236)
                     ->  Hash  (cost=0.02..0.02 rows=1 width=32)
                           ->  CTE Scan on qaccounts qaccounts_1  (cost=0.00..0.02 rows=1 width=32)
 JIT:
   Functions: 70
   Options: Inlining false, Optimization false, Expressions true, Deforming true
(53 rows)
```

After adding the asset:
```SQL
CREATE INDEX IF NOT EXISTS asset_by_creator_addr ON asset ( creator_addr );
```
We get a 10x speed up:
```bash
$ time curl -s -X GET ".../v2/accounts/REMF542E5ZFKS7SGSNHTYB255AUITEKHLAATWVPK3CY7TAFPT6GNNCHH6M"
{"account":{"address":"REMF542E5ZFKS7SGSNHTYB255AUITEKHLAATWVPK3CY7TAFPT6GNNCHH6M","amount":50477053751101,"amount-without-pending-rewards":50476952797197,"participation":{"selection-participation-key":"CGMtSQKUBxT0pp7xF6EDVvGYhrkRwVYo6n1ccf9z5bM=","vote-first-valid":8240000,"vote-key-dilution":10000,"vote-last-valid":15200000,"vote-participation-key":"IKAzqRvqPv8lcGr94OC0N7O+4bZJsNtGYDkoDFm9cRw="},"pending-rewards":100953904,"reward-base":176499,"rewards":0,"round":12776954,"sig-type":"msig","status":"Online"},"current-round":12776954}
curl -s -X GET   0.02s user 0.01s system 23% cpu 0.127 total
```

```plain
EXPLAIN WITH qaccounts AS (SELECT a.addr, a.microalgos, a.rewardsbase, a.keytype, a.account_data FROM account a WHERE a.addr = 'M4TNVJLDZZFAOH2M24BE7IU72KUX3P6M2D4JN4WZXW7WXH3C5QSHULJOU4' ORDER BY a.addr ASC LIMIT 1), qaa AS (SELECT xa.addr, json_agg(aa.assetid) as haid, json_agg(aa.amount) as hamt, json_agg(aa.frozen) as hf FROM account_asset aa JOIN qaccounts xa ON aa.addr = xa.addr GROUP BY 1), qap AS (SELECT ya.addr, json_agg(ap.index) as paid, json_agg(ap.params) as pp FROM asset ap JOIN qaccounts ya ON ap.creator_addr = ya.addr GROUP BY 1), qapp AS (SELECT app.creator as addr, json_agg(app.index) as papps, json_agg(app.params) as ppa FROM app JOIN qaccounts ON qaccounts.addr = app.creator GROUP BY 1), qls AS (SELECT la.addr, json_agg(la.app) as lsapps, json_agg(la.localstate) as lsls FROM account_app la JOIN qaccounts ON qaccounts.addr = la.addr GROUP BY 1) SELECT za.addr, za.microalgos, za.rewardsbase, za.keytype, za.account_data, qaa.haid, qaa.hamt, qaa.hf, qap.paid, qap.pp, qapp.papps, qapp.ppa, qls.lsapps, qls.lsls FROM qaccounts za LEFT JOIN qaa ON za.addr = qaa.addr LEFT JOIN qap ON za.addr = qap.addr LEFT JOIN qapp ON za.addr = qapp.addr LEFT JOIN qls ON qls.addr = za.addr ORDER BY za.addr ASC;
                                                                              QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop Left Join  (cost=471.85..473.02 rows=1 width=402)
   Join Filter: (la.addr = za.addr)
   CTE qaccounts
     ->  Limit  (cost=0.56..8.58 rows=1 width=115)
           ->  Index Scan using account_pkey on account a  (cost=0.56..8.58 rows=1 width=115)
                 Index Cond: (addr = '\x4d34544e564a4c445a5a46414f48324d3234424537495537324b55583350364d3244344a4e34575a585737575848334335515348554c4a4f5534'::bytea)
   ->  Nested Loop Left Join  (cost=459.27..460.39 rows=1 width=338)
         Join Filter: (za.addr = app.creator)
         ->  Nested Loop Left Join  (cost=378.95..380.02 rows=1 width=274)
               Join Filter: (za.addr = ya.addr)
               ->  Merge Left Join  (cost=113.99..114.38 rows=1 width=210)
                     Merge Cond: (za.addr = xa.addr)
                     ->  Sort  (cost=0.03..0.04 rows=1 width=114)
                           Sort Key: za.addr
                           ->  CTE Scan on qaccounts za  (cost=0.00..0.02 rows=1 width=114)
                     ->  GroupAggregate  (cost=113.96..114.32 rows=1 width=128)
                           Group Key: xa.addr
                           ->  Sort  (cost=113.96..114.03 rows=27 width=46)
                                 Sort Key: xa.addr
                                 ->  Nested Loop  (cost=0.56..113.32 rows=27 width=46)
                                       ->  CTE Scan on qaccounts xa  (cost=0.00..0.02 rows=1 width=32)
                                       ->  Index Scan using account_asset_pkey on account_asset aa  (cost=0.56..113.03 rows=27 width=47)
                                             Index Cond: (addr = xa.addr)
               ->  GroupAggregate  (cost=264.96..265.62 rows=1 width=96)
                     Group Key: ya.addr
                     ->  Sort  (cost=264.96..265.12 rows=65 width=317)
                           Sort Key: ya.addr
                           ->  Nested Loop  (cost=5.06..263.00 rows=65 width=317)
                                 ->  CTE Scan on qaccounts ya  (cost=0.00..0.02 rows=1 width=32)
                                 ->  Bitmap Heap Scan on asset ap  (cost=5.06..262.33 rows=65 width=318)
                                       Recheck Cond: (creator_addr = ya.addr)
                                       ->  Bitmap Index Scan on asset_by_creator_addr  (cost=0.00..5.04 rows=65 width=0)
                                             Index Cond: (creator_addr = ya.addr)
         ->  GroupAggregate  (cost=80.32..80.35 rows=1 width=97)
               Group Key: app.creator
               ->  Sort  (cost=80.32..80.33 rows=1 width=1536)
                     Sort Key: app.creator
                     ->  Hash Join  (cost=0.03..80.31 rows=1 width=1536)
                           Hash Cond: (app.creator = qaccounts.addr)
                           ->  Seq Scan on app  (cost=0.00..79.65 rows=165 width=1536)
                           ->  Hash  (cost=0.02..0.02 rows=1 width=32)
                                 ->  CTE Scan on qaccounts  (cost=0.00..0.02 rows=1 width=32)
   ->  GroupAggregate  (cost=4.00..4.03 rows=1 width=97)
         Group Key: la.addr
         ->  Sort  (cost=4.00..4.01 rows=1 width=236)
               Sort Key: la.addr
               ->  Hash Join  (cost=0.03..3.99 rows=1 width=236)
                     Hash Cond: (la.addr = qaccounts_1.addr)
                     ->  Seq Scan on account_app la  (cost=0.00..3.69 rows=69 width=236)
                     ->  Hash  (cost=0.02..0.02 rows=1 width=32)
                           ->  CTE Scan on qaccounts qaccounts_1  (cost=0.00..0.02 rows=1 width=32)
(51 rows)
```

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Test Plan

Tested on Indexer v2.2.1 on Ubuntu 18.04.
