### PR TITLE
make check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 # Build artifacts
 cmd/algorand-indexer/algorand-indexer
+cmd/block-generator/block-generator
+cmd/e2equeries/e2equeries
+cmd/idbtest/idbtest
+cmd/texttosource/texttosource
+cmd/validator/validator
 api/.3tmp.json
 tmp/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,5 @@
 # Build artifacts
 cmd/algorand-indexer/algorand-indexer
-cmd/block-generator/block-generator
-cmd/e2equeries/e2equeries
-cmd/idbtest/idbtest
-cmd/texttosource/texttosource
-cmd/validator/validator
 api/.3tmp.json
 tmp/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 script:
 - test -z `go fmt ./...`
 - make lint
-- make
+- make check
 - make integration
 - make test
 # e2e tests can't run without installing algod.

--- a/Makefile
+++ b/Makefile
@@ -25,21 +25,6 @@ idb/mocks/IndexerDb.go:	idb/idb.go
 	go get github.com/vektra/mockery/.../
 	cd idb && mockery -name=IndexerDb
 
-cmd/block-generator/block-generator:
-	cd cmd/block-generator && go build
-
-cmd/e2equeries/e2equeries:
-	cd cmd/e2equeries && go build
-
-cmd/idbtest/idbtest:
-	cd cmd/idbtest && go build
-
-cmd/texttosource/texttosource:
-	cd cmd/texttosource && go build
-
-cmd/validator/validator:
-	cd cmd/validator && go build
-
 # check that all packages (except tests) compile
 check:
 	go build ./...
@@ -87,4 +72,4 @@ sign:
 test-package:
 	mule/e2e.sh
 
-.PHONY: test e2e integration fmt lint deploy sign test-package package fakepackage cmd/algorand-indexer/algorand-indexer idb/mocks/IndexerDb.go cmd/block-generator/block-generator cmd/e2equeries/e2equeries cmd/idbtest/idbtest cmd/texttosource/texttosource cmd/validator/validator
+.PHONY: test e2e integration fmt lint deploy sign test-package package fakepackage cmd/algorand-indexer/algorand-indexer idb/mocks/IndexerDb.go

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,25 @@ idb/mocks/IndexerDb.go:	idb/idb.go
 	go get github.com/vektra/mockery/.../
 	cd idb && mockery -name=IndexerDb
 
+cmd/block-generator/block-generator:
+	cd cmd/block-generator && go build
+
+cmd/e2equeries/e2equeries:
+	cd cmd/e2equeries && go build
+
+cmd/idbtest/idbtest:
+	cd cmd/idbtest && go build
+
+cmd/texttosource/texttosource:
+	cd cmd/texttosource && go build
+
+cmd/validator/validator:
+	cd cmd/validator && go build
+
+# check that all packages (except tests) compile
+check:
+	go build ./...
+
 package:
 	rm -rf $(PKG_DIR)
 	mkdir -p $(PKG_DIR)
@@ -68,4 +87,4 @@ sign:
 test-package:
 	mule/e2e.sh
 
-.PHONY: test e2e integration fmt lint deploy sign test-package package fakepackage cmd/algorand-indexer/algorand-indexer idb/mocks/IndexerDb.go
+.PHONY: test e2e integration fmt lint deploy sign test-package package fakepackage cmd/algorand-indexer/algorand-indexer idb/mocks/IndexerDb.go cmd/block-generator/block-generator cmd/e2equeries/e2equeries cmd/idbtest/idbtest cmd/texttosource/texttosource cmd/validator/validator


### PR DESCRIPTION
## Summary

Add a make target that checks that all go code (except tests) can be compiled and use this rule in the CI script.