### PR TITLE
Creatable ID is wrong on round 0.

### DIFF
--- a/cmd/block-generator/generator/generate.go
+++ b/cmd/block-generator/generator/generate.go
@@ -293,12 +293,15 @@ func (g *generator) WriteBlock(output io.Writer, round uint64) {
 	// Generate the transactions
 	sp := g.getSuggestedParams(round)
 	transactions := make([]types.SignedTxnInBlock, 0, g.config.TxnPerBlock)
-	for i := uint64(0); i < g.config.TxnPerBlock; i++ {
-		txn, err := g.generateTransaction(sp, g.round, i)
-		if err != nil {
-			panic(fmt.Sprintf("failed to generate transaction: %v\n", err))
+	// Do not put transactions in round 0
+	if round != 0 {
+		for i := uint64(0); i < g.config.TxnPerBlock; i++ {
+			txn, err := g.generateTransaction(sp, g.round, i)
+			if err != nil {
+				panic(fmt.Sprintf("failed to generate transaction: %v\n", err))
+			}
+			transactions = append(transactions, txn)
 		}
-		transactions = append(transactions, txn)
 	}
 
 	g.txnCounter += g.config.TxnPerBlock


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Something about assets created on round 0 was leading to negative asset balances. Since it isn't possible to have transactions on round zero anyway, just skip it to avoid the problem.

## Test Plan

New unit tests.