### PR TITLE
Delete unused variables and functions.

### DIFF
--- a/accounting/accounting.go
+++ b/accounting/accounting.go
@@ -1,7 +1,6 @@
 package accounting
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"math/big"
@@ -26,10 +25,6 @@ type State struct {
 
 	rewardsLevel uint64
 
-	// number of txns at the end of the previous block
-	txnCounter      uint64
-	txnCounterRound uint64
-
 	accountTypes accountTypeCache
 }
 
@@ -53,12 +48,6 @@ func (accounting *State) InitRoundParts(round uint64, feeSink, rewardsPool sdk_t
 	accounting.rewardsLevel = rewardsLevel
 	accounting.currentRound = round
 	return nil
-}
-
-var zeroAddr = [32]byte{}
-
-func addrIsZero(a types.Address) bool {
-	return bytes.Equal(a[:], zeroAddr[:])
 }
 
 func bytesAreZero(b []byte) bool {

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/labstack/echo/v4"
-	log "github.com/sirupsen/logrus"
 
 	sdk_types "github.com/algorand/go-algorand-sdk/types"
 
@@ -29,8 +28,6 @@ type ServerImplementation struct {
 	db idb.IndexerDb
 
 	fetcher error
-
-	log *log.Logger
 }
 
 /////////////////////
@@ -697,13 +694,6 @@ func (si *ServerImplementation) fetchTransactions(ctx context.Context, filter id
 
 func min(x, y uint64) uint64 {
 	if x < y {
-		return x
-	}
-	return y
-}
-
-func max(x, y uint64) uint64 {
-	if x > y {
 		return x
 	}
 	return y

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -426,7 +426,6 @@ func TestFetchTransactions(t *testing.T) {
 			// Setup the mocked responses
 
 			mockIndexer := &mocks.IndexerDb{}
-			indexerDb = mockIndexer
 			si := ServerImplementation{
 				EnableAddressSearchRoundRewind: true,
 				db:                             mockIndexer,

--- a/api/middlewares/migration_middleware_test.go
+++ b/api/middlewares/migration_middleware_test.go
@@ -14,7 +14,6 @@ import (
 
 var errSuccess = errors.New("unexpected success")
 var e = echo.New()
-var testAPIHeader = "API-Header-Whatever"
 
 // success is the "next" handler, it is only called when a request is allowed to continue
 func success(ctx echo.Context) error {

--- a/api/pointer_utils.go
+++ b/api/pointer_utils.go
@@ -92,8 +92,3 @@ func strArrayPtr(x []string) *[]string {
 	}
 	return &x
 }
-
-type genesis struct {
-	genesisHash []byte
-	genesisID   string
-}

--- a/api/server.go
+++ b/api/server.go
@@ -16,13 +16,8 @@ import (
 	"github.com/algorand/indexer/idb"
 )
 
-// TODO: Get rid of this global
-var indexerDb idb.IndexerDb
-
 // Serve starts an http server for the indexer API. This call blocks.
 func Serve(ctx context.Context, serveAddr string, db idb.IndexerDb, fetcherError error, log *log.Logger, tokens []string, developerMode bool) {
-	indexerDb = db
-
 	e := echo.New()
 	e.HideBanner = true
 

--- a/cmd/e2equeries/main.go
+++ b/cmd/e2equeries/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
 	"flag"
 	"fmt"
 	"os"
@@ -26,14 +25,6 @@ var (
 var maybeFail = testutil.MaybeFail
 var printAccountQuery = testutil.PrintAccountQuery
 var printTxnQuery = testutil.PrintTxnQuery
-
-func b64(x string) []byte {
-	v, err := base64.StdEncoding.DecodeString(x)
-	if err != nil {
-		panic(err)
-	}
-	return v
-}
 
 func main() {
 	start := time.Now()

--- a/cmd/idbtest/idbtest.go
+++ b/cmd/idbtest/idbtest.go
@@ -16,7 +16,6 @@ import (
 	models "github.com/algorand/indexer/api/generated/v2"
 	"github.com/algorand/indexer/idb"
 	_ "github.com/algorand/indexer/idb/postgres"
-	"github.com/algorand/indexer/types"
 	testutil "github.com/algorand/indexer/util/test"
 )
 
@@ -103,19 +102,6 @@ func testTxnPaging(db idb.IndexerDb, q idb.TransactionFilter) {
 	if exitValue == 0 {
 		info("ok fetching %d entries over %d pages\n", len(all), page)
 	}
-}
-
-func printAssetBalanceQuery(db idb.IndexerDb, assetID uint64) {
-	rows, _ := db.AssetBalances(context.Background(), idb.AssetBalanceQuery{AssetID: assetID})
-	count := 0
-	for row := range rows {
-		maybeFail(row.Error, "err %v\n", row.Error)
-		var addr types.Address
-		copy(addr[:], row.Address)
-		fmt.Printf("%s %d %12d %t\n", addr.String(), row.AssetID, row.Amount, row.Frozen)
-		count++
-	}
-	fmt.Printf("%d asset balances\n", count)
 }
 
 func getAccount(db idb.IndexerDb, addr []byte) (account models.Account, err error) {

--- a/cmd/texttosource/main.go
+++ b/cmd/texttosource/main.go
@@ -18,14 +18,12 @@ func main() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %v\n", fname, err)
 			os.Exit(1)
-			return
 		}
 		outname := strings.ReplaceAll(fname, ".", "_") + ".go"
 		fout, err := os.Create(outname)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %v\n", outname, err)
 			os.Exit(1)
-			return
 		}
 		varname := strings.ReplaceAll(fname, ".", "_")
 		bodyConstant := "`" + strings.ReplaceAll(string(data), "`", "\\u0060") + "`"
@@ -35,5 +33,9 @@ package %s
 
 const %s = %s
 `, fname, packageName, varname, bodyConstant)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to write to %s: %v\n", outname, err)
+			os.Exit(1)
+		}
 	}
 }

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -936,14 +936,13 @@ func TestDestroyAssetDeleteCreatorsHolding(t *testing.T) {
 func TestAssetFreezeTxnParticipation(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
-	pdb, _ := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
+	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
 	blockImporter := importer.NewDBImporter(pdb)
 
 	///////////
 	// Given // A block containing an asset freeze txn
 	///////////
-	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
-	assert.NoError(t, err)
 
 	// Create a block with freeze txn
 	freeze, _ := test.MakeAssetFreezeOrPanic(test.Round, 1234, true, test.AccountA, test.AccountB)

--- a/idb/postgres/postgres_test.go
+++ b/idb/postgres/postgres_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,6 +78,7 @@ func TestNoMigrationsNeeded(t *testing.T) {
 	pdb, err := openPostgres(db, idb.IndexerDbOptions{
 		ReadOnly: false,
 	}, nil)
+	assert.NoError(t, err)
 
 	// Just need a moment for the go routine to get started
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
## Summary
Delete unused `idb/postgres/postgres.go:GetAsset()` and some variables and functions returned by `staticcheck` (https://staticcheck.io/). Some unused error are checked instead.
```
accounting/accounting.go:30:2: field txnCounter is unused (U1000)
accounting/accounting.go:31:2: field txnCounterRound is unused (U1000)
accounting/accounting.go:58:5: var zeroAddr is unused (U1000)
accounting/accounting.go:60:6: func addrIsZero is unused (U1000)
accounting/rewind.go:217:4: the surrounding loop is unconditionally terminated (SA4004)
api/handlers.go:33:2: field log is unused (U1000)
api/handlers.go:269:3: the surrounding loop is unconditionally terminated (SA4004)
api/handlers.go:705:6: func max is unused (U1000)
api/middlewares/migration_middleware_test.go:17:5: var testAPIHeader is unused (U1000)
api/pointer_utils.go:90:5: should omit nil check; len() for nil slices is defined as zero (S1009)
api/pointer_utils.go:96:6: type genesis is unused (U1000)
api/server.go:20:5: var indexerDb is unused (U1000)
cmd/algorand-indexer/daemon.go:120:2: should use for {} instead of for true {} (S1006)
cmd/algorand-indexer/daemon.go:185:8: should use time.Since instead of time.Now().Sub (S1012)
cmd/algorand-indexer/reset.go:58:16: sleeping for 2 nanoseconds is probably a bug; be explicit if it isn't (SA1004)
cmd/e2equeries/main.go:30:6: func b64 is unused (U1000)
cmd/e2equeries/main.go:81:8: should use time.Since instead of time.Now().Sub (S1012)
cmd/idbtest/idbtest.go:108:6: func printAssetBalanceQuery is unused (U1000)
cmd/idbtest/idbtest.go:204:8: should use time.Since instead of time.Now().Sub (S1012)
cmd/texttosource/main.go:32:3: this value of err is never used (SA4006)
cmd/validator/dynamic_processor.go:62:9: assigning the result of this type assertion to a variable (switch val := val.(type)) could eliminate type assertions in switch cases (S1034)
	cmd/validator/dynamic_processor.go:64:10: could eliminate this type assertion
cmd/validator/dynamic_processor.go:146:9: assigning the result of this type assertion to a variable (switch data := data.(type)) could eliminate type assertions in switch cases (S1034)
	cmd/validator/dynamic_processor.go:149:13: could eliminate this type assertion
	cmd/validator/dynamic_processor.go:212:26: could eliminate this type assertion
cmd/validator/struct_processor.go:235:7: should use !bytes.Equal(algodCreatedApp.Params.ApprovalProgram, indexerCreatedApp.Params.ApprovalProgram) instead (S1004)
cmd/validator/struct_processor.go:238:7: should use !bytes.Equal(algodCreatedApp.Params.ClearStateProgram, indexerCreatedApp.Params.ClearStateProgram) instead (S1004)
cmd/validator/struct_processor.go:256:6: func appSchemaComparePtrEqual is unused (U1000)
cmd/validator/struct_processor.go:311:9: should use bytes.Equal(*val1, *val2) instead (S1004)
cmd/validator/struct_processor.go:340:6: func uint64PtrEqual is unused (U1000)
fetcher/fetcher.go:103:2: should use for {} instead of for true {} (S1006)
fetcher/fetcher.go:131:2: should use for {} instead of for true {} (S1006)
fetcher/fetcher.go:166:2: should use for {} instead of for true {} (S1006)
idb/idb.go:389:77: should use make(map[[32]byte][]AssetUpdate) instead (S1019)
idb/migration/migration.go:215:2: redundant return statement (S1023)
idb/migration/migration_test.go:22:5: var fastErrorTask2 is unused (U1000)
idb/migration/migration_test.go:23:5: var fastErrorTask3 is unused (U1000)
idb/migration/migration_test.go:25:5: var slowErrorTask1 is unused (U1000)
idb/migration/migration_test.go:26:5: var slowErrorTask2 is unused (U1000)
idb/migration/migration_test.go:33:5: var fastSuccessBlockingTask1 is unused (U1000)
idb/migration/migration_test.go:34:5: var fastSuccessBlockingTask2 is unused (U1000)
idb/migration/migration_test.go:35:5: var fastSuccessBlockingTask3 is unused (U1000)
idb/migration/migration_test.go:37:5: var fastErrorBlockingTask1 is unused (U1000)
idb/migration/migration_test.go:38:5: var fastErrorBlockingTask2 is unused (U1000)
idb/migration/migration_test.go:39:5: var fastErrorBlockingTask3 is unused (U1000)
idb/migration/migration_test.go:41:5: var slowErrorBlockingTask1 is unused (U1000)
idb/migration/migration_test.go:42:5: var slowErrorBlockingTask2 is unused (U1000)
idb/migration/migration_test.go:43:5: var slowErrorBlockingTask3 is unused (U1000)
idb/postgres/postgres.go:93:2: field tx is unused (U1000)
idb/postgres/postgres.go:94:2: field addtx is unused (U1000)
idb/postgres/postgres.go:95:2: field addtxpart is unused (U1000)
idb/postgres/postgres.go:360:3: this value of err is never used (SA4006)
idb/postgres/postgres.go:620:2: field _struct is unused (U1000)
idb/postgres/postgres.go:638:2: field _struct is unused (U1000)
idb/postgres/postgres.go:749:2: field _struct is unused (U1000)
idb/postgres/postgres.go:761:2: field _struct is unused (U1000)
idb/postgres/postgres.go:1570:35: unnecessary use of fmt.Sprintf (S1039)
idb/postgres/postgres.go:1811:7: const maxAccountsLimit is unused (U1000)
idb/postgres/postgres.go:2338:5: should omit nil check; len() for nil slices is defined as zero (S1009)
idb/postgres/postgres.go:2356:5: var emptyString is unused (U1000)
idb/postgres/postgres.go:2376:6: func bytesStr is unused (U1000)
idb/postgres/postgres_integration_test.go:945:2: this value of pdb is never used (SA4006)
idb/postgres/postgres_test.go:77:2: this value of err is never used (SA4006)
types/types.go:41:3: field _struct is unused (U1000)
types/types.go:221:3: field _struct is unused (U1000)
types/types.go:231:3: field _struct is unused (U1000)
types/types.go:239:3: field _struct is unused (U1000)
types/types.go:258:3: field _struct is unused (U1000)
types/types.go:274:3: field _struct is unused (U1000)
types/types.go:298:3: field _struct is unused (U1000)
types/types.go:310:3: field _struct is unused (U1000)
types/types.go:327:3: field _struct is unused (U1000)
types/types.go:367:3: field _struct is unused (U1000)
types/types.go:418:3: field _struct is unused (U1000)
version/strings.go:44:9: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
```