### PR TITLE
Warn the user during m7 if it might use too much memory.

### DIFF
--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -26,6 +26,7 @@ var (
 	noAlgod          bool
 	developerMode    bool
 	tokenString      string
+	forceM7          bool
 )
 
 var daemonCmd = &cobra.Command{
@@ -46,11 +47,12 @@ var daemonCmd = &cobra.Command{
 		if algodDataDir == "" {
 			algodDataDir = os.Getenv("ALGORAND_DATA")
 		}
-		opts := idb.IndexerDbOptions{}
+		migrationOpts := idb.MigrationOptions{ForceM7: forceM7}
+		opts := idb.IndexerDbOptions{MigrationOptions: migrationOpts}
 		if noAlgod {
 			opts.ReadOnly = true
 		}
-		db := globalIndexerDb(&opts)
+		db := globalIndexerDb(opts)
 
 		ctx, cf := context.WithCancel(context.Background())
 		defer cf()
@@ -154,6 +156,8 @@ func init() {
 	daemonCmd.Flags().BoolVarP(&noAlgod, "no-algod", "", false, "disable connecting to algod for block following")
 	daemonCmd.Flags().StringVarP(&tokenString, "token", "t", "", "an optional auth token, when set REST calls must use this token in a bearer format, or in a 'X-Indexer-API-Token' header")
 	daemonCmd.Flags().BoolVarP(&developerMode, "dev-mode", "", false, "allow performance intensive operations like searching for accounts at a particular round")
+	daemonCmd.Flags().BoolVar(&forceM7, "force-m7", false,
+		"force running migration 7 (rewards and create/close dates)")
 
 	viper.RegisterAlias("algod", "algod-data-dir")
 	viper.RegisterAlias("algod-net", "algod-address")

--- a/cmd/algorand-indexer/import.go
+++ b/cmd/algorand-indexer/import.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/algorand/indexer/config"
+	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/importer"
 )
 
@@ -22,7 +23,7 @@ var importCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		db := globalIndexerDb(nil)
+		db := globalIndexerDb(idb.IndexerDbOptions{})
 
 		cache, err := db.GetDefaultFrozen()
 		if err != nil {

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -84,7 +84,7 @@ var (
 	logger         *log.Logger
 )
 
-func globalIndexerDb(opts *idb.IndexerDbOptions) idb.IndexerDb {
+func globalIndexerDb(opts idb.IndexerDbOptions) idb.IndexerDb {
 	if db == nil {
 		if postgresAddr != "" {
 			var err error

--- a/cmd/e2equeries/main.go
+++ b/cmd/e2equeries/main.go
@@ -42,7 +42,7 @@ func main() {
 	flag.Parse()
 	testutil.SetQuiet(quiet)
 
-	db, err := idb.IndexerDbByName("postgres", pgdb, &idb.IndexerDbOptions{ReadOnly: true}, nil)
+	db, err := idb.IndexerDbByName("postgres", pgdb, idb.IndexerDbOptions{ReadOnly: true}, nil)
 	maybeFail(err, "open postgres, %v", err)
 
 	rekeyTxnQuery := idb.TransactionFilter{RekeyTo: &truev, Limit: 1}

--- a/cmd/idbtest/idbtest.go
+++ b/cmd/idbtest/idbtest.go
@@ -139,7 +139,7 @@ func main() {
 	flag.Parse()
 	testutil.SetQuiet(quiet)
 
-	db, err := idb.IndexerDbByName("postgres", pgdb, nil, nil)
+	db, err := idb.IndexerDbByName("postgres", pgdb, idb.IndexerDbOptions{}, nil)
 	maybeFail(err, "open postgres, %v", err)
 
 	if accounttest {

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -149,7 +149,7 @@ func (db *dummyIndexerDb) Health() (state Health, err error) {
 // IndexerFactory is used to install an IndexerDb implementation.
 type IndexerFactory interface {
 	Name() string
-	Build(arg string, opts *IndexerDbOptions, log *log.Logger) (IndexerDb, error)
+	Build(arg string, opts IndexerDbOptions, log *log.Logger) (IndexerDb, error)
 }
 
 // TxnRow is metadata relating to one transaction in a transaction query.
@@ -424,7 +424,7 @@ func (df dummyFactory) Name() string {
 }
 
 // Build is part of the IndexerFactory interface.
-func (df dummyFactory) Build(arg string, opts *IndexerDbOptions, log *log.Logger) (IndexerDb, error) {
+func (df dummyFactory) Build(arg string, opts IndexerDbOptions, log *log.Logger) (IndexerDb, error) {
 	return &dummyIndexerDb{log: log}, nil
 }
 
@@ -436,9 +436,15 @@ func init() {
 	RegisterFactory("dummy", &dummyFactory{})
 }
 
+// MigrationOptions are the options common to all indexer backends.
+type MigrationOptions struct {
+	ForceM7 bool
+}
+
 // IndexerDbOptions are the options common to all indexer backends.
 type IndexerDbOptions struct {
-	ReadOnly bool
+	ReadOnly         bool
+	MigrationOptions MigrationOptions
 }
 
 // RegisterFactory is used by IndexerDb implementations to register their implementations. This mechanism allows
@@ -449,7 +455,7 @@ func RegisterFactory(name string, factory IndexerFactory) {
 }
 
 // IndexerDbByName is used to construct an IndexerDb object by name.
-func IndexerDbByName(name, arg string, opts *IndexerDbOptions, log *log.Logger) (IndexerDb, error) {
+func IndexerDbByName(name, arg string, opts IndexerDbOptions, log *log.Logger) (IndexerDb, error) {
 	if val, ok := indexerFactories[name]; ok {
 		return val.Build(arg, opts, log)
 	}

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/algorand/go-algorand-sdk/crypto"
-	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
 	"github.com/algorand/go-algorand-sdk/encoding/json"
+	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
 	"github.com/algorand/go-algorand-sdk/types"
 
 	"github.com/algorand/indexer/accounting"
@@ -66,7 +66,7 @@ func TestMaxRoundOnUninitializedDB(t *testing.T) {
 	///////////
 	// Given // A database that has not yet imported the genesis accounts.
 	///////////
-	db, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	db, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	//////////
@@ -91,7 +91,7 @@ func TestMaxRoundEmptyMetastate(t *testing.T) {
 	///////////
 	// Given // The database has the metastate set but the account_round is missing.
 	///////////
-	db, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	db, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 	pg.Exec(`INSERT INTO metastate (k, v) values ('state', '{}')`)
 
@@ -114,7 +114,7 @@ func TestMaxRound(t *testing.T) {
 	///////////
 	// Given // The database has the metastate set normally.
 	///////////
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 	db.Exec(`INSERT INTO metastate (k, v) values ($1, $2)`, "state", "{\"account_round\":123454321}")
 	db.Exec(`INSERT INTO block_header (round, realtime, rewardslevel, header) VALUES ($1, NOW(), 0, '{}') ON CONFLICT DO NOTHING`, 543212345)
@@ -151,7 +151,7 @@ func TestAssetCloseReopenTransfer(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	assetid := uint64(2222)
@@ -201,7 +201,7 @@ func TestDefaultFrozenAndCache(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	assetid := uint64(2222)
@@ -247,7 +247,7 @@ func TestInitializeFrozenCache(t *testing.T) {
 	defer shutdownFunc()
 
 	// Initialize DB by creating one of these things.
-	_, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	_, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	// Add some assets
@@ -255,7 +255,7 @@ func TestInitializeFrozenCache(t *testing.T) {
 	db.Exec(`INSERT INTO asset (index, creator_addr, params) values ($1, $2, $3)`, 2, test.AccountA[:], `{"df":false}`)
 	db.Exec(`INSERT INTO asset (index, creator_addr, params) values ($1, $2, $3)`, 3, test.AccountA[:], `{}`)
 
-	pdb, err := OpenPostgres(connStr, nil, nil)
+	pdb, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 	cache, err := pdb.GetDefaultFrozen()
 	assert.NoError(t, err)
@@ -272,7 +272,7 @@ func TestReCreateAssetHolding(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	assetid := uint64(2222)
@@ -338,7 +338,7 @@ func TestNoopOptins(t *testing.T) {
 	// create asst
 	//db.Exec(`INSERT INTO asset (index, creator_addr, params) values ($1, $2, $3)`, assetid, test.AccountA[:], `{"df":true}`)
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	_, createAsset := test.MakeAssetConfigOrPanic(test.Round, 0, assetid, uint64(1000000), uint64(6), true, "icicles", "frozen coin", "http://antarctica.com", test.AccountD)
@@ -371,7 +371,7 @@ func TestMultipleWriters(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	amt := uint64(10000)
@@ -431,7 +431,7 @@ func TestBlockWithTransactions(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	assetid := uint64(2222)
@@ -481,7 +481,7 @@ func TestRekeyBasic(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	///////////
@@ -516,7 +516,7 @@ func TestRekeyToItself(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	///////////
@@ -565,7 +565,7 @@ func TestRekeyThreeTimesInSameRound(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	///////////
@@ -612,7 +612,7 @@ func TestRekeyToItselfHasNotBeenRekeyed(t *testing.T) {
 	_, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	///////////
@@ -638,7 +638,7 @@ func TestIgnoreDefaultFrozenConfigUpdate(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	assetid := uint64(2222)
@@ -677,7 +677,7 @@ func TestZeroTotalAssetCreate(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	assetid := uint64(2222)
@@ -722,8 +722,8 @@ func assertAssetDates(t *testing.T, db *sql.DB, assetID uint64, deleted sql.Null
 
 func assertAssetHoldingDates(t *testing.T, db *sql.DB, address types.Address, assetID uint64, deleted sql.NullBool, createdAt sql.NullInt64, closedAt sql.NullInt64) {
 	row := db.QueryRow(
-		"SELECT deleted, created_at, closed_at FROM account_asset WHERE " +
-		"addr = $1 AND assetid = $2",
+		"SELECT deleted, created_at, closed_at FROM account_asset WHERE "+
+			"addr = $1 AND assetid = $2",
 		address[:], assetID)
 
 	var retDeleted sql.NullBool
@@ -741,7 +741,7 @@ func TestDestroyAssetBasic(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	cache, err := pdb.GetDefaultFrozen()
@@ -763,13 +763,13 @@ func TestDestroyAssetBasic(t *testing.T) {
 	}
 	// Destroy an asset.
 	{
-		_, txnRow := test.MakeAssetDestroyTxn(test.Round + 1, assetID)
+		_, txnRow := test.MakeAssetDestroyTxn(test.Round+1, assetID)
 
-		state := getAccounting(test.Round + 1, cache)
+		state := getAccounting(test.Round+1, cache)
 		err := state.AddTransaction(txnRow)
 		assert.NoError(t, err)
 
-		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round + 1, &itypes.Block{})
+		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round+1, &itypes.Block{})
 		assert.NoError(t, err, "failed to commit")
 	}
 
@@ -790,7 +790,7 @@ func TestDestroyAssetZeroSupply(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	cache, err := pdb.GetDefaultFrozen()
@@ -837,7 +837,7 @@ func TestDestroyAssetDeleteCreatorsHolding(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, nil, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	cache, err := pdb.GetDefaultFrozen()
@@ -855,14 +855,14 @@ func TestDestroyAssetDeleteCreatorsHolding(t *testing.T) {
 				Txn: types.Transaction{
 					Type: "acfg",
 					Header: types.Header{
-						Sender:     test.AccountA,
+						Sender: test.AccountA,
 					},
 					AssetConfigTxnFields: types.AssetConfigTxnFields{
 						AssetParams: types.AssetParams{
-							Manager:       test.AccountB,
-							Reserve:       test.AccountB,
-							Freeze:        test.AccountB,
-							Clawback:      test.AccountB,
+							Manager:  test.AccountB,
+							Reserve:  test.AccountB,
+							Freeze:   test.AccountB,
+							Clawback: test.AccountB,
 						},
 					},
 				},

--- a/idb/postgres/postgres_test.go
+++ b/idb/postgres/postgres_test.go
@@ -33,7 +33,7 @@ func TestAllMigrations(t *testing.T) {
 			})
 
 			// This automatically runs migrations
-			pdb, err := openPostgres(db, &idb.IndexerDbOptions{
+			pdb, err := openPostgres(db, idb.IndexerDbOptions{
 				ReadOnly: false,
 			}, nil)
 			require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestNoMigrationsNeeded(t *testing.T) {
 	})
 
 	// This automatically runs migraions
-	pdb, err := openPostgres(db, &idb.IndexerDbOptions{
+	pdb, err := openPostgres(db, idb.IndexerDbOptions{
 		ReadOnly: false,
 	}, nil)
 

--- a/util/test/account_testutil.go
+++ b/util/test/account_testutil.go
@@ -163,21 +163,21 @@ func MakeAssetTxnOrPanic(round, assetid, amt uint64, sender, receiver, close typ
 
 // MakeAssetDestroyTxn makes a transaction that destroys an asset.
 func MakeAssetDestroyTxn(round uint64, assetID uint64) (*types.SignedTxnWithAD, *idb.TxnRow) {
-	txn := types.SignedTxnWithAD {
-		SignedTxn: types.SignedTxn {
-			Txn: types.Transaction {
+	txn := types.SignedTxnWithAD{
+		SignedTxn: types.SignedTxn{
+			Txn: types.Transaction{
 				Type: "acfg",
-				AssetConfigTxnFields: types.AssetConfigTxnFields {
+				AssetConfigTxnFields: types.AssetConfigTxnFields{
 					ConfigAsset: types.AssetIndex(assetID),
 				},
 			},
 		},
 	}
 
-	txnRow := idb.TxnRow {
-		Round: round,
+	txnRow := idb.TxnRow{
+		Round:    round,
 		TxnBytes: msgpack.Encode(txn),
-		AssetID: assetID,
+		AssetID:  assetID,
 	}
 
 	return &txn, &txnRow


### PR DESCRIPTION
## Summary
Adds a warning and asks to pass `--force-m7` flag to override it.

## Test Plan
Replaced the if statement to warn unconditionally and ran `make integrate` with and without `--force-m7` to verify the behavior.