### PR TITLE
Replace `GetMaxRoundLoaded()` with `GetNextRoundToLoad()`

### DIFF
--- a/idb/dummy/dummy.go
+++ b/idb/dummy/dummy.go
@@ -47,8 +47,8 @@ func (db *dummyIndexerDb) GetMaxRoundAccounted() (round uint64, err error) {
 	return 0, nil
 }
 
-// GetMaxRoundLoaded is part of idb.IndexerDB
-func (db *dummyIndexerDb) GetMaxRoundLoaded() (round uint64, err error) {
+// GetNextRoundToLoad is part of idb.IndexerDB
+func (db *dummyIndexerDb) GetNextRoundToLoad() (round uint64, err error) {
 	return 0, nil
 }
 

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -87,8 +87,7 @@ type IndexerDb interface {
 
 	// GetMaxRoundAccounted returns ErrorNotInitialized if there are no accounted rounds.
 	GetMaxRoundAccounted() (round uint64, err error)
-	// GetMaxRoundLoaded returns ErrorNotInitialized if there are no loaded rounds.
-	GetMaxRoundLoaded() (round uint64, err error)
+	GetNextRoundToLoad() (round uint64, err error)
 	GetSpecialAccounts() (SpecialAccounts, error)
 	GetDefaultFrozen() (defaultFrozen map[uint64]bool, err error)
 

--- a/idb/mocks/IndexerDb.go
+++ b/idb/mocks/IndexerDb.go
@@ -226,8 +226,8 @@ func (_m *IndexerDb) GetMaxRoundAccounted() (uint64, error) {
 	return r0, r1
 }
 
-// GetMaxRoundLoaded provides a mock function with given fields:
-func (_m *IndexerDb) GetMaxRoundLoaded() (uint64, error) {
+// GetNextRoundToLoad provides a mock function with given fields:
+func (_m *IndexerDb) GetNextRoundToLoad() (uint64, error) {
 	ret := _m.Called()
 
 	var r0 uint64

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -399,24 +399,23 @@ func (db *IndexerDb) GetMaxRoundAccounted() (round uint64, err error) {
 	return db.getMaxRoundAccounted(nil)
 }
 
-// GetMaxRoundLoaded is part of idb.IndexerDB
-func (db *IndexerDb) GetMaxRoundLoaded() (round uint64, err error) {
-	var nullableRound sql.NullInt64
-	round = 0
+// GetNextRoundToLoad is part of idb.IndexerDB
+func (db *IndexerDb) GetNextRoundToLoad() (uint64, error) {
 	row := db.db.QueryRow(`SELECT max(round) FROM block_header`)
-	err = row.Scan(&nullableRound)
 
-	if err == sql.ErrNoRows || !nullableRound.Valid {
-		err = idb.ErrorNotInitialized
-		return
+	var nullableRound sql.NullInt64
+	err := row.Scan(&nullableRound)
+	if err == sql.ErrNoRows {
+		return 0, nil
 	}
-
 	if err != nil {
-		return
+		return 0, err
 	}
 
-	round = uint64(nullableRound.Int64)
-	return
+	if !nullableRound.Valid {
+		return 0, nil
+	}
+	return uint64(nullableRound.Int64), nil
 }
 
 // Break the read query so that PostgreSQL doesn't get bogged down

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -415,7 +415,7 @@ func (db *IndexerDb) GetNextRoundToLoad() (uint64, error) {
 	if !nullableRound.Valid {
 		return 0, nil
 	}
-	return uint64(nullableRound.Int64), nil
+	return uint64(nullableRound.Int64 + 1), nil
 }
 
 // Break the read query so that PostgreSQL doesn't get bogged down

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -44,14 +44,15 @@ func TestMaxRoundOnUninitializedDB(t *testing.T) {
 	// When // We request the max round.
 	//////////
 	roundA, errA := db.GetMaxRoundAccounted()
-	roundL, errL := db.GetMaxRoundLoaded()
+	roundL, errL := db.GetNextRoundToLoad()
 
 	//////////
 	// Then // The error message should be set.
 	//////////
 	assert.Equal(t, errA, idb.ErrorNotInitialized)
-	assert.Equal(t, errL, idb.ErrorNotInitialized)
 	assert.Equal(t, uint64(0), roundA)
+
+	require.NoError(t, errL)
 	assert.Equal(t, uint64(0), roundL)
 }
 
@@ -95,14 +96,14 @@ func TestMaxRound(t *testing.T) {
 	//////////
 	roundA, err := pdb.GetMaxRoundAccounted()
 	assert.NoError(t, err)
-	roundL, err := pdb.GetMaxRoundLoaded()
+	roundL, err := pdb.GetNextRoundToLoad()
 	assert.NoError(t, err)
 
 	//////////
 	// Then // There should be no error and we return that there are zero rounds.
 	//////////
 	assert.Equal(t, uint64(123454321), roundA)
-	assert.Equal(t, uint64(543212345), roundL)
+	assert.Equal(t, uint64(543212346), roundL)
 }
 
 func assertAccountAsset(t *testing.T, db *sql.DB, addr sdk_types.Address, assetid uint64, frozen bool, amount uint64) {


### PR DESCRIPTION
Also fixes a bug in `GetMaxRoundLoaded()`.