### PR TITLE
Ignore DefaultFrozen when initializing an asset holding for the creator.

### DIFF
--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -232,7 +232,7 @@ func TestDefaultFrozenAndCache(t *testing.T) {
 	// Then // Make sure the accounts have the correct default-frozen after create/optin
 	//////////
 	// default-frozen = true
-	assertAccountAsset(t, db, test.AccountA, assetid, true, total)
+	assertAccountAsset(t, db, test.AccountA, assetid, false, total) // the creator ignores default-frozen
 	assertAccountAsset(t, db, test.AccountB, assetid, true, 0)
 
 	// default-frozen = false


### PR DESCRIPTION
## Summary

When creating an Asset with `default-frozen = true` an asset holding is added to the creator account with `default-frozen = false`. The creator account ignores the `default-frozen` value.

## Test Plan

We had a test verifying the incorrect behavior, I updated that test to verify the correct behavior.