### PR TITLE
Fix tag parsing and mockery install in mule docker

### DIFF
--- a/docker/Dockerfile.mule
+++ b/docker/Dockerfile.mule
@@ -8,7 +8,7 @@ ENV GOROOT=/usr/local/go
 ENV GOPATH=$HOME/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
-RUN apt-get update && apt-get install -y apt-transport-https awscli ca-certificates build-essential curl git software-properties-common && \
+RUN apt-get update && apt-get install -y apt-transport-https awscli ca-certificates build-essential curl git software-properties-common gnupg2 wget && \
     curl https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz | tar xzf - && \
     mv go /usr/local && \
     export PATH=/usr/local/go/bin:$PATH && \
@@ -19,7 +19,10 @@ RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update && apt-get install -y postgresql-12 libpq-dev python3 python3-dev python3-psycopg2 python3-pip sudo && \
     pip3 install boto3 markdown2 "msgpack >=1" py-algorand-sdk
 
-RUN go get github.com/vektra/mockery/.../
+RUN wget https://github.com/vektra/mockery/releases/download/v2.5.1/mockery_2.5.1_Linux_x86_64.tar.gz && \
+    tar -xzf mockery_2.5.1_Linux_x86_64.tar.gz mockery && \
+    mv mockery /usr/local/bin && \
+    rm mockery_2.5.1_Linux_x86_64.tar.gz
 
 COPY ./ $HOME/go/src/github.com/algorand/indexer/
 WORKDIR $HOME/go/src/github.com/algorand/indexer/

--- a/misc/release.py
+++ b/misc/release.py
@@ -99,7 +99,7 @@ def link(sourcepath, destpath):
         os.remove(destpath)
     os.link(sourcepath, destpath)
 
-_tagpat = re.compile(r'tag:\s+([^,]+)')
+_tagpat = re.compile(r'tag:\s+([^,\n]+)')
 
 def compile_version_opts(release_version=None, allow_mismatch=False):
     result = subprocess.run(['git', 'log', '-n', '1', '--pretty=%H %D'], stdout=subprocess.PIPE)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Mockery is installed for the mule docker container, but this is currently broken. Hard code this for now until upstream is fixed.

Tag parsing had a small bug where newlines were included in the parsing. Modified the regex to exclude newlines.

## Test Plan

Completed `mule -f mule.yaml package` with these changes.