### PR TITLE
Fix paging inconsistencies when using amazon aurora

### DIFF
--- a/accounting/rewind.go
+++ b/accounting/rewind.go
@@ -12,15 +12,6 @@ import (
 	"github.com/algorand/indexer/types"
 )
 
-// ConsistencyError is returned when the database returns inconsistent (stale) results.
-type ConsistencyError struct {
-	msg string
-}
-
-func (e ConsistencyError) Error() string {
-	return e.msg
-}
-
 func assetUpdate(account *models.Account, assetid uint64, add, sub uint64) {
 	if account.Assets == nil {
 		account.Assets = new([]models.AssetHolding)
@@ -101,7 +92,7 @@ func AccountAtRound(account models.Account, round uint64, db idb.IndexerDb) (acc
 	}
 	txns, r := db.Transactions(context.Background(), tf)
 	if r < account.Round {
-		err = ConsistencyError{fmt.Sprintf("queried round r: %d < account.Round: %d", r, account.Round)}
+		err = types.MakeConsistencyError(fmt.Sprintf("queried round r: %d < account.Round: %d", r, account.Round))
 		return
 	}
 	txcount := 0
@@ -179,8 +170,8 @@ func AccountAtRound(account models.Account, round uint64, db idb.IndexerDb) (acc
 		tf.Limit = 1
 		txns, r = db.Transactions(context.Background(), tf)
 		if r < round {
-			err = ConsistencyError{
-				fmt.Sprintf("queried round r: %d < requested round round: %d", r, round)}
+			err = types.MakeConsistencyError(
+				fmt.Sprintf("queried round r: %d < requested round round: %d", r, round))
 			return
 		}
 		for txnrow := range txns {

--- a/accounting/rewind_test.go
+++ b/accounting/rewind_test.go
@@ -12,6 +12,7 @@ import (
 	models "github.com/algorand/indexer/api/generated/v2"
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/idb/mocks"
+	"github.com/algorand/indexer/types"
 )
 
 func TestBasic(t *testing.T) {
@@ -73,7 +74,7 @@ func TestStaleTransactions1(t *testing.T) {
 	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(7)).Once()
 
 	account, err := AccountAtRound(account, 6, db)
-	assert.True(t, errors.As(err, &ConsistencyError{}), "err: %v", err)
+	assert.True(t, errors.As(err, &types.ConsistencyError{}), "err: %v", err)
 }
 
 // Test that when idb.Transactions() returns stale data the second time, we return an error.
@@ -111,5 +112,5 @@ func TestStaleTransactions2(t *testing.T) {
 	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(5)).Once()
 
 	account, err := AccountAtRound(account, 6, db)
-	assert.True(t, errors.As(err, &ConsistencyError{}), "err: %v", err)
+	assert.True(t, errors.As(err, &types.ConsistencyError{}), "err: %v", err)
 }

--- a/types/errors.go
+++ b/types/errors.go
@@ -1,0 +1,15 @@
+package types
+
+// ConsistencyError is returned when the database returns inconsistent (stale) results.
+type ConsistencyError struct {
+	msg string
+}
+
+// MakeConsistencyError creates a new consistency error object.
+func MakeConsistencyError(msg string) ConsistencyError {
+	return ConsistencyError{msg}
+}
+
+func (e ConsistencyError) Error() string {
+	return "consistency error: " + e.msg
+}


### PR DESCRIPTION
## Summary
It is possible that the user gets only some transactions for a round because of the limit, but the next `Transactions()` call will not return the rest of the transactions for this round because a follower DB replica returned stale data.

Fixes one item in #461.

## Test Plan
Will add a test.