### PR TITLE
Remove duplicate key.

### DIFF
--- a/api/indexer.oas2.json
+++ b/api/indexer.oas2.json
@@ -1547,11 +1547,6 @@
           ],
           "x-algorand-format": "tx-type-enum"
         },
-        "auth-addr": {
-          "description": "\\[sgnr\\] The address used to sign the transaction. This is used for rekeyed accounts to indicate that the sender address did not sign the transaction.",
-          "type": "string",
-          "x-algorand-format": "Address"
-        },
         "local-state-delta": {
           "description": "\\[ld\\] Local state key/value changes for the application being executed by this transaction.",
           "type": "array",


### PR DESCRIPTION
## Summary

This was specified multiple times. I guess the tools we're using don't care if a map has multiple keys with the same name.
