### PR TITLE
Creator holding with Total = 0 is valid.

### DIFF
--- a/accounting/accounting.go
+++ b/accounting/accounting.go
@@ -360,10 +360,10 @@ func (accounting *State) AddTransaction(txnr *idb.TxnRow) (err error) {
 					accounting.defaultFrozen[assetID] = stxn.Txn.AssetParams.DefaultFrozen
 				}
 
-				// Initial creation, give all initial value to creator. Ignore DefaultFrozen.
-				if stxn.Txn.AssetParams.Total != 0 {
-					accounting.updateAsset(stxn.Txn.Sender, assetID, stxn.Txn.AssetParams.Total, 0, false)
-				}
+				// Initial creation, give all initial value to creator.
+				// Ignore DefaultFrozen.
+				// Total = 0 is valid.
+				accounting.updateAsset(stxn.Txn.Sender, assetID, stxn.Txn.AssetParams.Total, 0, false)
 			}
 		}
 	case atypes.AssetTransferTx:

--- a/accounting/accounting_test.go
+++ b/accounting/accounting_test.go
@@ -153,3 +153,28 @@ func TestAssetCloseWithAmountReopenPay(t *testing.T) {
 	// Subround 2 is empty
 	assert.Len(t, state.RoundUpdates.AssetUpdates[1], 0)
 }
+
+// TestCreateAssetWithTotalZero checks that we can create an asset with total = 0
+func TestCreateAssetWithTotalZero(t *testing.T) {
+	assetid := uint64(2222)
+	total := uint64(0)
+
+	///////////
+	// Given // Empty state.
+	///////////
+	state := GetAccounting()
+
+	//////////
+	// When // We add a create asset transaction with total = 0.
+	//////////
+	_, createAsset := test.MakeAssetConfigOrPanic(test.Round, 0, assetid, total, uint64(6), false, "empty-asset", "empty", "http://empty.com", test.AccountA)
+	state.AddTransaction(createAsset)
+
+	//////////
+	// Then // There should be deltas.
+	//////////
+	// Config + Transfer
+	assert.Len(t, state.RoundUpdates.AssetUpdates, 2)
+	assert.True(t, state.RoundUpdates.AssetUpdates[0][test.AccountA][0].Config.IsNew)
+	assert.Equal(t, state.RoundUpdates.AssetUpdates[1][test.AccountA][0].Transfer.Delta.Int64(), int64(0))
+}


### PR DESCRIPTION
## Summary

It is valid to create an asset with Total = 0 and in this case algod will create an asset holding on the creator with Amount = 0. Indexer was skipping the zero balance asset holding, this PR changes that behavior to match algod.

## Test Plan

Added tests.