### PR TITLE
Use sdk_types alias for go-algorand-sdk/types

### DIFF
--- a/accounting/accounting.go
+++ b/accounting/accounting.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 
 	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
-	atypes "github.com/algorand/go-algorand-sdk/types"
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/types"
@@ -46,7 +46,7 @@ func (accounting *State) InitRound(block types.Block) error {
 }
 
 // InitRoundParts are the specific parts from a block needed to initialize accounting. Used for testing, normally you would pass in the block.
-func (accounting *State) InitRoundParts(round uint64, feeSink, rewardsPool atypes.Address, rewardsLevel uint64) error {
+func (accounting *State) InitRoundParts(round uint64, feeSink, rewardsPool sdk_types.Address, rewardsLevel uint64) error {
 	accounting.RoundUpdates.Clear()
 	accounting.feeAddr = feeSink
 	accounting.rewardAddr = rewardsPool
@@ -188,7 +188,7 @@ func (accounting *State) addAssetAccounting(addr types.Address, update idb.Asset
 	}
 }
 
-func (accounting *State) configAsset(assetID uint64, isNew bool, creator types.Address, params atypes.AssetParams) {
+func (accounting *State) configAsset(assetID uint64, isNew bool, creator types.Address, params sdk_types.AssetParams) {
 	update := idb.AssetUpdate{
 		AssetID:       assetID,
 		DefaultFrozen: accounting.defaultFrozen[assetID],
@@ -230,7 +230,7 @@ func (accounting *State) destroyAsset(assetID uint64) {
 }
 
 // TODO: move to go-algorand-sdk as Signature.IsZero()
-func zeroSig(sig atypes.Signature) bool {
+func zeroSig(sig sdk_types.Signature) bool {
 	for _, b := range sig {
 		if b != 0 {
 			return false
@@ -240,7 +240,7 @@ func zeroSig(sig atypes.Signature) bool {
 }
 
 // TODO: move to go-algorand-sdk as LogicSig.Blank()
-func blankLsig(lsig atypes.LogicSig) bool {
+func blankLsig(lsig sdk_types.LogicSig) bool {
 	return len(lsig.Logic) == 0
 }
 
@@ -301,7 +301,7 @@ func (accounting *State) AddTransaction(txnr *idb.TxnRow) (err error) {
 	}
 
 	switch stxn.Txn.Type {
-	case atypes.PaymentTx:
+	case sdk_types.PaymentTx:
 		amount := int64(stxn.Txn.Amount)
 		if amount != 0 {
 			accounting.updateAlgo(stxn.Txn.Sender, -amount)
@@ -322,7 +322,7 @@ func (accounting *State) AddTransaction(txnr *idb.TxnRow) (err error) {
 		if AccountCloseTxn(stxn.Txn.Sender, stxn) {
 			accounting.closeAccount(stxn.Txn.Sender)
 		}
-	case atypes.KeyRegistrationTx:
+	case sdk_types.KeyRegistrationTx:
 		// see https://github.com/algorand/go-algorand/blob/master/data/transactions/keyreg.go
 		accounting.updateAccountData(stxn.Txn.Sender, "vote", stxn.Txn.VotePK)
 		accounting.updateAccountData(stxn.Txn.Sender, "sel", stxn.Txn.SelectionPK)
@@ -341,7 +341,7 @@ func (accounting *State) AddTransaction(txnr *idb.TxnRow) (err error) {
 			accounting.updateAccountData(stxn.Txn.Sender, "voteLst", uint64(stxn.Txn.VoteLast))
 			accounting.updateAccountData(stxn.Txn.Sender, "voteKD", stxn.Txn.VoteKeyDilution)
 		}
-	case atypes.AssetConfigTx:
+	case sdk_types.AssetConfigTx:
 		assetID := uint64(stxn.Txn.ConfigAsset)
 		isNew := AssetCreateTxn(stxn)
 		if isNew {
@@ -366,7 +366,7 @@ func (accounting *State) AddTransaction(txnr *idb.TxnRow) (err error) {
 				accounting.updateAsset(stxn.Txn.Sender, assetID, stxn.Txn.AssetParams.Total, 0, false)
 			}
 		}
-	case atypes.AssetTransferTx:
+	case sdk_types.AssetTransferTx:
 		assetID := uint64(stxn.Txn.XferAsset)
 		defaultFrozen := accounting.defaultFrozen[assetID]
 		sender := stxn.Txn.AssetSender // clawback
@@ -384,10 +384,10 @@ func (accounting *State) AddTransaction(txnr *idb.TxnRow) (err error) {
 		if AssetOptOutTxn(stxn) {
 			accounting.closeAsset(sender, assetID, stxn.Txn.AssetCloseTo, round, intra)
 		}
-	case atypes.AssetFreezeTx:
+	case sdk_types.AssetFreezeTx:
 		accounting.freezeAsset(stxn.Txn.FreezeAccount, uint64(stxn.Txn.FreezeAsset), stxn.Txn.AssetFrozen)
-	case atypes.ApplicationCallTx:
-		hasGlobal := (len(stxn.EvalDelta.GlobalDelta) > 0) || (len(stxn.Txn.ApprovalProgram) > 0) || (len(stxn.Txn.ClearStateProgram) > 0) || stxn.Txn.OnCompletion == atypes.DeleteApplicationOC
+	case sdk_types.ApplicationCallTx:
+		hasGlobal := (len(stxn.EvalDelta.GlobalDelta) > 0) || (len(stxn.Txn.ApprovalProgram) > 0) || (len(stxn.Txn.ClearStateProgram) > 0) || stxn.Txn.OnCompletion == sdk_types.DeleteApplicationOC
 		appid := uint64(stxn.Txn.ApplicationID)
 		if appid == 0 {
 			// creation
@@ -437,7 +437,7 @@ func (accounting *State) AddTransaction(txnr *idb.TxnRow) (err error) {
 			)
 		}
 		// if there's no other content change, but a state change of opt-in/close-out/clear-state, record that
-		if len(stxn.EvalDelta.LocalDeltas) == 0 && (stxn.Txn.OnCompletion == atypes.OptInOC || stxn.Txn.OnCompletion == atypes.CloseOutOC || stxn.Txn.OnCompletion == atypes.ClearStateOC) {
+		if len(stxn.EvalDelta.LocalDeltas) == 0 && (stxn.Txn.OnCompletion == sdk_types.OptInOC || stxn.Txn.OnCompletion == sdk_types.CloseOutOC || stxn.Txn.OnCompletion == sdk_types.ClearStateOC) {
 			accounting.AppLocalDeltas = append(
 				accounting.AppLocalDeltas,
 				idb.AppDelta{

--- a/accounting/accounting_test.go
+++ b/accounting/accounting_test.go
@@ -3,7 +3,7 @@ package accounting
 import (
 	"testing"
 
-	"github.com/algorand/go-algorand-sdk/types"
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/algorand/indexer/idb"
@@ -22,19 +22,19 @@ func assertUpdates(t *testing.T, update *idb.AlgoUpdate, closed bool, balance, r
 	assert.Equal(t, rewards, update.Rewards)
 }
 
-func getSenderAmounts(txn *types.SignedTxnWithAD) (balance, rewards int64) {
+func getSenderAmounts(txn *sdk_types.SignedTxnWithAD) (balance, rewards int64) {
 	balance = -int64(txn.Txn.Amount) + -int64(txn.Txn.Fee) + -int64(txn.ClosingAmount) + int64(txn.SenderRewards)
 	rewards = int64(txn.SenderRewards)
 	return
 }
 
-func getReceiverAmounts(txn *types.SignedTxnWithAD) (balance, rewards int64) {
+func getReceiverAmounts(txn *sdk_types.SignedTxnWithAD) (balance, rewards int64) {
 	balance = int64(txn.Txn.Amount) + int64(txn.ReceiverRewards)
 	rewards = int64(txn.ReceiverRewards)
 	return
 }
 
-func getCloseAmounts(txn *types.SignedTxnWithAD) (balance, rewards int64) {
+func getCloseAmounts(txn *sdk_types.SignedTxnWithAD) (balance, rewards int64) {
 	balance = int64(txn.ClosingAmount) + int64(txn.CloseRewards)
 	rewards = int64(txn.CloseRewards)
 	return
@@ -111,8 +111,8 @@ func TestAssetCloseReopenPay(t *testing.T) {
 	assetid := uint64(22222)
 	amt := uint64(10000)
 	_, closeMain := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountA, test.AccountB, test.AccountB)
-	_, optinMain := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountA, test.AccountA, types.ZeroAddress)
-	_, payMain := test.MakeAssetTxnOrPanic(test.Round, assetid, amt, test.AccountB, test.AccountA, types.ZeroAddress)
+	_, optinMain := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountA, test.AccountA, sdk_types.ZeroAddress)
+	_, payMain := test.MakeAssetTxnOrPanic(test.Round, assetid, amt, test.AccountB, test.AccountA, sdk_types.ZeroAddress)
 
 	state := GetAccounting()
 	state.AddTransaction(closeMain)

--- a/accounting/rewind_test.go
+++ b/accounting/rewind_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
-	"github.com/algorand/go-algorand-sdk/types"
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -15,7 +15,7 @@ import (
 )
 
 func TestBasic(t *testing.T) {
-	var a types.Address
+	var a sdk_types.Address
 	a[0] = 'a'
 
 	account := models.Account{
@@ -25,11 +25,11 @@ func TestBasic(t *testing.T) {
 		Round:                       8,
 	}
 
-	txnBytes := msgpack.Encode(types.SignedTxnWithAD{
-		SignedTxn: types.SignedTxn{
-			Txn: types.Transaction{
-				Type: types.PaymentTx,
-				PaymentTxnFields: types.PaymentTxnFields{
+	txnBytes := msgpack.Encode(sdk_types.SignedTxnWithAD{
+		SignedTxn: sdk_types.SignedTxn{
+			Txn: sdk_types.Transaction{
+				Type: sdk_types.PaymentTx,
+				PaymentTxnFields: sdk_types.PaymentTxnFields{
 					Receiver: a,
 					Amount:   2,
 				},
@@ -58,7 +58,7 @@ func TestBasic(t *testing.T) {
 
 // Test that when idb.Transactions() returns stale data the first time, we return an error.
 func TestStaleTransactions1(t *testing.T) {
-	var a types.Address
+	var a sdk_types.Address
 	a[0] = 'a'
 
 	account := models.Account{
@@ -78,7 +78,7 @@ func TestStaleTransactions1(t *testing.T) {
 
 // Test that when idb.Transactions() returns stale data the second time, we return an error.
 func TestStaleTransactions2(t *testing.T) {
-	var a types.Address
+	var a sdk_types.Address
 	a[0] = 'a'
 
 	account := models.Account{
@@ -88,10 +88,10 @@ func TestStaleTransactions2(t *testing.T) {
 		Round:                       8,
 	}
 
-	txnBytes := msgpack.Encode(types.SignedTxnWithAD{
-		SignedTxn: types.SignedTxn{
-			Txn: types.Transaction{
-				Type: types.PaymentTx,
+	txnBytes := msgpack.Encode(sdk_types.SignedTxnWithAD{
+		SignedTxn: sdk_types.SignedTxn{
+			Txn: sdk_types.Transaction{
+				Type: sdk_types.PaymentTx,
 			},
 		},
 	})

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/algorand/go-algorand-sdk/types"
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 
 	"github.com/algorand/indexer/accounting"
 	"github.com/algorand/indexer/api/generated/common"
@@ -163,7 +163,7 @@ func (si *ServerImplementation) SearchForAccounts(ctx echo.Context, params gener
 	}
 
 	if params.Next != nil {
-		addr, err := types.DecodeAddress(*params.Next)
+		addr, err := sdk_types.DecodeAddress(*params.Next)
 		if err != nil {
 			ctx.JSON(http.StatusBadRequest, errUnableToParseNext)
 		}
@@ -315,7 +315,7 @@ func (si *ServerImplementation) LookupAssetBalances(ctx echo.Context, assetID ui
 	}
 
 	if params.Next != nil {
-		addr, err := types.DecodeAddress(*params.Next)
+		addr, err := sdk_types.DecodeAddress(*params.Next)
 		if err != nil {
 			ctx.JSON(http.StatusBadRequest, errUnableToParseNext)
 		}
@@ -495,7 +495,7 @@ func (si *ServerImplementation) fetchAssets(ctx context.Context, options idb.Ass
 			return nil, round, row.Error
 		}
 
-		creator := types.Address{}
+		creator := sdk_types.Address{}
 		if len(row.Creator) != len(creator) {
 			return nil, round, fmt.Errorf(errInvalidCreatorAddress)
 		}
@@ -540,7 +540,7 @@ func (si *ServerImplementation) fetchAssetBalances(ctx context.Context, options 
 			return nil, round, row.Error
 		}
 
-		addr := types.Address{}
+		addr := sdk_types.Address{}
 		if len(row.Address) != len(addr) {
 			return nil, round, fmt.Errorf(errInvalidCreatorAddress)
 		}

--- a/api/pointer_utils.go
+++ b/api/pointer_utils.go
@@ -3,7 +3,7 @@ package api
 import (
 	"time"
 
-	"github.com/algorand/go-algorand-sdk/types"
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 )
 
 ////////////////////////////////
@@ -66,7 +66,7 @@ func timePtr(x time.Time) *time.Time {
 	return &x
 }
 
-func addrPtr(x types.Address) *string {
+func addrPtr(x sdk_types.Address) *string {
 	if x.IsZero() {
 		return nil
 	}

--- a/cmd/e2equeries/main.go
+++ b/cmd/e2equeries/main.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
-	atypes "github.com/algorand/go-algorand-sdk/types"
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 
 	"github.com/algorand/indexer/idb"
 	_ "github.com/algorand/indexer/idb/postgres"
@@ -49,7 +49,7 @@ func main() {
 	printTxnQuery(db, rekeyTxnQuery)
 
 	rowchan, _ := db.Transactions(context.Background(), rekeyTxnQuery)
-	var rekeyTo atypes.Address
+	var rekeyTo sdk_types.Address
 	for txnrow := range rowchan {
 		maybeFail(txnrow.Error, "err rekey txn %v\n", txnrow.Error)
 		var stxn types.SignedTxnWithAD

--- a/cmd/idbtest/idbtest.go
+++ b/cmd/idbtest/idbtest.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	ajson "github.com/algorand/go-algorand-sdk/encoding/json"
-	atypes "github.com/algorand/go-algorand-sdk/types"
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 
 	"github.com/algorand/indexer/accounting"
 	models "github.com/algorand/indexer/api/generated/v2"
@@ -43,7 +43,7 @@ func doAssetQueryTests(db idb.IndexerDb) {
 	printAssetQuery(db, idb.AssetsQuery{Unit: "USDt", Limit: 2})
 	printAssetQuery(db, idb.AssetsQuery{AssetID: 312769, Limit: 1})
 	printAssetQuery(db, idb.AssetsQuery{AssetIDGreaterThan: 312769, Query: "us", Limit: 2})
-	tcreator, err := atypes.DecodeAddress("XIU7HGGAJ3QOTATPDSIIHPFVKMICXKHMOR2FJKHTVLII4FAOA3CYZQDLG4")
+	tcreator, err := sdk_types.DecodeAddress("XIU7HGGAJ3QOTATPDSIIHPFVKMICXKHMOR2FJKHTVLII4FAOA3CYZQDLG4")
 	maybeFail(err, "addr decode, %v\n", err)
 	printAssetQuery(db, idb.AssetsQuery{Creator: tcreator[:], Limit: 1})
 }
@@ -152,7 +152,7 @@ func main() {
 
 	if false {
 		// account rewind debug
-		xa, _ := atypes.DecodeAddress("QRP4AJLQXHJ42VJ5PSGAH53IVVACYCI6ZDRJMF4JPRFY5VKSYKFWKKMFVU")
+		xa, _ := sdk_types.DecodeAddress("QRP4AJLQXHJ42VJ5PSGAH53IVVACYCI6ZDRJMF4JPRFY5VKSYKFWKKMFVU")
 		account, err := getAccount(db, xa[:])
 		fmt.Printf("account %s\n", string(ajson.Encode(account)))
 		maybeFail(err, "addr lookup, %v", err)
@@ -170,7 +170,7 @@ func main() {
 
 	if txntest {
 		// txn query tests
-		xa, _ := atypes.DecodeAddress("QRP4AJLQXHJ42VJ5PSGAH53IVVACYCI6ZDRJMF4JPRFY5VKSYKFWKKMFVU")
+		xa, _ := sdk_types.DecodeAddress("QRP4AJLQXHJ42VJ5PSGAH53IVVACYCI6ZDRJMF4JPRFY5VKSYKFWKKMFVU")
 		printTxnQuery(db, idb.TransactionFilter{Limit: 2})
 		printTxnQuery(db, idb.TransactionFilter{MinRound: 5000000, Limit: 2})
 		printTxnQuery(db, idb.TransactionFilter{MaxRound: 100000, Limit: 2})
@@ -195,7 +195,7 @@ func main() {
 	//printAssetBalanceQuery(db, 312769)
 
 	if pagingtest {
-		xa, _ := atypes.DecodeAddress("QRP4AJLQXHJ42VJ5PSGAH53IVVACYCI6ZDRJMF4JPRFY5VKSYKFWKKMFVU")
+		xa, _ := sdk_types.DecodeAddress("QRP4AJLQXHJ42VJ5PSGAH53IVVACYCI6ZDRJMF4JPRFY5VKSYKFWKKMFVU")
 		testTxnPaging(db, idb.TransactionFilter{Address: xa[:]})
 		testTxnPaging(db, idb.TransactionFilter{TypeEnum: 2})
 		testTxnPaging(db, idb.TransactionFilter{AlgosGT: 1})

--- a/cmd/validator/validate_accounting.go
+++ b/cmd/validator/validate_accounting.go
@@ -15,7 +15,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/algorand/go-algorand-sdk/types"
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 )
 
 // Params are the program arguments which need to be passed between objects.
@@ -152,14 +152,14 @@ func start(processor Processor, threads int, config Params, results chan<- Resul
 
 // normalizeAddress accepts an algorand address or base64 encoded address and outputs the algorand address
 func normalizeAddress(addr string) (string, error) {
-	_, err := types.DecodeAddress(addr)
+	_, err := sdk_types.DecodeAddress(addr)
 	if err == nil {
 		return addr, nil
 	}
 
 	addrBytes, err := base64.StdEncoding.DecodeString(addr)
 	if err == nil {
-		var address types.Address
+		var address sdk_types.Address
 		copy(address[:], addrBytes)
 		return address.String(), nil
 	}

--- a/idb/dummy.go
+++ b/idb/dummy.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	atypes "github.com/algorand/go-algorand-sdk/types"
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 	log "github.com/sirupsen/logrus"
 
 	models "github.com/algorand/indexer/api/generated/v2"
@@ -581,13 +581,13 @@ type AppDelta struct {
 	AddrIndex    uint64 // 0=Sender, otherwise stxn.Txn.Accounts[i-1]
 	Creator      []byte
 	Delta        types.StateDelta
-	OnCompletion atypes.OnCompletion
+	OnCompletion sdk_types.OnCompletion
 
 	// AppParams settings coppied from Txn, only for AppGlobalDeltas
-	ApprovalProgram   []byte             `codec:"approv"`
-	ClearStateProgram []byte             `codec:"clearp"`
-	LocalStateSchema  atypes.StateSchema `codec:"lsch"`
-	GlobalStateSchema atypes.StateSchema `codec:"gsch"`
+	ApprovalProgram   []byte                `codec:"approv"`
+	ClearStateProgram []byte                `codec:"clearp"`
+	LocalStateSchema  sdk_types.StateSchema `codec:"lsch"`
+	GlobalStateSchema sdk_types.StateSchema `codec:"gsch"`
 }
 
 // String is part of the Stringer interface.
@@ -629,12 +629,12 @@ type StateDelta struct {
 
 // AppReverseDelta extra data attached to transactions relating to applications
 type AppReverseDelta struct {
-	Delta             []StateDelta        `codec:"d,omitempty"`
-	OnCompletion      atypes.OnCompletion `codec:"oc,omitempty"`
-	ApprovalProgram   []byte              `codec:"approv,omitempty"`
-	ClearStateProgram []byte              `codec:"clearp,omitempty"`
-	LocalStateSchema  atypes.StateSchema  `codec:"lsch,omitempty"`
-	GlobalStateSchema atypes.StateSchema  `codec:"gsch,omitempty"`
+	Delta             []StateDelta           `codec:"d,omitempty"`
+	OnCompletion      sdk_types.OnCompletion `codec:"oc,omitempty"`
+	ApprovalProgram   []byte                 `codec:"approv,omitempty"`
+	ClearStateProgram []byte                 `codec:"clearp,omitempty"`
+	LocalStateSchema  sdk_types.StateSchema  `codec:"lsch,omitempty"`
+	GlobalStateSchema sdk_types.StateSchema  `codec:"gsch,omitempty"`
 }
 
 // SetDelta adds delta values to the AppReverseDelta object.

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/algorand/go-algorand-sdk/crypto"
 	"github.com/algorand/go-algorand-sdk/encoding/json"
 	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
-	"github.com/algorand/go-algorand-sdk/types"
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 
 	"github.com/algorand/indexer/accounting"
 	"github.com/algorand/indexer/idb"
-	itypes "github.com/algorand/indexer/types"
+	"github.com/algorand/indexer/types"
 	"github.com/algorand/indexer/util/test"
 )
 
@@ -135,7 +135,7 @@ func TestMaxRound(t *testing.T) {
 	assert.Equal(t, uint64(543212345), roundL)
 }
 
-func assertAccountAsset(t *testing.T, db *sql.DB, addr types.Address, assetid uint64, frozen bool, amount uint64) {
+func assertAccountAsset(t *testing.T, db *sql.DB, addr sdk_types.Address, assetid uint64, frozen bool, amount uint64) {
 	var row *sql.Row
 	var f bool
 	var a uint64
@@ -163,10 +163,10 @@ func TestAssetCloseReopenTransfer(t *testing.T) {
 	// Given // A round scenario requiring subround accounting: AccountA is funded, closed, opts back, and funded again.
 	///////////
 	_, createAsset := test.MakeAssetConfigOrPanic(test.Round, 0, assetid, total, uint64(6), false, "icicles", "frozen coin", "http://antarctica.com", test.AccountD)
-	_, fundMain := test.MakeAssetTxnOrPanic(test.Round, assetid, amt, test.AccountD, test.AccountA, types.ZeroAddress)
+	_, fundMain := test.MakeAssetTxnOrPanic(test.Round, assetid, amt, test.AccountD, test.AccountA, sdk_types.ZeroAddress)
 	_, closeMain := test.MakeAssetTxnOrPanic(test.Round, assetid, 1000, test.AccountA, test.AccountB, test.AccountC)
-	_, optinMain := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountA, test.AccountA, types.ZeroAddress)
-	_, payMain := test.MakeAssetTxnOrPanic(test.Round, assetid, amt, test.AccountD, test.AccountA, types.ZeroAddress)
+	_, optinMain := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountA, test.AccountA, sdk_types.ZeroAddress)
+	_, payMain := test.MakeAssetTxnOrPanic(test.Round, assetid, amt, test.AccountD, test.AccountA, sdk_types.ZeroAddress)
 
 	cache, err := pdb.GetDefaultFrozen()
 	assert.NoError(t, err)
@@ -180,7 +180,7 @@ func TestAssetCloseReopenTransfer(t *testing.T) {
 	//////////
 	// When // We commit the round accounting to the database.
 	//////////
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
 	assert.NoError(t, err, "failed to commit")
 
 	//////////
@@ -213,8 +213,8 @@ func TestDefaultFrozenAndCache(t *testing.T) {
 	///////////
 	_, createAssetFrozen := test.MakeAssetConfigOrPanic(test.Round, 0, assetid, total, uint64(6), true, "icicles", "frozen coin", "http://antarctica.com", test.AccountA)
 	_, createAssetNotFrozen := test.MakeAssetConfigOrPanic(test.Round, 0, assetid+1, total, uint64(6), false, "icicles", "frozen coin", "http://antarctica.com", test.AccountA)
-	_, optinB1 := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountB, test.AccountB, types.ZeroAddress)
-	_, optinB2 := test.MakeAssetTxnOrPanic(test.Round, assetid+1, 0, test.AccountB, test.AccountB, types.ZeroAddress)
+	_, optinB1 := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountB, test.AccountB, sdk_types.ZeroAddress)
+	_, optinB2 := test.MakeAssetTxnOrPanic(test.Round, assetid+1, 0, test.AccountB, test.AccountB, sdk_types.ZeroAddress)
 
 	cache, err := pdb.GetDefaultFrozen()
 	assert.NoError(t, err)
@@ -227,7 +227,7 @@ func TestDefaultFrozenAndCache(t *testing.T) {
 	//////////
 	// When // We commit the round accounting to the database.
 	//////////
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
 	assert.NoError(t, err, "failed to commit")
 
 	//////////
@@ -300,7 +300,7 @@ func TestReCreateAssetHolding(t *testing.T) {
 		// Given // A new asset with default-frozen, AccountB opts-in and has its frozen state toggled.
 		/////////// Then AccountB opts-out then opts-in again.
 		_, createAssetFrozen := test.MakeAssetConfigOrPanic(round, 0, aid, total, uint64(6), testcase.frozen, "icicles", "frozen coin", "http://antarctica.com", test.AccountA)
-		_, optinB := test.MakeAssetTxnOrPanic(round, aid, 0, test.AccountB, test.AccountB, types.ZeroAddress)
+		_, optinB := test.MakeAssetTxnOrPanic(round, aid, 0, test.AccountB, test.AccountB, sdk_types.ZeroAddress)
 		_, unfreezeB := test.MakeAssetFreezeOrPanic(round, aid, !testcase.frozen, test.AccountB)
 		_, optoutB := test.MakeAssetTxnOrPanic(round, aid, 0, test.AccountB, test.AccountC, test.AccountD)
 
@@ -316,7 +316,7 @@ func TestReCreateAssetHolding(t *testing.T) {
 		//////////
 		// When // We commit the round accounting to the database.
 		//////////
-		err = pdb.CommitRoundAccounting(state.RoundUpdates, round, &itypes.Block{})
+		err = pdb.CommitRoundAccounting(state.RoundUpdates, round, &types.Block{})
 		assert.NoError(t, err, "failed to commit")
 
 		//////////
@@ -343,7 +343,7 @@ func TestNoopOptins(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, createAsset := test.MakeAssetConfigOrPanic(test.Round, 0, assetid, uint64(1000000), uint64(6), true, "icicles", "frozen coin", "http://antarctica.com", test.AccountD)
-	_, optinB := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountB, test.AccountB, types.ZeroAddress)
+	_, optinB := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountB, test.AccountB, sdk_types.ZeroAddress)
 	_, unfreezeB := test.MakeAssetFreezeOrPanic(test.Round, assetid, false, test.AccountB)
 
 	cache, err := pdb.GetDefaultFrozen()
@@ -357,7 +357,7 @@ func TestNoopOptins(t *testing.T) {
 	//////////
 	// When // We commit the round accounting to the database.
 	//////////
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
 	assert.NoError(t, err, "failed to commit")
 
 	//////////
@@ -381,7 +381,7 @@ func TestMultipleWriters(t *testing.T) {
 	// Given // Send amt to AccountA
 	///////////
 	_, payAccountA := test.MakePayTxnRowOrPanic(test.Round, 1000, amt, 0, 0, 0, 0, test.AccountD,
-		test.AccountA, types.ZeroAddress, types.ZeroAddress)
+		test.AccountA, sdk_types.ZeroAddress, sdk_types.ZeroAddress)
 
 	cache, err := pdb.GetDefaultFrozen()
 	assert.NoError(t, err)
@@ -400,7 +400,7 @@ func TestMultipleWriters(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			errors <- pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+			errors <- pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
 		}()
 	}
 	close(start)
@@ -445,11 +445,11 @@ func TestBlockWithTransactions(t *testing.T) {
 	// Given // A block at round test.Round with 5 transactions.
 	///////////
 	tx1, row1 := test.MakeAssetConfigOrPanic(test.Round, 0, assetid, total, uint64(6), false, "icicles", "frozen coin", "http://antarctica.com", test.AccountD)
-	tx2, row2 := test.MakeAssetTxnOrPanic(test.Round, assetid, amt, test.AccountD, test.AccountA, types.ZeroAddress)
+	tx2, row2 := test.MakeAssetTxnOrPanic(test.Round, assetid, amt, test.AccountD, test.AccountA, sdk_types.ZeroAddress)
 	tx3, row3 := test.MakeAssetTxnOrPanic(test.Round, assetid, 1000, test.AccountA, test.AccountB, test.AccountC)
-	tx4, row4 := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountA, test.AccountA, types.ZeroAddress)
-	tx5, row5 := test.MakeAssetTxnOrPanic(test.Round, assetid, amt, test.AccountD, test.AccountA, types.ZeroAddress)
-	txns := []*types.SignedTxnWithAD{tx1, tx2, tx3, tx4, tx5}
+	tx4, row4 := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountA, test.AccountA, sdk_types.ZeroAddress)
+	tx5, row5 := test.MakeAssetTxnOrPanic(test.Round, assetid, amt, test.AccountD, test.AccountA, sdk_types.ZeroAddress)
+	txns := []*sdk_types.SignedTxnWithAD{tx1, tx2, tx3, tx4, tx5}
 	txnRows := []*idb.TxnRow{row1, row2, row3, row4, row5}
 
 	_, err = db.Exec(`INSERT INTO metastate (k, v) values ($1, $2)`, "state", `{"account_round": 11}`)
@@ -496,14 +496,14 @@ func TestRekeyBasic(t *testing.T) {
 	// Given // Send rekey transaction
 	///////////
 	_, txnRow := test.MakePayTxnRowOrPanic(test.Round, 1000, 0, 0, 0, 0, 0, test.AccountA,
-		test.AccountA, types.ZeroAddress, test.AccountB)
+		test.AccountA, sdk_types.ZeroAddress, test.AccountB)
 
 	cache, err := pdb.GetDefaultFrozen()
 	assert.NoError(t, err)
 	state := getAccounting(test.Round, cache)
 	state.AddTransaction(txnRow)
 
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
 	assert.NoError(t, err, "failed to commit")
 
 	//////////
@@ -514,7 +514,7 @@ func TestRekeyBasic(t *testing.T) {
 	err = row.Scan(&accountDataStr)
 	assert.NoError(t, err, "querying account data")
 
-	var ad itypes.AccountData
+	var ad types.AccountData
 	err = json.Decode(accountDataStr, &ad)
 	assert.NoError(t, err, "failed to parse account data json")
 	assert.Equal(t, test.AccountB, ad.SpendingKey)
@@ -532,26 +532,26 @@ func TestRekeyToItself(t *testing.T) {
 	///////////
 	{
 		_, txnRow := test.MakePayTxnRowOrPanic(test.Round, 1000, 0, 0, 0, 0, 0, test.AccountA,
-			test.AccountA, types.ZeroAddress, test.AccountB)
+			test.AccountA, sdk_types.ZeroAddress, test.AccountB)
 
 		cache, err := pdb.GetDefaultFrozen()
 		assert.NoError(t, err)
 		state := getAccounting(test.Round, cache)
 		state.AddTransaction(txnRow)
 
-		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
 		assert.NoError(t, err, "failed to commit")
 	}
 	{
 		_, txnRow := test.MakePayTxnRowOrPanic(test.Round+1, 1000, 0, 0, 0, 0, 0, test.AccountA,
-			test.AccountA, types.ZeroAddress, test.AccountA)
+			test.AccountA, sdk_types.ZeroAddress, test.AccountA)
 
 		cache, err := pdb.GetDefaultFrozen()
 		assert.NoError(t, err)
 		state := getAccounting(test.Round+1, cache)
 		state.AddTransaction(txnRow)
 
-		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round+1, &itypes.Block{})
+		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round+1, &types.Block{})
 		assert.NoError(t, err, "failed to commit")
 	}
 
@@ -563,10 +563,10 @@ func TestRekeyToItself(t *testing.T) {
 	err = row.Scan(&accountDataStr)
 	assert.NoError(t, err, "querying account data")
 
-	var ad itypes.AccountData
+	var ad types.AccountData
 	err = json.Decode(accountDataStr, &ad)
 	assert.NoError(t, err, "failed to parse account data json")
-	assert.Equal(t, types.ZeroAddress, ad.SpendingKey)
+	assert.Equal(t, sdk_types.ZeroAddress, ad.SpendingKey)
 }
 
 func TestRekeyThreeTimesInSameRound(t *testing.T) {
@@ -585,21 +585,21 @@ func TestRekeyThreeTimesInSameRound(t *testing.T) {
 
 	{
 		_, txnRow := test.MakePayTxnRowOrPanic(test.Round, 1000, 0, 0, 0, 0, 0, test.AccountA,
-			test.AccountA, types.ZeroAddress, test.AccountB)
+			test.AccountA, sdk_types.ZeroAddress, test.AccountB)
 		state.AddTransaction(txnRow)
 	}
 	{
 		_, txnRow := test.MakePayTxnRowOrPanic(test.Round, 1000, 0, 0, 0, 0, 0, test.AccountA,
-			test.AccountA, types.ZeroAddress, types.ZeroAddress)
+			test.AccountA, sdk_types.ZeroAddress, sdk_types.ZeroAddress)
 		state.AddTransaction(txnRow)
 	}
 	{
 		_, txnRow := test.MakePayTxnRowOrPanic(test.Round, 1000, 0, 0, 0, 0, 0, test.AccountA,
-			test.AccountA, types.ZeroAddress, test.AccountC)
+			test.AccountA, sdk_types.ZeroAddress, test.AccountC)
 		state.AddTransaction(txnRow)
 	}
 
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
 	assert.NoError(t, err, "failed to commit")
 
 	//////////
@@ -610,7 +610,7 @@ func TestRekeyThreeTimesInSameRound(t *testing.T) {
 	err = row.Scan(&accountDataStr)
 	assert.NoError(t, err, "querying account data")
 
-	var ad itypes.AccountData
+	var ad types.AccountData
 	err = json.Decode(accountDataStr, &ad)
 	assert.NoError(t, err, "failed to parse account data json")
 	assert.Equal(t, test.AccountC, ad.SpendingKey)
@@ -627,7 +627,7 @@ func TestRekeyToItselfHasNotBeenRekeyed(t *testing.T) {
 	// Given // Send rekey transaction
 	///////////
 	_, txnRow := test.MakePayTxnRowOrPanic(test.Round, 1000, 0, 0, 0, 0, 0, test.AccountA,
-		test.AccountA, types.ZeroAddress, types.ZeroAddress)
+		test.AccountA, sdk_types.ZeroAddress, sdk_types.ZeroAddress)
 
 	cache, err := pdb.GetDefaultFrozen()
 	assert.NoError(t, err)
@@ -637,7 +637,7 @@ func TestRekeyToItselfHasNotBeenRekeyed(t *testing.T) {
 	//////////
 	// Then // No error when committing to the DB.
 	//////////
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
 	assert.NoError(t, err, "failed to commit")
 }
 
@@ -657,7 +657,7 @@ func TestIgnoreDefaultFrozenConfigUpdate(t *testing.T) {
 	///////////
 	_, createAssetNotFrozen := test.MakeAssetConfigOrPanic(test.Round, 0, assetid, total, uint64(6), false, "icicles", "frozen coin", "http://antarctica.com", test.AccountA)
 	_, modifyAssetToFrozen := test.MakeAssetConfigOrPanic(test.Round, assetid, assetid, total, uint64(6), true, "icicles", "frozen coin", "http://antarctica.com", test.AccountA)
-	_, optin := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountB, test.AccountB, types.ZeroAddress)
+	_, optin := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountB, test.AccountB, sdk_types.ZeroAddress)
 
 	cache, err := pdb.GetDefaultFrozen()
 	assert.NoError(t, err)
@@ -669,7 +669,7 @@ func TestIgnoreDefaultFrozenConfigUpdate(t *testing.T) {
 	//////////
 	// When // We commit the round accounting to the database.
 	//////////
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
 	assert.NoError(t, err, "failed to commit")
 
 	//////////
@@ -704,7 +704,7 @@ func TestZeroTotalAssetCreate(t *testing.T) {
 	//////////
 	// When // We commit the round accounting to the database.
 	//////////
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
 	assert.NoError(t, err, "failed to commit")
 
 	//////////
@@ -728,7 +728,7 @@ func assertAssetDates(t *testing.T, db *sql.DB, assetID uint64, deleted sql.Null
 	assert.Equal(t, closedAt, retClosedAt)
 }
 
-func assertAssetHoldingDates(t *testing.T, db *sql.DB, address types.Address, assetID uint64, deleted sql.NullBool, createdAt sql.NullInt64, closedAt sql.NullInt64) {
+func assertAssetHoldingDates(t *testing.T, db *sql.DB, address sdk_types.Address, assetID uint64, deleted sql.NullBool, createdAt sql.NullInt64, closedAt sql.NullInt64) {
 	row := db.QueryRow(
 		"SELECT deleted, created_at, closed_at FROM account_asset WHERE "+
 			"addr = $1 AND assetid = $2",
@@ -766,7 +766,7 @@ func TestDestroyAssetBasic(t *testing.T) {
 		err := state.AddTransaction(txnRow)
 		assert.NoError(t, err)
 
-		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
 		assert.NoError(t, err, "failed to commit")
 	}
 	// Destroy an asset.
@@ -777,7 +777,7 @@ func TestDestroyAssetBasic(t *testing.T) {
 		err := state.AddTransaction(txnRow)
 		assert.NoError(t, err)
 
-		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round+1, &itypes.Block{})
+		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round+1, &types.Block{})
 		assert.NoError(t, err, "failed to commit")
 	}
 
@@ -825,7 +825,7 @@ func TestDestroyAssetZeroSupply(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
 	assert.NoError(t, err, "failed to commit")
 
 	// Check that the asset is deleted.
@@ -858,15 +858,15 @@ func TestDestroyAssetDeleteCreatorsHolding(t *testing.T) {
 	// Create an asset.
 	{
 		// Create a transaction where all special addresses are different from creator's address.
-		txn := types.SignedTxnWithAD{
-			SignedTxn: types.SignedTxn{
-				Txn: types.Transaction{
+		txn := sdk_types.SignedTxnWithAD{
+			SignedTxn: sdk_types.SignedTxn{
+				Txn: sdk_types.Transaction{
 					Type: "acfg",
-					Header: types.Header{
+					Header: sdk_types.Header{
 						Sender: test.AccountA,
 					},
-					AssetConfigTxnFields: types.AssetConfigTxnFields{
-						AssetParams: types.AssetParams{
+					AssetConfigTxnFields: sdk_types.AssetConfigTxnFields{
+						AssetParams: sdk_types.AssetParams{
 							Manager:  test.AccountB,
 							Reserve:  test.AccountB,
 							Freeze:   test.AccountB,
@@ -888,7 +888,7 @@ func TestDestroyAssetDeleteCreatorsHolding(t *testing.T) {
 	// Another account opts in.
 	{
 		_, txnRow := test.MakeAssetTxnOrPanic(test.Round, assetID, 0, test.AccountC,
-			test.AccountC, types.ZeroAddress)
+			test.AccountC, sdk_types.ZeroAddress)
 		state.AddTransaction(txnRow)
 	}
 	// Destroy an asset.
@@ -897,7 +897,7 @@ func TestDestroyAssetDeleteCreatorsHolding(t *testing.T) {
 		state.AddTransaction(txnRow)
 	}
 
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &itypes.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
 	assert.NoError(t, err, "failed to commit")
 
 	// Check that the creator's asset holding is deleted.

--- a/misc/convertToAddress.go
+++ b/misc/convertToAddress.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/algorand/go-algorand-sdk/types"
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 )
 
 func main() {
@@ -16,7 +16,7 @@ func main() {
 	addrBytes, err := base64.StdEncoding.DecodeString(addrInput)
 	if err != nil {
 		// Failed to base64 decode, try algorand.
-		a, err := types.DecodeAddress(addrInput)
+		a, err := sdk_types.DecodeAddress(addrInput)
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -24,7 +24,7 @@ func main() {
 		fmt.Println(base64.StdEncoding.EncodeToString(a[:]))
 		return
 	}
-	var addr types.Address
+	var addr sdk_types.Address
 	copy(addr[:], addrBytes)
 	fmt.Println(addr.String())
 }

--- a/types/types.go
+++ b/types/types.go
@@ -4,14 +4,14 @@ package types
 import (
 	"time"
 
-	atypes "github.com/algorand/go-algorand-sdk/types"
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 )
 
 type (
 	// Address alias to SDK address.
-	Address = atypes.Address // [32]byte
+	Address = sdk_types.Address // [32]byte
 	// Digest is a hash value.
-	Digest = atypes.Digest // [32]byte
+	Digest = sdk_types.Digest // [32]byte
 
 	// Seed used by sortition.
 	Seed [32]byte
@@ -230,7 +230,7 @@ type (
 	SignedTxnWithAD struct {
 		_struct struct{} `codec:",omitempty,omitemptyarray"`
 
-		atypes.SignedTxn
+		sdk_types.SignedTxn
 		ApplyData
 	}
 
@@ -283,9 +283,9 @@ type (
 	DeltaAction uint64
 
 	// Transaction alias for the SDK transaction
-	Transaction = atypes.Transaction
+	Transaction = sdk_types.Transaction
 	// AssetParams alias for the SDK asset params
-	AssetParams = atypes.AssetParams
+	AssetParams = sdk_types.AssetParams
 
 	// EncodedBlockCert is the block encoded along with its certificate.
 	EncodedBlockCert struct {
@@ -875,13 +875,13 @@ const (
 )
 
 // MergeAssetConfig merges together two asset param objects.
-func MergeAssetConfig(old, new atypes.AssetParams) (out atypes.AssetParams) {
+func MergeAssetConfig(old, new sdk_types.AssetParams) (out sdk_types.AssetParams) {
 	// if asset is new, set.
 	// if new config is empty, set empty.
 	// else, update.
-	if old == (atypes.AssetParams{}) {
+	if old == (sdk_types.AssetParams{}) {
 		out = new
-	} else if new == (atypes.AssetParams{}) {
+	} else if new == (sdk_types.AssetParams{}) {
 		out = new
 	} else {
 		out = old

--- a/util/test/account_testutil.go
+++ b/util/test/account_testutil.go
@@ -3,7 +3,7 @@ package test
 import (
 	"fmt"
 	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
-	"github.com/algorand/go-algorand-sdk/types"
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 
 	"github.com/algorand/indexer/idb"
 )
@@ -26,31 +26,31 @@ var (
 	RewardAddr = DecodeAddressOrPanic("4C3S3A5II6AYMEADSW7EVL7JAKVU2ASJMMJAGVUROIJHYMS6B24NCXVEWM")
 
 	// OpenMainStxn is a premade signed transaction which may be useful in tests.
-	OpenMainStxn *types.SignedTxnWithAD
+	OpenMainStxn *sdk_types.SignedTxnWithAD
 	// OpenMain is a premade TxnRow which may be useful in tests.
 	OpenMain *idb.TxnRow
 
 	// CloseMainToBCStxn is a premade signed transaction which may be useful in tests.
-	CloseMainToBCStxn *types.SignedTxnWithAD
+	CloseMainToBCStxn *sdk_types.SignedTxnWithAD
 	// CloseMainToBC is a premade TxnRow which may be useful in tests.
 	CloseMainToBC *idb.TxnRow
 )
 
 func init() {
 	OpenMainStxn, OpenMain = MakePayTxnRowOrPanic(Round, 1000, 10234, 0, 111, 1111, 0, AccountC,
-		AccountA, types.ZeroAddress, types.ZeroAddress)
+		AccountA, sdk_types.ZeroAddress, sdk_types.ZeroAddress)
 	// CloseMainToBCStxn and CloseMainToBC are premade transactions which may be useful in tests.
 	CloseMainToBCStxn, CloseMainToBC = MakePayTxnRowOrPanic(Round, 1000, 1234, 9111, 0, 111, 111,
-		AccountA, AccountC, AccountB, types.ZeroAddress)
+		AccountA, AccountC, AccountB, sdk_types.ZeroAddress)
 }
 
 // DecodeAddressOrPanic is a helper to ensure addresses are initialized.
-func DecodeAddressOrPanic(addr string) types.Address {
+func DecodeAddressOrPanic(addr string) sdk_types.Address {
 	if addr == "" {
-		return types.ZeroAddress
+		return sdk_types.ZeroAddress
 	}
 
-	result, err := types.DecodeAddress(addr)
+	result, err := sdk_types.DecodeAddress(addr)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to decode address: '%s'", addr))
 	}
@@ -58,20 +58,20 @@ func DecodeAddressOrPanic(addr string) types.Address {
 }
 
 // MakeAssetConfigOrPanic is a helper to ensure test asset config are initialized.
-func MakeAssetConfigOrPanic(round, configid, assetid, total, decimals uint64, defaultFrozen bool, unitName, assetName, url string, addr types.Address) (*types.SignedTxnWithAD, *idb.TxnRow) {
-	txn := types.SignedTxnWithAD{
-		SignedTxn: types.SignedTxn{
-			Txn: types.Transaction{
+func MakeAssetConfigOrPanic(round, configid, assetid, total, decimals uint64, defaultFrozen bool, unitName, assetName, url string, addr sdk_types.Address) (*sdk_types.SignedTxnWithAD, *idb.TxnRow) {
+	txn := sdk_types.SignedTxnWithAD{
+		SignedTxn: sdk_types.SignedTxn{
+			Txn: sdk_types.Transaction{
 				Type: "acfg",
-				Header: types.Header{
+				Header: sdk_types.Header{
 					Sender:     addr,
-					Fee:        types.MicroAlgos(1000),
-					FirstValid: types.Round(round),
-					LastValid:  types.Round(round),
+					Fee:        sdk_types.MicroAlgos(1000),
+					FirstValid: sdk_types.Round(round),
+					LastValid:  sdk_types.Round(round),
 				},
-				AssetConfigTxnFields: types.AssetConfigTxnFields{
-					ConfigAsset: types.AssetIndex(configid),
-					AssetParams: types.AssetParams{
+				AssetConfigTxnFields: sdk_types.AssetConfigTxnFields{
+					ConfigAsset: sdk_types.AssetIndex(configid),
+					AssetParams: sdk_types.AssetParams{
 						Total:         total,
 						Decimals:      uint32(decimals),
 						DefaultFrozen: defaultFrozen,
@@ -99,20 +99,20 @@ func MakeAssetConfigOrPanic(round, configid, assetid, total, decimals uint64, de
 }
 
 // MakeAssetFreezeOrPanic create an asset freeze/unfreeze transaction.
-func MakeAssetFreezeOrPanic(round, assetid uint64, frozen bool, addr types.Address) (*types.SignedTxnWithAD, *idb.TxnRow) {
-	txn := types.SignedTxnWithAD{
-		SignedTxn: types.SignedTxn{
-			Txn: types.Transaction{
+func MakeAssetFreezeOrPanic(round, assetid uint64, frozen bool, addr sdk_types.Address) (*sdk_types.SignedTxnWithAD, *idb.TxnRow) {
+	txn := sdk_types.SignedTxnWithAD{
+		SignedTxn: sdk_types.SignedTxn{
+			Txn: sdk_types.Transaction{
 				Type: "afrz",
-				Header: types.Header{
+				Header: sdk_types.Header{
 					Sender:     addr,
-					Fee:        types.MicroAlgos(1000),
-					FirstValid: types.Round(round),
-					LastValid:  types.Round(round),
+					Fee:        sdk_types.MicroAlgos(1000),
+					FirstValid: sdk_types.Round(round),
+					LastValid:  sdk_types.Round(round),
 				},
-				AssetFreezeTxnFields: types.AssetFreezeTxnFields{
+				AssetFreezeTxnFields: sdk_types.AssetFreezeTxnFields{
 					FreezeAccount: addr,
-					FreezeAsset:   types.AssetIndex(assetid),
+					FreezeAsset:   sdk_types.AssetIndex(assetid),
 					AssetFrozen:   frozen,
 				},
 			},
@@ -129,28 +129,28 @@ func MakeAssetFreezeOrPanic(round, assetid uint64, frozen bool, addr types.Addre
 }
 
 // MakeAssetTxnOrPanic creates an asset transfer transaction.
-func MakeAssetTxnOrPanic(round, assetid, amt uint64, sender, receiver, close types.Address) (*types.SignedTxnWithAD, *idb.TxnRow) {
-	txn := types.SignedTxnWithAD{
-		SignedTxn: types.SignedTxn{
-			Txn: types.Transaction{
+func MakeAssetTxnOrPanic(round, assetid, amt uint64, sender, receiver, close sdk_types.Address) (*sdk_types.SignedTxnWithAD, *idb.TxnRow) {
+	txn := sdk_types.SignedTxnWithAD{
+		SignedTxn: sdk_types.SignedTxn{
+			Txn: sdk_types.Transaction{
 				Type: "axfer",
-				Header: types.Header{
+				Header: sdk_types.Header{
 					Sender:     sender,
-					Fee:        types.MicroAlgos(1000),
-					FirstValid: types.Round(round),
-					LastValid:  types.Round(round),
+					Fee:        sdk_types.MicroAlgos(1000),
+					FirstValid: sdk_types.Round(round),
+					LastValid:  sdk_types.Round(round),
 				},
-				AssetTransferTxnFields: types.AssetTransferTxnFields{
-					XferAsset:   types.AssetIndex(assetid),
+				AssetTransferTxnFields: sdk_types.AssetTransferTxnFields{
+					XferAsset:   sdk_types.AssetIndex(assetid),
 					AssetAmount: amt,
 					//only used for clawback transactions
-					//AssetSender:   types.Address{},
+					//AssetSender:   sdk_types.Address{},
 					AssetReceiver: receiver,
 					AssetCloseTo:  close,
 				},
 			},
 		},
-		ApplyData: types.ApplyData{},
+		ApplyData: sdk_types.ApplyData{},
 	}
 
 	txnRow := idb.TxnRow{
@@ -162,13 +162,13 @@ func MakeAssetTxnOrPanic(round, assetid, amt uint64, sender, receiver, close typ
 }
 
 // MakeAssetDestroyTxn makes a transaction that destroys an asset.
-func MakeAssetDestroyTxn(round uint64, assetID uint64) (*types.SignedTxnWithAD, *idb.TxnRow) {
-	txn := types.SignedTxnWithAD{
-		SignedTxn: types.SignedTxn{
-			Txn: types.Transaction{
+func MakeAssetDestroyTxn(round uint64, assetID uint64) (*sdk_types.SignedTxnWithAD, *idb.TxnRow) {
+	txn := sdk_types.SignedTxnWithAD{
+		SignedTxn: sdk_types.SignedTxn{
+			Txn: sdk_types.Transaction{
 				Type: "acfg",
-				AssetConfigTxnFields: types.AssetConfigTxnFields{
-					ConfigAsset: types.AssetIndex(assetID),
+				AssetConfigTxnFields: sdk_types.AssetConfigTxnFields{
+					ConfigAsset: sdk_types.AssetIndex(assetID),
 				},
 			},
 		},
@@ -185,31 +185,31 @@ func MakeAssetDestroyTxn(round uint64, assetID uint64) (*types.SignedTxnWithAD, 
 
 // MakePayTxnRowOrPanic creates an algo transfer transaction.
 func MakePayTxnRowOrPanic(round, fee, amt, closeAmt, sendRewards, receiveRewards,
-	closeRewards uint64, sender, receiver, close, rekeyTo types.Address) (*types.SignedTxnWithAD,
+	closeRewards uint64, sender, receiver, close, rekeyTo sdk_types.Address) (*sdk_types.SignedTxnWithAD,
 	*idb.TxnRow) {
-	txn := types.SignedTxnWithAD{
-		SignedTxn: types.SignedTxn{
-			Txn: types.Transaction{
+	txn := sdk_types.SignedTxnWithAD{
+		SignedTxn: sdk_types.SignedTxn{
+			Txn: sdk_types.Transaction{
 				Type: "pay",
-				Header: types.Header{
+				Header: sdk_types.Header{
 					Sender:     sender,
-					Fee:        types.MicroAlgos(fee),
-					FirstValid: types.Round(round),
-					LastValid:  types.Round(round),
+					Fee:        sdk_types.MicroAlgos(fee),
+					FirstValid: sdk_types.Round(round),
+					LastValid:  sdk_types.Round(round),
 					RekeyTo:    rekeyTo,
 				},
-				PaymentTxnFields: types.PaymentTxnFields{
+				PaymentTxnFields: sdk_types.PaymentTxnFields{
 					Receiver:         receiver,
-					Amount:           types.MicroAlgos(amt),
+					Amount:           sdk_types.MicroAlgos(amt),
 					CloseRemainderTo: close,
 				},
 			},
 		},
-		ApplyData: types.ApplyData{
-			ClosingAmount:   types.MicroAlgos(closeAmt),
-			SenderRewards:   types.MicroAlgos(sendRewards),
-			ReceiverRewards: types.MicroAlgos(receiveRewards),
-			CloseRewards:    types.MicroAlgos(closeRewards),
+		ApplyData: sdk_types.ApplyData{
+			ClosingAmount:   sdk_types.MicroAlgos(closeAmt),
+			SenderRewards:   sdk_types.MicroAlgos(sendRewards),
+			ReceiverRewards: sdk_types.MicroAlgos(receiveRewards),
+			CloseRewards:    sdk_types.MicroAlgos(closeRewards),
 		},
 	}
 

--- a/util/test/testutil.go
+++ b/util/test/testutil.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 
 	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
-	atypes "github.com/algorand/go-algorand-sdk/types"
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/types"
 )
@@ -61,7 +61,7 @@ func PrintAssetQuery(db idb.IndexerDb, q idb.AssetsQuery) {
 		MaybeFail(ar.Error, "asset query %v\n", ar.Error)
 		pjs, err := json.Marshal(ar.Params)
 		MaybeFail(err, "json.Marshal params %v\n", err)
-		var creator atypes.Address
+		var creator sdk_types.Address
 		copy(creator[:], ar.Creator)
 		info("%d %s %s\n", ar.AssetID, creator.String(), pjs)
 		count++


### PR DESCRIPTION
## Summary
Make the use of go-algorand-sdk/types consistent.