### PR TITLE
Load genesis in `setupIdb()`

### DIFF
--- a/idb/postgres/postgres_integration_common_test.go
+++ b/idb/postgres/postgres_integration_common_test.go
@@ -51,7 +51,7 @@ func setupIdb(t *testing.T, genesis types.Genesis) (*IndexerDb /*db*/, func() /*
 	require.NoError(t, err)
 
 	err = idb.LoadGenesis(genesis)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return idb, shutdownFunc
 }

--- a/idb/postgres/postgres_integration_common_test.go
+++ b/idb/postgres/postgres_integration_common_test.go
@@ -43,10 +43,13 @@ func setupPostgres(t *testing.T) (*sql.DB, string, func()) {
 	return db, connStr, shutdownFunc
 }
 
-func setupIdb(t *testing.T) (*IndexerDb /*db*/, func() /*shutdownFunc*/) {
+func setupIdb(t *testing.T, genesis types.Genesis) (*IndexerDb /*db*/, func() /*shutdownFunc*/) {
 	_, connStr, shutdownFunc := setupPostgres(t)
 
 	idb, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+
+	err = idb.LoadGenesis(genesis)
 	assert.NoError(t, err)
 
 	return idb, shutdownFunc

--- a/idb/postgres/postgres_migrations_integration_test.go
+++ b/idb/postgres/postgres_migrations_integration_test.go
@@ -29,7 +29,7 @@ func nextMigrationNum(t *testing.T, db *IndexerDb) int {
 }
 
 func TestFixFreezeLookupMigration(t *testing.T) {
-	db, shutdownFunc := setupIdb(t)
+	db, shutdownFunc := setupIdb(t, test.MakeGenesis())
 	defer shutdownFunc()
 
 	var sender types.Address
@@ -61,11 +61,8 @@ func TestFixFreezeLookupMigration(t *testing.T) {
 
 // Test that ClearAccountDataMigration() clears account data for closed accounts.
 func TestClearAccountDataMigrationClosedAccounts(t *testing.T) {
-	db, shutdownFunc := setupIdb(t)
+	db, shutdownFunc := setupIdb(t, test.MakeGenesis())
 	defer shutdownFunc()
-
-	err := db.LoadGenesis(test.MakeGenesis())
-	require.NoError(t, err)
 
 	// Rekey account A.
 	{
@@ -85,7 +82,7 @@ func TestClearAccountDataMigrationClosedAccounts(t *testing.T) {
 	}
 
 	// Run migration.
-	err = ClearAccountDataMigration(db, &MigrationState{})
+	err := ClearAccountDataMigration(db, &MigrationState{})
 	assert.NoError(t, err)
 
 	// Check that account A has no account data.
@@ -103,11 +100,8 @@ func TestClearAccountDataMigrationClosedAccounts(t *testing.T) {
 
 // Test that ClearAccountDataMigration() clears account data that was set before account was closed.
 func TestClearAccountDataMigrationClearsReopenedAccounts(t *testing.T) {
-	db, shutdownFunc := setupIdb(t)
+	db, shutdownFunc := setupIdb(t, test.MakeGenesis())
 	defer shutdownFunc()
-
-	err := db.LoadGenesis(test.MakeGenesis())
-	require.NoError(t, err)
 
 	// Create account A.
 	{
@@ -153,7 +147,7 @@ func TestClearAccountDataMigrationClearsReopenedAccounts(t *testing.T) {
 	}
 
 	// Run migration.
-	err = ClearAccountDataMigration(db, &MigrationState{})
+	err := ClearAccountDataMigration(db, &MigrationState{})
 	assert.NoError(t, err)
 
 	// Check that account A is offline and has no account data.
@@ -172,11 +166,8 @@ func TestClearAccountDataMigrationClearsReopenedAccounts(t *testing.T) {
 // Test that ClearAccountDataMigration() does not clear account data because is was updated after
 // account was closed.
 func TestClearAccountDataMigrationDoesNotClear(t *testing.T) {
-	db, shutdownFunc := setupIdb(t)
+	db, shutdownFunc := setupIdb(t, test.MakeGenesis())
 	defer shutdownFunc()
-
-	err := db.LoadGenesis(test.MakeGenesis())
-	require.NoError(t, err)
 
 	// Create account A.
 	{
@@ -214,7 +205,7 @@ func TestClearAccountDataMigrationDoesNotClear(t *testing.T) {
 	}
 
 	// Run migration.
-	err = ClearAccountDataMigration(db, &MigrationState{})
+	err := ClearAccountDataMigration(db, &MigrationState{})
 	assert.NoError(t, err)
 
 	// Check that account A is online and has auth addr and keyreg data.
@@ -233,15 +224,12 @@ func TestClearAccountDataMigrationDoesNotClear(t *testing.T) {
 
 // Test that ClearAccountDataMigration() increments the next migration number.
 func TestClearAccountDataMigrationIncMigrationNum(t *testing.T) {
-	db, shutdownFunc := setupIdb(t)
+	db, shutdownFunc := setupIdb(t, test.MakeGenesis())
 	defer shutdownFunc()
-
-	err := db.LoadGenesis(test.MakeGenesis())
-	require.NoError(t, err)
 
 	// Run migration.
 	state := MigrationState{NextMigration: 13}
-	err = ClearAccountDataMigration(db, &state)
+	err := ClearAccountDataMigration(db, &state)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 14, state.NextMigration)
@@ -250,7 +238,7 @@ func TestClearAccountDataMigrationIncMigrationNum(t *testing.T) {
 }
 
 func TestMakeDeletedNotNullMigration(t *testing.T) {
-	db, shutdownFunc := setupIdb(t)
+	db, shutdownFunc := setupIdb(t, test.MakeGenesis())
 	defer shutdownFunc()
 
 	// Make deleted columns nullable.


### PR DESCRIPTION
## Summary

Load genesis in `setupIdb()` and use `setupIdb()` more.