### PR TITLE
Use type.BlockHeader instead of type.Block for representing a header

### DIFF
--- a/accounting/accounting.go
+++ b/accounting/accounting.go
@@ -36,8 +36,8 @@ func New(defaultFrozenCache map[uint64]bool) *State {
 }
 
 // InitRound should be called before each round to initialize the accounting state.
-func (accounting *State) InitRound(block types.Block) error {
-	return accounting.InitRoundParts(uint64(block.Round), block.FeeSink, block.RewardsPool, block.RewardsLevel)
+func (accounting *State) InitRound(blockHeader *types.BlockHeader) error {
+	return accounting.InitRoundParts(uint64(blockHeader.Round), blockHeader.FeeSink, blockHeader.RewardsPool, blockHeader.RewardsLevel)
 }
 
 // InitRoundParts are the specific parts from a block needed to initialize accounting. Used for testing, normally you would pass in the block.

--- a/accounting/rewind.go
+++ b/accounting/rewind.go
@@ -193,13 +193,13 @@ func AccountAtRound(account models.Account, round uint64, db idb.IndexerDb) (acc
 			if err != nil {
 				return
 			}
-			var baseBlock types.Block
-			baseBlock, _, err = db.GetBlock(context.Background(), txnrow.Round, idb.GetBlockOptions{})
+			var baseBlockHeader types.BlockHeader
+			baseBlockHeader, _, err = db.GetBlock(context.Background(), txnrow.Round, idb.GetBlockOptions{})
 			if err != nil {
 				return
 			}
-			prevRewardsBase := baseBlock.RewardsLevel
-			var blockheader types.Block
+			prevRewardsBase := baseBlockHeader.RewardsLevel
+			var blockheader types.BlockHeader
 			blockheader, _, err = db.GetBlock(context.Background(), round, idb.GetBlockOptions{})
 			if err != nil {
 				return

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -561,46 +561,47 @@ func (si *ServerImplementation) fetchAssetBalances(ctx context.Context, options 
 // fetchBlock looks up a block and converts it into a generated.Block object
 // the method also loads the transactions into the returned block object.
 func (si *ServerImplementation) fetchBlock(ctx context.Context, round uint64) (generated.Block, error) {
-	blk, transactions, err := si.db.GetBlock(ctx, round, idb.GetBlockOptions{Transactions: true})
+	blockHeader, transactions, err :=
+		si.db.GetBlock(ctx, round, idb.GetBlockOptions{Transactions: true})
 
 	if err != nil {
 		return generated.Block{}, fmt.Errorf("%s '%d': %v", errLookingUpBlock, round, err)
 	}
 
 	rewards := generated.BlockRewards{
-		FeeSink:                 blk.FeeSink.String(),
-		RewardsCalculationRound: uint64(blk.RewardsRecalculationRound),
-		RewardsLevel:            blk.RewardsLevel,
-		RewardsPool:             blk.RewardsPool.String(),
-		RewardsRate:             blk.RewardsRate,
-		RewardsResidue:          blk.RewardsResidue,
+		FeeSink:                 blockHeader.FeeSink.String(),
+		RewardsCalculationRound: uint64(blockHeader.RewardsRecalculationRound),
+		RewardsLevel:            blockHeader.RewardsLevel,
+		RewardsPool:             blockHeader.RewardsPool.String(),
+		RewardsRate:             blockHeader.RewardsRate,
+		RewardsResidue:          blockHeader.RewardsResidue,
 	}
 
 	upgradeState := generated.BlockUpgradeState{
-		CurrentProtocol:        string(blk.CurrentProtocol),
-		NextProtocol:           strPtr(string(blk.NextProtocol)),
-		NextProtocolApprovals:  uint64Ptr(blk.NextProtocolApprovals),
-		NextProtocolSwitchOn:   uint64Ptr(uint64(blk.NextProtocolSwitchOn)),
-		NextProtocolVoteBefore: uint64Ptr(uint64(blk.NextProtocolVoteBefore)),
+		CurrentProtocol:        string(blockHeader.CurrentProtocol),
+		NextProtocol:           strPtr(string(blockHeader.NextProtocol)),
+		NextProtocolApprovals:  uint64Ptr(blockHeader.NextProtocolApprovals),
+		NextProtocolSwitchOn:   uint64Ptr(uint64(blockHeader.NextProtocolSwitchOn)),
+		NextProtocolVoteBefore: uint64Ptr(uint64(blockHeader.NextProtocolVoteBefore)),
 	}
 
 	upgradeVote := generated.BlockUpgradeVote{
-		UpgradeApprove: boolPtr(blk.UpgradeApprove),
-		UpgradeDelay:   uint64Ptr(uint64(blk.UpgradeDelay)),
-		UpgradePropose: strPtr(string(blk.UpgradePropose)),
+		UpgradeApprove: boolPtr(blockHeader.UpgradeApprove),
+		UpgradeDelay:   uint64Ptr(uint64(blockHeader.UpgradeDelay)),
+		UpgradePropose: strPtr(string(blockHeader.UpgradePropose)),
 	}
 
 	ret := generated.Block{
-		GenesisHash:       blk.GenesisHash[:],
-		GenesisId:         blk.GenesisID,
-		PreviousBlockHash: blk.Branch[:],
+		GenesisHash:       blockHeader.GenesisHash[:],
+		GenesisId:         blockHeader.GenesisID,
+		PreviousBlockHash: blockHeader.Branch[:],
 		Rewards:           &rewards,
-		Round:             uint64(blk.Round),
-		Seed:              blk.Seed[:],
-		Timestamp:         uint64(blk.TimeStamp),
+		Round:             uint64(blockHeader.Round),
+		Seed:              blockHeader.Seed[:],
+		Timestamp:         uint64(blockHeader.TimeStamp),
 		Transactions:      nil,
-		TransactionsRoot:  blk.TxnRoot[:],
-		TxnCounter:        uint64Ptr(blk.TxnCounter),
+		TransactionsRoot:  blockHeader.TxnRoot[:],
+		TxnCounter:        uint64Ptr(blockHeader.TxnCounter),
 		UpgradeState:      &upgradeState,
 		UpgradeVote:       &upgradeVote,
 	}

--- a/idb/dummy/dummy.go
+++ b/idb/dummy/dummy.go
@@ -78,13 +78,13 @@ func (db *dummyIndexerDb) YieldTxns(ctx context.Context, firstRound uint64) <-ch
 }
 
 // CommitRoundAccounting is part of idb.IndexerDB
-func (db *dummyIndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round uint64, blockPtr *types.Block) (err error) {
+func (db *dummyIndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round uint64, blockHeader *types.BlockHeader) (err error) {
 	return nil
 }
 
 // GetBlock is part of idb.IndexerDB
-func (db *dummyIndexerDb) GetBlock(ctx context.Context, round uint64, options idb.GetBlockOptions) (block types.Block, transactions []idb.TxnRow, err error) {
-	return types.Block{}, nil, nil
+func (db *dummyIndexerDb) GetBlock(ctx context.Context, round uint64, options idb.GetBlockOptions) (blockHeader types.BlockHeader, transactions []idb.TxnRow, err error) {
+	return types.BlockHeader{}, nil, nil
 }
 
 // Transactions is part of idb.IndexerDB

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -97,9 +97,9 @@ type IndexerDb interface {
 	// YieldTxns returns a channel that produces the whole transaction stream starting at the specified round
 	YieldTxns(ctx context.Context, firstRound uint64) <-chan TxnRow
 
-	CommitRoundAccounting(updates RoundUpdates, round uint64, blockPtr *types.Block) (err error)
+	CommitRoundAccounting(updates RoundUpdates, round uint64, blockHeader *types.BlockHeader) (err error)
 
-	GetBlock(ctx context.Context, round uint64, options GetBlockOptions) (block types.Block, transactions []TxnRow, err error)
+	GetBlock(ctx context.Context, round uint64, options GetBlockOptions) (blockHeader types.BlockHeader, transactions []TxnRow, err error)
 
 	// The next multiple functions return a channel with results as well as the latest round
 	// accounted.

--- a/idb/mocks/IndexerDb.go
+++ b/idb/mocks/IndexerDb.go
@@ -115,13 +115,13 @@ func (_m *IndexerDb) CommitBlock(round uint64, timestamp int64, rewardslevel uin
 	return r0
 }
 
-// CommitRoundAccounting provides a mock function with given fields: updates, round, blockPtr
-func (_m *IndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round uint64, blockPtr *types.Block) error {
-	ret := _m.Called(updates, round, blockPtr)
+// CommitRoundAccounting provides a mock function with given fields: updates, round, blockHeader
+func (_m *IndexerDb) CommitRoundAccounting(updates idb.RoundUpdates, round uint64, blockHeader *types.BlockHeader) error {
+	ret := _m.Called(updates, round, blockHeader)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(idb.RoundUpdates, uint64, *types.Block) error); ok {
-		r0 = rf(updates, round, blockPtr)
+	if rf, ok := ret.Get(0).(func(idb.RoundUpdates, uint64, *types.BlockHeader) error); ok {
+		r0 = rf(updates, round, blockHeader)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -153,14 +153,14 @@ func (_m *IndexerDb) GetAccounts(ctx context.Context, opts idb.AccountQueryOptio
 }
 
 // GetBlock provides a mock function with given fields: ctx, round, options
-func (_m *IndexerDb) GetBlock(ctx context.Context, round uint64, options idb.GetBlockOptions) (types.Block, []idb.TxnRow, error) {
+func (_m *IndexerDb) GetBlock(ctx context.Context, round uint64, options idb.GetBlockOptions) (types.BlockHeader, []idb.TxnRow, error) {
 	ret := _m.Called(ctx, round, options)
 
-	var r0 types.Block
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, idb.GetBlockOptions) types.Block); ok {
+	var r0 types.BlockHeader
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, idb.GetBlockOptions) types.BlockHeader); ok {
 		r0 = rf(ctx, round, options)
 	} else {
-		r0 = ret.Get(0).(types.Block)
+		r0 = ret.Get(0).(types.BlockHeader)
 	}
 
 	var r1 []idb.TxnRow

--- a/idb/postgres/postgres_integration_common_test.go
+++ b/idb/postgres/postgres_integration_common_test.go
@@ -72,7 +72,7 @@ func accountTxns(t *testing.T, db *IndexerDb, round uint64, txns ...*idb.TxnRow)
 		assert.NoError(t, err)
 	}
 
-	err = db.CommitRoundAccounting(state.RoundUpdates, round, &types.Block{})
+	err = db.CommitRoundAccounting(state.RoundUpdates, round, &types.BlockHeader{})
 	assert.NoError(t, err)
 }
 

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -150,7 +150,7 @@ func TestAssetCloseReopenTransfer(t *testing.T) {
 	//////////
 	// When // We commit the round accounting to the database.
 	//////////
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.BlockHeader{})
 	assert.NoError(t, err, "failed to commit")
 
 	//////////
@@ -197,7 +197,7 @@ func TestDefaultFrozenAndCache(t *testing.T) {
 	//////////
 	// When // We commit the round accounting to the database.
 	//////////
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.BlockHeader{})
 	assert.NoError(t, err, "failed to commit")
 
 	//////////
@@ -286,7 +286,7 @@ func TestReCreateAssetHolding(t *testing.T) {
 		//////////
 		// When // We commit the round accounting to the database.
 		//////////
-		err = pdb.CommitRoundAccounting(state.RoundUpdates, round, &types.Block{})
+		err = pdb.CommitRoundAccounting(state.RoundUpdates, round, &types.BlockHeader{})
 		assert.NoError(t, err, "failed to commit")
 
 		//////////
@@ -327,7 +327,7 @@ func TestNoopOptins(t *testing.T) {
 	//////////
 	// When // We commit the round accounting to the database.
 	//////////
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.BlockHeader{})
 	assert.NoError(t, err, "failed to commit")
 
 	//////////
@@ -370,7 +370,7 @@ func TestMultipleWriters(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			errors <- pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
+			errors <- pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.BlockHeader{})
 		}()
 	}
 	close(start)
@@ -473,7 +473,7 @@ func TestRekeyBasic(t *testing.T) {
 	state := getAccounting(test.Round, cache)
 	state.AddTransaction(txnRow)
 
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.BlockHeader{})
 	assert.NoError(t, err, "failed to commit")
 
 	//////////
@@ -509,7 +509,7 @@ func TestRekeyToItself(t *testing.T) {
 		state := getAccounting(test.Round, cache)
 		state.AddTransaction(txnRow)
 
-		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
+		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.BlockHeader{})
 		assert.NoError(t, err, "failed to commit")
 	}
 	{
@@ -521,7 +521,7 @@ func TestRekeyToItself(t *testing.T) {
 		state := getAccounting(test.Round+1, cache)
 		state.AddTransaction(txnRow)
 
-		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round+1, &types.Block{})
+		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round+1, &types.BlockHeader{})
 		assert.NoError(t, err, "failed to commit")
 	}
 
@@ -569,7 +569,7 @@ func TestRekeyThreeTimesInSameRound(t *testing.T) {
 		state.AddTransaction(txnRow)
 	}
 
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.BlockHeader{})
 	assert.NoError(t, err, "failed to commit")
 
 	//////////
@@ -607,7 +607,7 @@ func TestRekeyToItselfHasNotBeenRekeyed(t *testing.T) {
 	//////////
 	// Then // No error when committing to the DB.
 	//////////
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.BlockHeader{})
 	assert.NoError(t, err, "failed to commit")
 }
 
@@ -639,7 +639,7 @@ func TestIgnoreDefaultFrozenConfigUpdate(t *testing.T) {
 	//////////
 	// When // We commit the round accounting to the database.
 	//////////
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.BlockHeader{})
 	assert.NoError(t, err, "failed to commit")
 
 	//////////
@@ -674,7 +674,7 @@ func TestZeroTotalAssetCreate(t *testing.T) {
 	//////////
 	// When // We commit the round accounting to the database.
 	//////////
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.BlockHeader{})
 	assert.NoError(t, err, "failed to commit")
 
 	//////////
@@ -736,7 +736,7 @@ func TestDestroyAssetBasic(t *testing.T) {
 		err := state.AddTransaction(txnRow)
 		assert.NoError(t, err)
 
-		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
+		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.BlockHeader{})
 		assert.NoError(t, err, "failed to commit")
 	}
 	// Destroy an asset.
@@ -747,7 +747,7 @@ func TestDestroyAssetBasic(t *testing.T) {
 		err := state.AddTransaction(txnRow)
 		assert.NoError(t, err)
 
-		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round+1, &types.Block{})
+		err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round+1, &types.BlockHeader{})
 		assert.NoError(t, err, "failed to commit")
 	}
 
@@ -795,7 +795,7 @@ func TestDestroyAssetZeroSupply(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.BlockHeader{})
 	assert.NoError(t, err, "failed to commit")
 
 	// Check that the asset is deleted.
@@ -867,7 +867,7 @@ func TestDestroyAssetDeleteCreatorsHolding(t *testing.T) {
 		state.AddTransaction(txnRow)
 	}
 
-	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.Block{})
+	err = pdb.CommitRoundAccounting(state.RoundUpdates, test.Round, &types.BlockHeader{})
 	assert.NoError(t, err, "failed to commit")
 
 	// Check that the creator's asset holding is deleted.

--- a/importer/helper.go
+++ b/importer/helper.go
@@ -275,12 +275,12 @@ func updateAccounting(db idb.IndexerDb, frozenCache map[uint64]bool, filter idb.
 	roundsSeen := 0
 	lastRoundsSeen := roundsSeen
 	txnForRound := 0
-	var blockPtr *types.Block = nil
+	var blockHeaderPtr *types.BlockHeader = nil
 	for txn := range txns {
 		maybeFail(txn.Error, l, "updateAccounting txn fetch, %v", txn.Error)
 		if txn.Round != currentRound {
-			if blockPtr != nil && txnForRound > 0 {
-				err := db.CommitRoundAccounting(act.RoundUpdates, currentRound, blockPtr)
+			if blockHeaderPtr != nil && txnForRound > 0 {
+				err := db.CommitRoundAccounting(act.RoundUpdates, currentRound, blockHeaderPtr)
 				maybeFail(err, l, "failed to commit round accounting")
 			}
 
@@ -295,10 +295,10 @@ func updateAccounting(db idb.IndexerDb, frozenCache map[uint64]bool, filter idb.
 				break
 			}
 
-			block, _, err := db.GetBlock(context.Background(), currentRound, idb.GetBlockOptions{})
+			blockHeader, _, err := db.GetBlock(context.Background(), currentRound, idb.GetBlockOptions{})
 			maybeFail(err, l, "problem fetching next round (%d)", currentRound)
-			blockPtr = &block
-			act.InitRound(block)
+			blockHeaderPtr = &blockHeader
+			act.InitRound(blockHeaderPtr)
 
 			// Log progress
 			if (filter.RoundLimit != nil) && (roundsSeen > *filter.RoundLimit) {
@@ -321,8 +321,8 @@ func updateAccounting(db idb.IndexerDb, frozenCache map[uint64]bool, filter idb.
 	}
 
 	// Commit the final round
-	if blockPtr != nil && txnForRound > 0 {
-		err := db.CommitRoundAccounting(act.RoundUpdates, currentRound, blockPtr)
+	if blockHeaderPtr != nil && txnForRound > 0 {
+		err := db.CommitRoundAccounting(act.RoundUpdates, currentRound, blockHeaderPtr)
 		maybeFail(err, l, "failed to commit round accounting")
 	}
 

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -120,9 +120,7 @@ func (imp *dbImporter) ImportDecodedBlock(blockContainer *types.EncodedBlockCert
 		}
 		txCount++
 	}
-	blockHeader := block
-	blockHeader.Payset = nil
-	blockheaderBytes := msgpack.Encode(blockHeader)
+	blockheaderBytes := msgpack.Encode(block.BlockHeader)
 	err = imp.db.CommitBlock(round, block.TimeStamp, block.RewardsLevel, blockheaderBytes)
 	if err != nil {
 		return txCount, fmt.Errorf("error committing block, %v", err)


### PR DESCRIPTION
## Summary

Before the `block_header.blockheader` json column was read and written to using `types.Block` with empty payset. This type embeds `types.BlockHeader`.
```
	Block struct {
		BlockHeader
		Payset Payset `codec:"txns"`
	}
```
Here is an example of a serialized `block_header.blockheader` value.
```
{"earn":184105,"fees":"x/zNsljw1BicK/i21o7ml1CGQrCtAB8x/LkYw1S6hZo=","frac":1557792033,"gen":"mainnet-v1.0","gh":"wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=","prev":"3iPOkbey8F2373sTx8f8lne50cFlAU6nsQhNvxqxsus=","proto":"https://github.com/algorandfoundation/specs/tree/d050b3cade6d5c664df8bd729bf219f179812595","rate":42300002,"rnd":13751456,"rwcalr":14000000,"rwd":"/v////////////////////////////////////////8=","seed":"gFw4S9tjvR0dZgB9zl/qyY/EMNwh66xFRRGABMffwg4=","tc":216693603,"ts":1620773791,"txn":"/eO9ouulrQAjbbQeTS599qMVNk6oaDsPOY1g3XdvmlY="}
```

We can and should just use `type.BlockHeader`.

## Test Plan

Current tests test it.
