### PR TITLE
Remove creator's asset holding when total supply is 0 on asset destruction

### DIFF
--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -1077,7 +1077,7 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 		// Note! leaves `asset` and `account_asset` rows present for historical reference, but deletes all holdings from all accounts
 		any = true
 		// Update any account_asset holdings which were not previously closed. By now the amount should already be 0.
-		ads, err := tx.Prepare(`UPDATE account_asset SET amount = 0, closed_at = $1, deleted = true WHERE assetid = $2 AND amount != 0`)
+		ads, err := tx.Prepare(`UPDATE account_asset SET amount = 0, closed_at = $1, deleted = true WHERE addr = (SELECT creator_addr FROM asset WHERE index = $2) AND assetid = $2`)
 		if err != nil {
 			return fmt.Errorf("prepare asset destroy, %v", err)
 		}

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/algorand/go-algorand-sdk/crypto"
+	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
 	"github.com/algorand/go-algorand-sdk/encoding/json"
 	"github.com/algorand/go-algorand-sdk/types"
 
@@ -702,4 +703,247 @@ func TestZeroTotalAssetCreate(t *testing.T) {
 	// Then // Make sure the creator has an asset holding with amount = 0.
 	//////////
 	assertAccountAsset(t, db, test.AccountA, assetid, false, 0)
+}
+
+func TestDestroyAssetBasic(t *testing.T) {
+	db, connStr, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+
+	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	assert.NoError(t, err)
+
+	cache, err := pdb.GetDefaultFrozen()
+	assert.NoError(t, err)
+
+	assetID := uint64(3)
+
+	// Create an asset.
+	{
+		_, txnRow := test.MakeAssetConfigOrPanic(test.Round, 0, assetID, 4, 0, false, "uu", "aa", "",
+			test.AccountA)
+
+		state := getAccounting(test.Round, cache)
+		err := state.AddTransaction(txnRow)
+		assert.NoError(t, err)
+
+		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+		assert.NoError(t, err, "failed to commit")
+	}
+	// Destroy an asset.
+	{
+		_, txnRow := test.MakeAssetDestroyTxn(test.Round + 1, assetID)
+
+		state := getAccounting(test.Round + 1, cache)
+		err := state.AddTransaction(txnRow)
+		assert.NoError(t, err)
+
+		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round + 1, &itypes.Block{})
+		assert.NoError(t, err, "failed to commit")
+	}
+
+	// Check that the asset is deleted.
+	{
+		row := db.QueryRow(
+			"SELECT deleted, created_at, closed_at FROM asset WHERE index = $1", int64(assetID))
+
+		var deleted sql.NullBool
+		var createdAt sql.NullInt64
+		var closedAt sql.NullInt64
+		err := row.Scan(&deleted, &createdAt, &closedAt)
+		assert.NoError(t, err)
+
+		assert.Equal(t, sql.NullBool{Valid: true, Bool: true}, deleted)
+		assert.Equal(t, sql.NullInt64{Valid: true, Int64: int64(test.Round)}, createdAt)
+		assert.Equal(t, sql.NullInt64{Valid: true, Int64: int64(test.Round + 1)}, closedAt)
+	}
+
+	// Check that the account's asset holding is deleted.
+	{
+		row := db.QueryRow(
+			"SELECT assetid, deleted, created_at, closed_at FROM account_asset WHERE addr = $1",
+			test.AccountA[:])
+
+		var id int64
+		var deleted sql.NullBool
+		var createdAt sql.NullInt64
+		var closedAt sql.NullInt64
+		err := row.Scan(&id, &deleted, &createdAt, &closedAt)
+		assert.NoError(t, err)
+
+		assert.Equal(t, assetID, uint64(id))
+		assert.Equal(t, sql.NullBool{Valid: true, Bool: true}, deleted)
+		assert.Equal(t, sql.NullInt64{Valid: true, Int64: int64(test.Round)}, createdAt)
+		assert.Equal(t, sql.NullInt64{Valid: true, Int64: int64(test.Round + 1)}, closedAt)
+	}
+}
+
+func TestDestroyAssetZeroSupply(t *testing.T) {
+	db, connStr, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+
+	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	assert.NoError(t, err)
+
+	cache, err := pdb.GetDefaultFrozen()
+	assert.NoError(t, err)
+
+	assetID := uint64(3)
+
+	state := getAccounting(test.Round, cache)
+
+	// Create an asset.
+	{
+		// Set total supply to 0.
+		_, txnRow := test.MakeAssetConfigOrPanic(test.Round, 0, assetID, 0, 0, false, "uu", "aa", "",
+			test.AccountA)
+
+		err := state.AddTransaction(txnRow)
+		assert.NoError(t, err)
+	}
+	// Destroy an asset.
+	{
+		_, txnRow := test.MakeAssetDestroyTxn(test.Round, assetID)
+
+		err := state.AddTransaction(txnRow)
+		assert.NoError(t, err)
+	}
+
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+	assert.NoError(t, err, "failed to commit")
+
+	// Check that the asset is deleted.
+	{
+		row := db.QueryRow(
+			"SELECT deleted, closed_at FROM asset WHERE index = $1", int64(assetID))
+
+		var deleted sql.NullBool
+		var closedAt sql.NullInt64
+		err := row.Scan(&deleted, &closedAt)
+		assert.NoError(t, err)
+
+		assert.Equal(t, sql.NullBool{Valid: true, Bool: true}, deleted)
+		assert.Equal(t, sql.NullInt64{Valid: true, Int64: int64(test.Round)}, closedAt)
+	}
+
+	// Check that the account's asset holding is deleted.
+	{
+		row := db.QueryRow(
+			"SELECT assetid, deleted, closed_at FROM account_asset WHERE addr = $1",
+			test.AccountA[:])
+
+		var id int64
+		var deleted sql.NullBool
+		var closedAt sql.NullInt64
+		err := row.Scan(&id, &deleted, &closedAt)
+		assert.NoError(t, err)
+
+		assert.Equal(t, assetID, uint64(id))
+		assert.Equal(t, sql.NullBool{Valid: true, Bool: true}, deleted)
+		assert.Equal(t, sql.NullInt64{Valid: true, Int64: int64(test.Round)}, closedAt)
+	}
+}
+
+func TestDestroyAssetDeleteCreatorsHolding(t *testing.T) {
+	db, connStr, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+
+	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	assert.NoError(t, err)
+
+	cache, err := pdb.GetDefaultFrozen()
+	assert.NoError(t, err)
+
+	assetID := uint64(3)
+
+	state := getAccounting(test.Round, cache)
+
+	// Create an asset.
+	{
+		// Create a transaction where all special addresses are different from creator's address.
+		txn := types.SignedTxnWithAD{
+			SignedTxn: types.SignedTxn{
+				Txn: types.Transaction{
+					Type: "acfg",
+					Header: types.Header{
+						Sender:     test.AccountA,
+					},
+					AssetConfigTxnFields: types.AssetConfigTxnFields{
+						AssetParams: types.AssetParams{
+							Manager:       test.AccountB,
+							Reserve:       test.AccountB,
+							Freeze:        test.AccountB,
+							Clawback:      test.AccountB,
+						},
+					},
+				},
+			},
+		}
+		txnRow := idb.TxnRow{
+			Round:    uint64(test.Round),
+			TxnBytes: msgpack.Encode(txn),
+			AssetID:  assetID,
+		}
+
+		err := state.AddTransaction(&txnRow)
+		assert.NoError(t, err)
+	}
+	// Another account opts in.
+	{
+		_, txnRow := test.MakeAssetTxnOrPanic(test.Round, assetID, 0, test.AccountC,
+			test.AccountC, types.ZeroAddress)
+		state.AddTransaction(txnRow)
+	}
+	// Destroy an asset.
+	{
+		_, txnRow := test.MakeAssetDestroyTxn(test.Round, assetID)
+		state.AddTransaction(txnRow)
+	}
+
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+	assert.NoError(t, err, "failed to commit")
+
+	// Check that the creator's asset holding is deleted.
+	{
+		row := db.QueryRow(
+			"SELECT assetid, deleted, closed_at FROM account_asset WHERE addr = $1",
+			test.AccountA[:])
+
+		var id int64
+		var deleted sql.NullBool
+		var closedAt sql.NullInt64
+		err := row.Scan(&id, &deleted, &closedAt)
+		assert.NoError(t, err)
+
+		assert.Equal(t, assetID, uint64(id))
+		assert.Equal(t, sql.NullBool{Valid: true, Bool: true}, deleted)
+		assert.Equal(t, sql.NullInt64{Valid: true, Int64: int64(test.Round)}, closedAt)
+	}
+
+	// Check that other account's asset holding was not deleted.
+	{
+		row := db.QueryRow(
+			"SELECT assetid, deleted, closed_at FROM account_asset WHERE addr = $1",
+			test.AccountC[:])
+
+		var id int64
+		var deleted sql.NullBool
+		var closedAt sql.NullInt64
+		err := row.Scan(&id, &deleted, &closedAt)
+		assert.NoError(t, err)
+
+		assert.Equal(t, assetID, uint64(id))
+		assert.Equal(t, sql.NullBool{Valid: true, Bool: false}, deleted)
+		assert.False(t, closedAt.Valid)
+	}
+
+	// Check that the manager does not have an asset holding.
+	{
+		row := db.QueryRow("SELECT COUNT(*) FROM account_asset WHERE addr = $1", test.AccountB[:])
+
+		var count int64
+		err := row.Scan(&count)
+		assert.NoError(t, err)
+
+		assert.Equal(t, int64(0), count)
+	}
 }

--- a/util/test/account_testutil.go
+++ b/util/test/account_testutil.go
@@ -98,7 +98,7 @@ func MakeAssetConfigOrPanic(round, configid, assetid, total, decimals uint64, de
 	return &txn, &txnRow
 }
 
-// MakeAssetFreezeOrPanic is a helper to ensure test asset transactions are initialized.
+// MakeAssetFreezeOrPanic create an asset freeze/unfreeze transaction.
 func MakeAssetFreezeOrPanic(round, assetid uint64, frozen bool, addr types.Address) (*types.SignedTxnWithAD, *idb.TxnRow) {
 	txn := types.SignedTxnWithAD{
 		SignedTxn: types.SignedTxn{
@@ -128,7 +128,7 @@ func MakeAssetFreezeOrPanic(round, assetid uint64, frozen bool, addr types.Addre
 	return &txn, &txnRow
 }
 
-// MakeAssetTxnOrPanic is a helper to ensure test asset transactions are initialized.
+// MakeAssetTxnOrPanic creates an asset transfer transaction.
 func MakeAssetTxnOrPanic(round, assetid, amt uint64, sender, receiver, close types.Address) (*types.SignedTxnWithAD, *idb.TxnRow) {
 	txn := types.SignedTxnWithAD{
 		SignedTxn: types.SignedTxn{
@@ -161,7 +161,29 @@ func MakeAssetTxnOrPanic(round, assetid, amt uint64, sender, receiver, close typ
 	return &txn, &txnRow
 }
 
-// MakePayTxnRowOrPanic is a helper to ensure test asset transactions are initialized.
+// MakeAssetDestroyTxn makes a transaction that destroys an asset.
+func MakeAssetDestroyTxn(round uint64, assetID uint64) (*types.SignedTxnWithAD, *idb.TxnRow) {
+	txn := types.SignedTxnWithAD {
+		SignedTxn: types.SignedTxn {
+			Txn: types.Transaction {
+				Type: "acfg",
+				AssetConfigTxnFields: types.AssetConfigTxnFields {
+					ConfigAsset: types.AssetIndex(assetID),
+				},
+			},
+		},
+	}
+
+	txnRow := idb.TxnRow {
+		Round: round,
+		TxnBytes: msgpack.Encode(txn),
+		AssetID: assetID,
+	}
+
+	return &txn, &txnRow
+}
+
+// MakePayTxnRowOrPanic creates an algo transfer transaction.
 func MakePayTxnRowOrPanic(round, fee, amt, closeAmt, sendRewards, receiveRewards,
 	closeRewards uint64, sender, receiver, close, rekeyTo types.Address) (*types.SignedTxnWithAD,
 	*idb.TxnRow) {


### PR DESCRIPTION
## Summary
When an asset is destroyed, creator's asset holding was not deleted if the total supply is 0.

Section 9.2 of the ledger specification says that the total supply is allowed to be 0.

Closes #412.

## Test Plan
Added tests that exploit the bug.