### PR TITLE
Replace GetMaxRoundAccounted() with GetNextRoundToAccount()

### DIFF
--- a/accounting/rewind.go
+++ b/accounting/rewind.go
@@ -100,7 +100,7 @@ func AccountAtRound(account models.Account, round uint64, db idb.IndexerDb) (acc
 		MaxRound: account.Round,
 	}
 	txns, r := db.Transactions(context.Background(), tf)
-	if r < account.Round {
+	if r <= account.Round {
 		err = ConsistencyError{fmt.Sprintf("queried round r: %d < account.Round: %d", r, account.Round)}
 		return
 	}
@@ -178,7 +178,7 @@ func AccountAtRound(account models.Account, round uint64, db idb.IndexerDb) (acc
 		tf.MinRound = 0
 		tf.Limit = 1
 		txns, r = db.Transactions(context.Background(), tf)
-		if r < round {
+		if r <= round {
 			err = ConsistencyError{
 				fmt.Sprintf("queried round r: %d < requested round round: %d", r, round)}
 			return

--- a/accounting/rewind_test.go
+++ b/accounting/rewind_test.go
@@ -48,7 +48,7 @@ func TestBasic(t *testing.T) {
 
 	db := &mocks.IndexerDb{}
 	db.On("GetSpecialAccounts").Return(idb.SpecialAccounts{}, nil)
-	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(8))
+	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(9))
 
 	account, err := AccountAtRound(account, 6, db)
 	assert.NoError(t, err)
@@ -70,7 +70,7 @@ func TestStaleTransactions1(t *testing.T) {
 
 	db := &mocks.IndexerDb{}
 	db.On("GetSpecialAccounts").Return(idb.SpecialAccounts{}, nil)
-	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(7)).Once()
+	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(8)).Once()
 
 	account, err := AccountAtRound(account, 6, db)
 	assert.True(t, errors.As(err, &ConsistencyError{}), "err: %v", err)
@@ -107,8 +107,8 @@ func TestStaleTransactions2(t *testing.T) {
 
 	db := &mocks.IndexerDb{}
 	db.On("GetSpecialAccounts").Return(idb.SpecialAccounts{}, nil)
-	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(8)).Once()
-	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(5)).Once()
+	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(9)).Once()
+	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(6)).Once()
 
 	account, err := AccountAtRound(account, 6, db)
 	assert.True(t, errors.As(err, &ConsistencyError{}), "err: %v", err)

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -490,7 +490,7 @@ func TestFetchAccountsRewindRoundTooLarge(t *testing.T) {
 	var outCh <-chan idb.AccountRow = ch
 
 	db := &mocks.IndexerDb{}
-	db.On("GetAccounts", mock.Anything, mock.Anything).Return(outCh, uint64(7)).Once()
+	db.On("GetAccounts", mock.Anything, mock.Anything).Return(outCh, uint64(8)).Once()
 
 	si := ServerImplementation{
 		EnableAddressSearchRoundRewind: true,

--- a/idb/dummy/dummy.go
+++ b/idb/dummy/dummy.go
@@ -42,8 +42,8 @@ func (db *dummyIndexerDb) LoadGenesis(genesis types.Genesis) (err error) {
 	return nil
 }
 
-// GetMaxRoundAccounted is part of idb.IndexerDB
-func (db *dummyIndexerDb) GetMaxRoundAccounted() (round uint64, err error) {
+// GetNextRoundToAccount is part of idb.IndexerDB
+func (db *dummyIndexerDb) GetNextRoundToAccount() (round uint64, err error) {
 	return 0, nil
 }
 

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -85,8 +85,8 @@ type IndexerDb interface {
 
 	LoadGenesis(genesis types.Genesis) (err error)
 
-	// GetMaxRoundAccounted returns ErrorNotInitialized if there are no accounted rounds.
-	GetMaxRoundAccounted() (round uint64, err error)
+	// GetNextRoundToAccount returns ErrorNotInitialized if genesis is not loaded.
+	GetNextRoundToAccount() (round uint64, err error)
 	GetNextRoundToLoad() (round uint64, err error)
 	GetSpecialAccounts() (SpecialAccounts, error)
 	GetDefaultFrozen() (defaultFrozen map[uint64]bool, err error)
@@ -98,8 +98,8 @@ type IndexerDb interface {
 
 	GetBlock(ctx context.Context, round uint64, options GetBlockOptions) (blockHeader types.BlockHeader, transactions []TxnRow, err error)
 
-	// The next multiple functions return a channel with results as well as the latest round
-	// accounted.
+	// The next multiple functions return a channel with results as well as the next round
+	// to account.
 	Transactions(ctx context.Context, tf TransactionFilter) (<-chan TxnRow, uint64)
 	GetAccounts(ctx context.Context, opts AccountQueryOptions) (<-chan AccountRow, uint64)
 	Assets(ctx context.Context, filter AssetsQuery) (<-chan AssetRow, uint64)
@@ -472,11 +472,11 @@ func b32np(data []byte) string {
 
 // Health is the response object that IndexerDb objects need to return from the Health method.
 type Health struct {
-	Data        *map[string]interface{} `json:"data,omitempty"`
-	Round       uint64                  `json:"round"`
-	IsMigrating bool                    `json:"is-migrating"`
-	DBAvailable bool                    `json:"db-available"`
-	Error       string                  `json:"error"`
+	Data               *map[string]interface{}
+	NextRoundToAccount uint64
+	IsMigrating        bool
+	DBAvailable        bool
+	Error              string
 }
 
 // SpecialAccounts are the accounts which have special accounting rules.

--- a/idb/mocks/IndexerDb.go
+++ b/idb/mocks/IndexerDb.go
@@ -205,8 +205,8 @@ func (_m *IndexerDb) GetDefaultFrozen() (map[uint64]bool, error) {
 	return r0, r1
 }
 
-// GetMaxRoundAccounted provides a mock function with given fields:
-func (_m *IndexerDb) GetMaxRoundAccounted() (uint64, error) {
+// GetNextRoundToAccount provides a mock function with given fields:
+func (_m *IndexerDb) GetNextRoundToAccount() (uint64, error) {
 	ret := _m.Called()
 
 	var r0 uint64

--- a/idb/postgres/postgres_migrations_integration_test.go
+++ b/idb/postgres/postgres_migrations_integration_test.go
@@ -302,3 +302,114 @@ func TestMakeDeletedNotNullMigration(t *testing.T) {
 		assert.Equal(t, false, *deleted)
 	}
 }
+
+func TestMaxRoundAccountedMigrationAccountRound0(t *testing.T) {
+	_, connStr, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+	db, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+
+	round := int64(0)
+	importstate := importState{
+		AccountRound: &round,
+	}
+	err = db.setImportState(nil, importstate)
+	require.NoError(t, err)
+
+	migrationState := MigrationState{NextMigration: 4}
+	err = MaxRoundAccountedMigration(db, &migrationState)
+	require.NoError(t, err)
+
+	importstate, err = db.getImportState(nil)
+	require.NoError(t, err)
+
+	nextRound := uint64(0)
+	importstateExpected := importState{
+		NextRoundToAccount: &nextRound,
+	}
+	assert.Equal(t, importstateExpected, importstate)
+
+	// Check the next migration number.
+	assert.Equal(t, 5, migrationState.NextMigration)
+	newNum := nextMigrationNum(t, db)
+	assert.Equal(t, 5, newNum)
+}
+
+func TestMaxRoundAccountedMigrationAccountRoundPositive(t *testing.T) {
+	_, connStr, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+	db, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+
+	round := int64(2)
+	importstate := importState{
+		AccountRound: &round,
+	}
+	err = db.setImportState(nil, importstate)
+	require.NoError(t, err)
+
+	migrationState := MigrationState{NextMigration: 4}
+	err = MaxRoundAccountedMigration(db, &migrationState)
+	require.NoError(t, err)
+
+	importstate, err = db.getImportState(nil)
+	require.NoError(t, err)
+
+	nextRound := uint64(3)
+	importstateExpected := importState{
+		NextRoundToAccount: &nextRound,
+	}
+	assert.Equal(t, importstateExpected, importstate)
+
+	// Check the next migration number.
+	assert.Equal(t, 5, migrationState.NextMigration)
+	newNum := nextMigrationNum(t, db)
+	assert.Equal(t, 5, newNum)
+}
+
+func TestMaxRoundAccountedMigrationReadNewFormat(t *testing.T) {
+	_, connStr, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+	db, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+
+	nextRound := uint64(2)
+	importstate := importState{
+		NextRoundToAccount: &nextRound,
+	}
+	err = db.setImportState(nil, importstate)
+	require.NoError(t, err)
+
+	migrationState := MigrationState{NextMigration: 4}
+	err = MaxRoundAccountedMigration(db, &migrationState)
+	require.NoError(t, err)
+
+	importstateRead, err := db.getImportState(nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, importstate, importstateRead)
+
+	// Check the next migration number.
+	assert.Equal(t, 5, migrationState.NextMigration)
+	newNum := nextMigrationNum(t, db)
+	assert.Equal(t, 5, newNum)
+}
+
+func TestMaxRoundAccountedMigrationUninitialized(t *testing.T) {
+	_, connStr, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+	db, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+
+	migrationState := MigrationState{NextMigration: 4}
+	err = MaxRoundAccountedMigration(db, &migrationState)
+	require.NoError(t, err)
+
+	_, err = db.getImportState(nil)
+	assert.Equal(t, idb.ErrorNotInitialized, err)
+
+	// Check the next migration number.
+	assert.Equal(t, 5, migrationState.NextMigration)
+	newNum := nextMigrationNum(t, db)
+	assert.Equal(t, 5, newNum)
+}


### PR DESCRIPTION
## Summary

Currently the import state stores the last accounted round which creates ambiguities: we cannot distinguish between the state before accounting round 0 and after. This works because block 0 contains no transactions, and we don't actually do accounting for it. However, with one phase import it will be a problem.

This PR changes the import state to store the next round to account instead, `GetMaxRoundAccounted()` is replaced with `GetNextRoundToAccount()`, and a migration is added. Since older migrations run before that, `GetNextRoundToAccount()` still supports the old import state format. In most cases, however, `CommitRoundAccounting()` will upgrade import state to the new format before the migration.

## Test Plan

Wrote additional tests for `GetNextRoundToAccount()` to cover the old import state format, and added tests for the new migration.