### PR TITLE
Return an error in `CommitRoundAccounting()` when import state is uninitialized

### DIFF
--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -1255,15 +1255,12 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 	staterow := tx.QueryRow(`SELECT v FROM metastate WHERE k = 'state'`)
 	var stateJSONStr string
 	err = staterow.Scan(&stateJSONStr)
-	if err == sql.ErrNoRows {
-		// ok
-	} else if err != nil {
+	if err != nil {
 		return
-	} else {
-		err = encoding.DecodeJSON([]byte(stateJSONStr), &importState)
-		if err != nil {
-			return
-		}
+	}
+	err = encoding.DecodeJSON([]byte(stateJSONStr), &importState)
+	if err != nil {
+		return
 	}
 	if importState.AccountRound >= int64(round) {
 		msg := fmt.Sprintf(

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -125,6 +125,9 @@ func TestAssetCloseReopenTransfer(t *testing.T) {
 	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
+	err = pdb.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
+
 	assetid := uint64(2222)
 	amt := uint64(10000)
 	total := uint64(1000000)
@@ -174,6 +177,9 @@ func TestDefaultFrozenAndCache(t *testing.T) {
 
 	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
+
+	err = pdb.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
 
 	assetid := uint64(2222)
 	total := uint64(1000000)
@@ -255,6 +261,9 @@ func TestReCreateAssetHolding(t *testing.T) {
 	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
+	err = pdb.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
+
 	assetid := uint64(2222)
 	total := uint64(1000000)
 
@@ -321,6 +330,9 @@ func TestNoopOptins(t *testing.T) {
 	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
+	err = pdb.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
+
 	_, createAsset := test.MakeAssetConfigOrPanic(test.Round, 0, assetid, uint64(1000000), uint64(6), true, "icicles", "frozen coin", "http://antarctica.com", test.AccountD)
 	_, optinB := test.MakeAssetTxnOrPanic(test.Round, assetid, 0, test.AccountB, test.AccountB, sdk_types.ZeroAddress)
 	_, unfreezeB := test.MakeAssetFreezeOrPanic(test.Round, assetid, false, test.AccountB, test.AccountB)
@@ -354,18 +366,21 @@ func TestMultipleWriters(t *testing.T) {
 	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
+	err = pdb.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
+
 	amt := uint64(10000)
 
 	///////////
-	// Given // Send amt to AccountA
+	// Given // Send amt to AccountE
 	///////////
-	_, payAccountA := test.MakePayTxnRowOrPanic(test.Round, 1000, amt, 0, 0, 0, 0, test.AccountD,
-		test.AccountA, sdk_types.ZeroAddress, sdk_types.ZeroAddress)
+	_, payAccountE := test.MakePayTxnRowOrPanic(test.Round, 1000, amt, 0, 0, 0, 0, test.AccountD,
+		test.AccountE, sdk_types.ZeroAddress, sdk_types.ZeroAddress)
 
 	cache, err := pdb.GetDefaultFrozen()
 	assert.NoError(t, err)
 	state := getAccounting(test.Round, cache)
-	state.AddTransaction(payAccountA)
+	state.AddTransaction(payAccountE)
 
 	//////////
 	// When // We attempt commit the round accounting multiple times.
@@ -398,9 +413,9 @@ func TestMultipleWriters(t *testing.T) {
 	}
 	assert.Equal(t, commits-1, errorCount)
 
-	// AccountA should contain the final payment.
+	// AccountE should contain the final payment.
 	var balance uint64
-	row := db.QueryRow(`SELECT microalgos FROM account WHERE account.addr = $1`, test.AccountA[:])
+	row := db.QueryRow(`SELECT microalgos FROM account WHERE account.addr = $1`, test.AccountE[:])
 	err = row.Scan(&balance)
 	assert.NoError(t, err, "checking balance")
 	assert.Equal(t, amt, balance)
@@ -471,6 +486,9 @@ func TestRekeyBasic(t *testing.T) {
 	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
+	err = pdb.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
+
 	///////////
 	// Given // Send rekey transaction
 	///////////
@@ -505,6 +523,9 @@ func TestRekeyToItself(t *testing.T) {
 
 	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
+
+	err = pdb.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
 
 	///////////
 	// Given // Send rekey transaction
@@ -555,6 +576,9 @@ func TestRekeyThreeTimesInSameRound(t *testing.T) {
 	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
+	err = pdb.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
+
 	///////////
 	// Given // Send rekey transaction
 	///////////
@@ -602,6 +626,9 @@ func TestRekeyToItselfHasNotBeenRekeyed(t *testing.T) {
 	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
+	err = pdb.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
+
 	///////////
 	// Given // Send rekey transaction
 	///////////
@@ -627,6 +654,9 @@ func TestIgnoreDefaultFrozenConfigUpdate(t *testing.T) {
 
 	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
+
+	err = pdb.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
 
 	assetid := uint64(2222)
 	total := uint64(1000000)
@@ -666,6 +696,9 @@ func TestZeroTotalAssetCreate(t *testing.T) {
 
 	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
+
+	err = pdb.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
 
 	assetid := uint64(2222)
 	total := uint64(0)
@@ -731,6 +764,9 @@ func TestDestroyAssetBasic(t *testing.T) {
 	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
+	err = pdb.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
+
 	cache, err := pdb.GetDefaultFrozen()
 	assert.NoError(t, err)
 
@@ -780,6 +816,9 @@ func TestDestroyAssetZeroSupply(t *testing.T) {
 	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
+	err = pdb.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
+
 	cache, err := pdb.GetDefaultFrozen()
 	assert.NoError(t, err)
 
@@ -826,6 +865,9 @@ func TestDestroyAssetDeleteCreatorsHolding(t *testing.T) {
 
 	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
+
+	err = pdb.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
 
 	cache, err := pdb.GetDefaultFrozen()
 	assert.NoError(t, err)

--- a/idb/postgres/postgres_migrations_integration_test.go
+++ b/idb/postgres/postgres_migrations_integration_test.go
@@ -64,6 +64,9 @@ func TestClearAccountDataMigrationClosedAccounts(t *testing.T) {
 	db, shutdownFunc := setupIdb(t)
 	defer shutdownFunc()
 
+	err := db.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
+
 	// Rekey account A.
 	{
 		stxn, txnRow := test.MakePayTxnRowOrPanic(
@@ -82,7 +85,7 @@ func TestClearAccountDataMigrationClosedAccounts(t *testing.T) {
 	}
 
 	// Run migration.
-	err := ClearAccountDataMigration(db, &MigrationState{})
+	err = ClearAccountDataMigration(db, &MigrationState{})
 	assert.NoError(t, err)
 
 	// Check that account A has no account data.
@@ -102,6 +105,9 @@ func TestClearAccountDataMigrationClosedAccounts(t *testing.T) {
 func TestClearAccountDataMigrationClearsReopenedAccounts(t *testing.T) {
 	db, shutdownFunc := setupIdb(t)
 	defer shutdownFunc()
+
+	err := db.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
 
 	// Create account A.
 	{
@@ -147,7 +153,7 @@ func TestClearAccountDataMigrationClearsReopenedAccounts(t *testing.T) {
 	}
 
 	// Run migration.
-	err := ClearAccountDataMigration(db, &MigrationState{})
+	err = ClearAccountDataMigration(db, &MigrationState{})
 	assert.NoError(t, err)
 
 	// Check that account A is offline and has no account data.
@@ -168,6 +174,9 @@ func TestClearAccountDataMigrationClearsReopenedAccounts(t *testing.T) {
 func TestClearAccountDataMigrationDoesNotClear(t *testing.T) {
 	db, shutdownFunc := setupIdb(t)
 	defer shutdownFunc()
+
+	err := db.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
 
 	// Create account A.
 	{
@@ -205,7 +214,7 @@ func TestClearAccountDataMigrationDoesNotClear(t *testing.T) {
 	}
 
 	// Run migration.
-	err := ClearAccountDataMigration(db, &MigrationState{})
+	err = ClearAccountDataMigration(db, &MigrationState{})
 	assert.NoError(t, err)
 
 	// Check that account A is online and has auth addr and keyreg data.
@@ -227,9 +236,12 @@ func TestClearAccountDataMigrationIncMigrationNum(t *testing.T) {
 	db, shutdownFunc := setupIdb(t)
 	defer shutdownFunc()
 
+	err := db.LoadGenesis(test.MakeGenesis())
+	require.NoError(t, err)
+
 	// Run migration.
 	state := MigrationState{NextMigration: 13}
-	err := ClearAccountDataMigration(db, &state)
+	err = ClearAccountDataMigration(db, &state)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 14, state.NextMigration)

--- a/util/test/account_testutil.go
+++ b/util/test/account_testutil.go
@@ -22,6 +22,8 @@ var (
 	AccountC = DecodeAddressOrPanic("OKUWMFFEKF4B4D7FRQYBVV3C2SNS54ZO4WZ2MJ3576UYKFDHM5P3AFMRWE")
 	// AccountD is a premade account for use in tests.
 	AccountD = DecodeAddressOrPanic("6TB2ZQA2GEEDH6XTIOH5A7FUSGINXDPW5ONN6XBOBBGGUXVHRQTITAIIVI")
+	// AccountE is a premade account for use in tests.
+	AccountE = DecodeAddressOrPanic("QYE3RIRIIUS4VRZ4WYR7E5R6WBHTQXUY7F62C7U77SSRAXUSFTSRQPXPPU")
 	// FeeAddr is the fee addess to use when creating the state object.
 	FeeAddr = DecodeAddressOrPanic("ZROKLZW4GVOK5WQIF2GUR6LHFVEZBMV56BIQEQD4OTIZL2BPSYYUKFBSHM")
 	// RewardAddr is the fee addess to use when creating the state object.
@@ -283,5 +285,42 @@ func MakeBlockForTxns(round uint64, inputs ...*sdk_types.SignedTxnWithAD) types.
 			Payset: txns,
 		},
 		Certificate: types.Certificate{},
+	}
+}
+
+// MakeGenesis creates a sample genesis info.
+func MakeGenesis() types.Genesis {
+	return types.Genesis{
+		SchemaID: "main",
+		Network:  "mynet",
+		Proto:    types.ConsensusVersion(Proto),
+		Allocation: []types.GenesisAllocation{
+			{
+				Address: AccountA.String(),
+				State: types.AccountData{
+					MicroAlgos: 1000 * 1000 * 1000 * 1000,
+				},
+			},
+			{
+				Address: AccountB.String(),
+				State: types.AccountData{
+					MicroAlgos: 1000 * 1000 * 1000 * 1000,
+				},
+			},
+			{
+				Address: AccountC.String(),
+				State: types.AccountData{
+					MicroAlgos: 1000 * 1000 * 1000 * 1000,
+				},
+			},
+			{
+				Address: AccountD.String(),
+				State: types.AccountData{
+					MicroAlgos: 1000 * 1000 * 1000 * 1000,
+				},
+			},
+		},
+		RewardsPool: RewardAddr.String(),
+		FeeSink:     FeeAddr.String(),
 	}
 }


### PR DESCRIPTION
## Summary

`CommitRoundAccounting()` currently proceeds to commit even if the import state is uninitialized. In `daemon.go` we, however, make sure to initialize the import state before starting the fetcher.

## Test Plan

Some existing tests have to do the import state initialization now by calling `db.LoadGenesis()`.