### PR TITLE
Import performance test runner

### DIFF
--- a/cmd/block-generator/daemon.go
+++ b/cmd/block-generator/daemon.go
@@ -20,8 +20,8 @@ func init() {
 		Short: "Start the generator daemon in standalone mode.",
 		Run: func(cmd *cobra.Command, args []string) {
 			addr := fmt.Sprintf(":%d", port)
-			_, done := generator.StartServer(configFile, addr)
-			<-done
+			srv := generator.MakeServer(configFile, addr)
+			srv.ListenAndServe()
 		},
 	}
 

--- a/cmd/block-generator/daemon.go
+++ b/cmd/block-generator/daemon.go
@@ -21,7 +21,7 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			addr := fmt.Sprintf(":%d", port)
 			_, done := generator.StartServer(configFile, addr)
-			<- done
+			<-done
 		},
 	}
 

--- a/cmd/block-generator/daemon.go
+++ b/cmd/block-generator/daemon.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"math/rand"
 
 	"github.com/spf13/cobra"
@@ -18,7 +19,8 @@ func init() {
 		Use:   "daemon",
 		Short: "Start the generator daemon in standalone mode.",
 		Run: func(cmd *cobra.Command, args []string) {
-			_, done := generator.StartServer(configFile, port)
+			addr := fmt.Sprintf(":%d", port)
+			_, done := generator.StartServer(configFile, addr)
 			<- done
 		},
 	}

--- a/cmd/block-generator/daemon.go
+++ b/cmd/block-generator/daemon.go
@@ -1,10 +1,9 @@
 package main
 
 import (
-	"math/rand"
-
 	"github.com/algorand/indexer/cmd/block-generator/generator"
 	"github.com/spf13/cobra"
+	"math/rand"
 )
 
 const configFileName = "block_generator_config"
@@ -19,7 +18,8 @@ func init() {
 		Use:   "daemon",
 		Short: "Start the generator daemon in standalone mode.",
 		Run: func(cmd *cobra.Command, args []string) {
-			generator.StartServer(configFile, port)
+			_, done := generator.StartServer(configFile, int(port))
+			<- done
 		},
 	}
 

--- a/cmd/block-generator/daemon.go
+++ b/cmd/block-generator/daemon.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"github.com/algorand/indexer/cmd/block-generator/generator"
-	"github.com/spf13/cobra"
 	"math/rand"
-)
 
-const configFileName = "block_generator_config"
+	"github.com/spf13/cobra"
+
+	"github.com/algorand/indexer/cmd/block-generator/generator"
+)
 
 func init() {
 	rand.Seed(12345)
@@ -18,7 +18,7 @@ func init() {
 		Use:   "daemon",
 		Short: "Start the generator daemon in standalone mode.",
 		Run: func(cmd *cobra.Command, args []string) {
-			_, done := generator.StartServer(configFile, int(port))
+			_, done := generator.StartServer(configFile, port)
 			<- done
 		},
 	}

--- a/cmd/block-generator/generator/generate.go
+++ b/cmd/block-generator/generator/generate.go
@@ -105,7 +105,7 @@ func MakeGenerator(config GenerationConfig) (Generator, error) {
 		rewardsResidue:            0,
 		rewardsRate:               0,
 		rewardsRecalculationRound: 0,
-		reportData:                make(map[txTypeID]txData),
+		reportData:                make(map[txTypeID]TxData),
 	}
 
 	gen.feeSink[31] = 1
@@ -195,7 +195,7 @@ type generator struct {
 	assetTxWeights     []float32
 
 	// Reporting information from transaction type to data
-	reportData map[txTypeID]txData
+	reportData map[txTypeID]TxData
 }
 
 type assetData struct {
@@ -212,7 +212,7 @@ type assetHolding struct {
 	balance   uint64
 }
 
-type txData struct {
+type TxData struct {
 	GenerationTimeMilli time.Duration `json:"generation_time_milli"`
 	GenerationCount     uint64        `json:"num_generated"`
 }

--- a/cmd/block-generator/generator/generate.go
+++ b/cmd/block-generator/generator/generate.go
@@ -341,7 +341,6 @@ func (g *generator) WriteBlock(output io.Writer, round uint64) {
 	g.timestamp += consensusTimeMilli
 	g.round++
 
-	fmt.Println(g.txnCounter)
 	output.Write(msgpack.Encode(cert))
 }
 

--- a/cmd/block-generator/generator/generate_test.go
+++ b/cmd/block-generator/generator/generate_test.go
@@ -87,7 +87,7 @@ func TestAssetOptinEveryAccountOverride(t *testing.T) {
 
 	// Opt all the accounts in, this also verifies that no account is opted in twice
 	var txn sdk_types.Transaction
-	var actual txTypeID
+	var actual TxTypeID
 	for i := 2; uint64(i) <= g.numAccounts; i++ {
 		actual, txn = g.generateAssetTxnInternal(assetOptin, sp, 0)
 		require.Equal(t, assetOptin, actual)

--- a/cmd/block-generator/generator/server.go
+++ b/cmd/block-generator/generator/server.go
@@ -31,15 +31,12 @@ func initializeConfigFile(configFile string) (config GenerationConfig, err error
 }
 
 // StartServer configures http handlers then runs ListanAndServe. Returns the http server and a done channel.
-func StartServer(configFile string, addr string) (*http.Server, <- chan struct{}){
+func StartServer(configFile string, addr string) (*http.Server, <-chan struct{}) {
 	config, err := initializeConfigFile(configFile)
 	util.MaybeFail(err, "problem loading config file. Use '--config' or create a config file.")
 
 	gen, err := MakeGenerator(config)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to make generator with config file '%s': %v", configFile, err)
-		os.Exit(1)
-	}
+	util.MaybeFail(err, "Failed to make generator with config file '%s'", configFile)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", help)
@@ -48,7 +45,7 @@ func StartServer(configFile string, addr string) (*http.Server, <- chan struct{}
 	mux.HandleFunc("/report", getReportHandler(gen))
 
 	srv := &http.Server{
-		Addr: addr,
+		Addr:    addr,
 		Handler: mux,
 	}
 
@@ -58,8 +55,7 @@ func StartServer(configFile string, addr string) (*http.Server, <- chan struct{}
 
 		// always returns error. ErrServerClosed on graceful close
 		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-			// unexpected error. port in use?
-			fmt.Errorf("ListenAndServe()\n: %v", err)
+			util.MaybeFail(err, "ListenAndServe() failure to start with config file '%s'", configFile)
 		}
 	}()
 

--- a/cmd/block-generator/generator/server.go
+++ b/cmd/block-generator/generator/server.go
@@ -2,10 +2,11 @@ package generator
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/spf13/viper"
 
 	"github.com/algorand/indexer/util"
 )
@@ -30,7 +31,7 @@ func initializeConfigFile(configFile string) (config GenerationConfig, err error
 }
 
 // StartServer configures http handlers then runs ListanAndServe. Returns the http server and a done channel.
-func StartServer(configFile string, port int) (*http.Server, <- chan struct{}){
+func StartServer(configFile string, port uint64) (*http.Server, <- chan struct{}){
 	config, err := initializeConfigFile(configFile)
 	util.MaybeFail(err, "problem loading config file. Use '--config' or create a config file.")
 

--- a/cmd/block-generator/generator/server.go
+++ b/cmd/block-generator/generator/server.go
@@ -31,7 +31,7 @@ func initializeConfigFile(configFile string) (config GenerationConfig, err error
 }
 
 // StartServer configures http handlers then runs ListanAndServe. Returns the http server and a done channel.
-func StartServer(configFile string, port uint64) (*http.Server, <- chan struct{}){
+func StartServer(configFile string, addr string) (*http.Server, <- chan struct{}){
 	config, err := initializeConfigFile(configFile)
 	util.MaybeFail(err, "problem loading config file. Use '--config' or create a config file.")
 
@@ -47,9 +47,8 @@ func StartServer(configFile string, port uint64) (*http.Server, <- chan struct{}
 	mux.HandleFunc("/genesis", getGenesisHandler(gen))
 	mux.HandleFunc("/report", getReportHandler(gen))
 
-	portStr := fmt.Sprintf(":%d", port)
 	srv := &http.Server{
-		Addr: portStr,
+		Addr: addr,
 		Handler: mux,
 	}
 

--- a/cmd/block-generator/runner.go
+++ b/cmd/block-generator/runner.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-"math/rand"
+	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/spf13/cobra"
 
-"github.com/algorand/indexer/cmd/block-generator/runner"
+	"github.com/algorand/indexer/cmd/block-generator/runner"
 )
 
 func init() {
@@ -31,13 +32,15 @@ func init() {
 				RunDuration:              runDuration,
 				ReportDirectory:          reportDirectory,
 			}
-			runner.Run(runnerArgs)
+			if err := runner.Run(runnerArgs); err != nil {
+				fmt.Println(err)
+			}
 		},
 	}
 
 	runnerCmd.Flags().StringVarP(&scenarioDir, "scenario", "s", "", "Directory containing scenarios, or specific scenario file.")
 	runnerCmd.Flags().StringVarP(&indexerBinary, "indexer-binary", "i", "", "Path to indexer binary.")
-	runnerCmd.Flags().Uint64VarP(&indexerPort, "indexer-port", "p", 4010, "Port to start the server at.")
+	runnerCmd.Flags().Uint64VarP(&indexerPort, "indexer-port", "p", 4010, "Port to start the server at. This is useful if you have a prometheus server for collecting additional data.")
 	runnerCmd.Flags().StringVarP(&postgresConnectionString, "postgres-connection-string", "c", "", "Postgres connection string.")
 	runnerCmd.Flags().DurationVarP(&runDuration, "test-duration", "d", 5 * time.Minute, "Duration to use for each scenario.")
 	runnerCmd.Flags().StringVarP(&reportDirectory, "report-directory", "r", "", "Location to place test reports.")

--- a/cmd/block-generator/runner.go
+++ b/cmd/block-generator/runner.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+"math/rand"
+	"time"
+
+	"github.com/spf13/cobra"
+
+"github.com/algorand/indexer/cmd/block-generator/runner"
+)
+
+func init() {
+	rand.Seed(12345)
+
+	var scenarioDir string
+	var indexerBinary string
+	var indexerPort uint64
+	var postgresConnectionString string
+	var runDuration time.Duration
+	var reportDirectory string
+
+	var runnerCmd = &cobra.Command{
+		Use:   "runner",
+		Short: "Run test suite and collect results.",
+		Run: func(cmd *cobra.Command, args []string) {
+			runnerArgs := runner.RunnerArgs{
+				Path:                     scenarioDir,
+				IndexerBinary:            indexerBinary,
+				IndexerPort:              indexerPort,
+				PostgresConnectionString: postgresConnectionString,
+				RunDuration:              runDuration,
+				ReportDirectory:          reportDirectory,
+			}
+			runner.Run(runnerArgs)
+		},
+	}
+
+	runnerCmd.Flags().StringVarP(&scenarioDir, "scenario", "s", "", "Directory containing scenarios, or specific scenario file.")
+	runnerCmd.Flags().StringVarP(&indexerBinary, "indexer-binary", "i", "", "Path to indexer binary.")
+	runnerCmd.Flags().Uint64VarP(&indexerPort, "indexer-port", "p", 4010, "Port to start the server at.")
+	runnerCmd.Flags().StringVarP(&postgresConnectionString, "postgres-connection-string", "c", "", "Postgres connection string.")
+	runnerCmd.Flags().DurationVarP(&runDuration, "test-duration", "d", 5 * time.Minute, "Duration to use for each scenario.")
+	runnerCmd.Flags().StringVarP(&reportDirectory, "report-directory", "r", "", "Location to place test reports.")
+
+	runnerCmd.MarkFlagRequired("scenario")
+	runnerCmd.MarkFlagRequired("indexer-binary")
+	runnerCmd.MarkFlagRequired("postgres-connection-string")
+	runnerCmd.MarkFlagRequired("report-directory")
+
+	rootCmd.AddCommand(runnerCmd)
+}

--- a/cmd/block-generator/runner.go
+++ b/cmd/block-generator/runner.go
@@ -12,38 +12,24 @@ import (
 
 func init() {
 	rand.Seed(12345)
-
-	var scenarioDir string
-	var indexerBinary string
-	var indexerPort uint64
-	var postgresConnectionString string
-	var runDuration time.Duration
-	var reportDirectory string
+	var runnerArgs runner.Args
 
 	var runnerCmd = &cobra.Command{
 		Use:   "runner",
 		Short: "Run test suite and collect results.",
 		Run: func(cmd *cobra.Command, args []string) {
-			runnerArgs := runner.Args{
-				Path:                     scenarioDir,
-				IndexerBinary:            indexerBinary,
-				IndexerPort:              indexerPort,
-				PostgresConnectionString: postgresConnectionString,
-				RunDuration:              runDuration,
-				ReportDirectory:          reportDirectory,
-			}
 			if err := runner.Run(runnerArgs); err != nil {
 				fmt.Println(err)
 			}
 		},
 	}
 
-	runnerCmd.Flags().StringVarP(&scenarioDir, "scenario", "s", "", "Directory containing scenarios, or specific scenario file.")
-	runnerCmd.Flags().StringVarP(&indexerBinary, "indexer-binary", "i", "", "Path to indexer binary.")
-	runnerCmd.Flags().Uint64VarP(&indexerPort, "indexer-port", "p", 4010, "Port to start the server at. This is useful if you have a prometheus server for collecting additional data.")
-	runnerCmd.Flags().StringVarP(&postgresConnectionString, "postgres-connection-string", "c", "", "Postgres connection string.")
-	runnerCmd.Flags().DurationVarP(&runDuration, "test-duration", "d", 5*time.Minute, "Duration to use for each scenario.")
-	runnerCmd.Flags().StringVarP(&reportDirectory, "report-directory", "r", "", "Location to place test reports.")
+	runnerCmd.Flags().StringVarP(&runnerArgs.Path, "scenario", "s", "", "Directory containing scenarios, or specific scenario file.")
+	runnerCmd.Flags().StringVarP(&runnerArgs.IndexerBinary, "indexer-binary", "i", "", "Path to indexer binary.")
+	runnerCmd.Flags().Uint64VarP(&runnerArgs.IndexerPort, "indexer-port", "p", 4010, "Port to start the server at. This is useful if you have a prometheus server for collecting additional data.")
+	runnerCmd.Flags().StringVarP(&runnerArgs.PostgresConnectionString, "postgres-connection-string", "c", "", "Postgres connection string.")
+	runnerCmd.Flags().DurationVarP(&runnerArgs.RunDuration, "test-duration", "d", 5*time.Minute, "Duration to use for each scenario.")
+	runnerCmd.Flags().StringVarP(&runnerArgs.ReportDirectory, "report-directory", "r", "", "Location to place test reports.")
 
 	runnerCmd.MarkFlagRequired("scenario")
 	runnerCmd.MarkFlagRequired("indexer-binary")

--- a/cmd/block-generator/runner.go
+++ b/cmd/block-generator/runner.go
@@ -42,7 +42,7 @@ func init() {
 	runnerCmd.Flags().StringVarP(&indexerBinary, "indexer-binary", "i", "", "Path to indexer binary.")
 	runnerCmd.Flags().Uint64VarP(&indexerPort, "indexer-port", "p", 4010, "Port to start the server at. This is useful if you have a prometheus server for collecting additional data.")
 	runnerCmd.Flags().StringVarP(&postgresConnectionString, "postgres-connection-string", "c", "", "Postgres connection string.")
-	runnerCmd.Flags().DurationVarP(&runDuration, "test-duration", "d", 5 * time.Minute, "Duration to use for each scenario.")
+	runnerCmd.Flags().DurationVarP(&runDuration, "test-duration", "d", 5*time.Minute, "Duration to use for each scenario.")
 	runnerCmd.Flags().StringVarP(&reportDirectory, "report-directory", "r", "", "Location to place test reports.")
 
 	runnerCmd.MarkFlagRequired("scenario")

--- a/cmd/block-generator/runner.go
+++ b/cmd/block-generator/runner.go
@@ -24,7 +24,7 @@ func init() {
 		Use:   "runner",
 		Short: "Run test suite and collect results.",
 		Run: func(cmd *cobra.Command, args []string) {
-			runnerArgs := runner.RunnerArgs{
+			runnerArgs := runner.Args{
 				Path:                     scenarioDir,
 				IndexerBinary:            indexerBinary,
 				IndexerPort:              indexerPort,

--- a/cmd/block-generator/runner/metrics_collector.go
+++ b/cmd/block-generator/runner/metrics_collector.go
@@ -24,14 +24,14 @@ type Entry struct {
 
 // Collect fetches the metrics.
 func (r *MetricsCollector) Collect(prefix string) error {
-	metricsStr, err := r.getMetrics(prefix)
+	metrics, err := r.getMetrics(prefix)
 	if err != nil {
 		return err
 	}
 
-	if len(metricsStr) > 0 {
+	if len(metrics) > 0 {
 		entry := Entry{Timestamp: time.Now()}
-		for _, str := range metricsStr {
+		for _, str := range metrics {
 			entry.Data = append(entry.Data, str)
 		}
 		r.Data = append(r.Data, entry)

--- a/cmd/block-generator/runner/metrics_collector.go
+++ b/cmd/block-generator/runner/metrics_collector.go
@@ -30,9 +30,9 @@ func (r *MetricsCollector) Collect(prefix string) error {
 	}
 
 	if len(metrics) > 0 {
-		entry := Entry{Timestamp: time.Now()}
-		for _, str := range metrics {
-			entry.Data = append(entry.Data, str)
+		entry := Entry{
+			Timestamp: time.Now(),
+			Data: metrics,
 		}
 		r.Data = append(r.Data, entry)
 	}

--- a/cmd/block-generator/runner/metrics_collector.go
+++ b/cmd/block-generator/runner/metrics_collector.go
@@ -1,0 +1,69 @@
+package runner
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// MetricsCollector queries a /metrics endpoint for prometheus style metrics and saves metrics matching a pattern.
+type MetricsCollector struct {
+	// MetricsURL where metrics can be queried.
+	MetricsURL string
+	// Data is all of the results.
+	Data []Entry
+}
+
+// Entry is the raw data pulled from the endpoint along with a timestamp.
+type Entry struct {
+	Timestamp time.Time
+	Data      []string
+}
+
+// Collect fetches the metrics.
+func (r *MetricsCollector) Collect(prefix string) error {
+	metricsStr, err := r.getMetrics(prefix)
+	if err != nil {
+		return err
+	}
+
+	if len(metricsStr) > 0 {
+		entry := Entry{Timestamp: time.Now()}
+		for _, str := range metricsStr {
+			entry.Data = append(entry.Data, str)
+		}
+		r.Data = append(r.Data, entry)
+	}
+
+	return nil
+}
+
+func (r MetricsCollector) getMetrics(prefix string) (result []string, err error) {
+	resp, err := http.Get(r.MetricsURL)
+	if err != nil {
+		err = fmt.Errorf("unable to read metrics url '%s'", r.MetricsURL)
+		return
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		str := scanner.Text()
+
+		if strings.HasPrefix(str, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(str, prefix) {
+			result = append(result, str)
+		}
+	}
+
+	if scanner.Err() != nil {
+		err = fmt.Errorf("problem reading metrics response: %w", scanner.Err())
+	}
+
+	return
+}

--- a/cmd/block-generator/runner/metrics_collector.go
+++ b/cmd/block-generator/runner/metrics_collector.go
@@ -32,7 +32,7 @@ func (r *MetricsCollector) Collect(prefix string) error {
 	if len(metrics) > 0 {
 		entry := Entry{
 			Timestamp: time.Now(),
-			Data: metrics,
+			Data:      metrics,
 		}
 		r.Data = append(r.Data, entry)
 	}

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -1,13 +1,20 @@
 package runner
 
 import (
+	"bytes"
 	"context"
+	"database/sql"
 	"fmt"
-	"github.com/algorand/indexer/cmd/block-generator/generator"
+	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"time"
 
+	// Load the postgres sql.DB implementation
+	_ "github.com/lib/pq"
+
+	"github.com/algorand/indexer/cmd/block-generator/generator"
 	"github.com/algorand/indexer/util"
 )
 
@@ -42,24 +49,102 @@ func Run(args RunnerArgs) error {
 	return args.run()
 }
 
+func startGenerator(configFile string, port uint64) func() error {
+	// Start generator.
+	server, done := generator.StartServer(configFile, port)
+
+	return func() error {
+		if err := server.Shutdown(context.Background()); err != nil {
+			panic(err) // failure/timeout shutting down the server gracefully
+		}
+
+		// Wait for graceful shutdown or crash.
+		select {
+		case <- done:
+			// continue
+			return nil
+		case <- time.After(10 * time.Second):
+			return fmt.Errorf("failed to gracefully shutdown generator")
+		}
+	}
+}
+
+func startIndexer(indexerBinary string, algodPort uint64, indexerPort uint64, postgresConnectionString string) (func() error, error) {
+	{
+		db, err := sql.Open("postgres", postgresConnectionString)
+		if err != nil {
+			return nil, fmt.Errorf("postgres connection string did not work: %w", err)
+		}
+		db.Exec(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`)
+		db.Close()
+	}
+
+	time.Sleep(250 * time.Millisecond)
+
+	algodNet := fmt.Sprintf("localhost:%d", algodPort)
+	indexerNet := fmt.Sprintf("localhost:%d", indexerPort)
+	cmd := exec.Command(
+		indexerBinary,
+		"daemon",
+		"--algod-net", algodNet,
+		"--algod-token", "secure-token-here",
+		"--metrics-mode", "VERBOSE",
+		"--postgres", postgresConnectionString,
+		"--server", indexerNet)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failure calling Start(): %w", err)
+	}
+
+	time.Sleep(250 * time.Millisecond)
+	resp, err := http.Get(fmt.Sprintf("http://%s/health", indexerNet))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "stdout:\n%s\n", stdout.String())
+		fmt.Fprintf(os.Stderr, "stderr:\n%s\n", stderr.String())
+		return nil, fmt.Errorf("the process failed to start properly, health endpoint query failed")
+	}
+	resp.Body.Close()
+
+	return func() error {
+		if err := cmd.Process.Kill(); err != nil {
+			return fmt.Errorf("failed to kill indexer process: %w", err)
+		}
+
+		// Clear postgres DB
+		return nil
+	}, nil
+}
+
 func (r *RunnerArgs) run() error {
-	port := 11112
-	server, done := generator.StartServer(r.Path, port)
+	port := uint64(11112)
+
+	// Start services
+	generatorShutdownFunc := startGenerator(r.Path, port)
+	indexerShutdownFunc, err := startIndexer(r.IndexerBinary, port, r.IndexerPort, r.PostgresConnectionString)
+	if err != nil {
+		return fmt.Errorf("failed to start indexer: %w", err)
+	}
 
 	time.Sleep(r.RunDuration)
 
-	if err := server.Shutdown(context.Background()); err != nil {
-		panic(err) // failure/timeout shutting down the server gracefully
+	// Collect results
+
+	// Shutdown generator.
+	if err := generatorShutdownFunc(); err != nil {
+		return err
 	}
 
-	// Wait for graceful shutdown or crash.
-	select {
-		case <- done:
-			// continue
-		case <- time.After(10 * time.Second):
-			fmt.Println("Failed to gracefully shutdown generator.")
-			os.Exit(1)
+	// Shutdown indexer
+	if err := indexerShutdownFunc(); err != nil {
+		return err
 	}
+
+	// Delete DB
 
 	return nil
 }

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -135,7 +135,7 @@ func (r *Args) runTest(indexerURL string, generatorURL string) error {
 		if metric == "genesis" {
 			continue
 		}
-		str := fmt.Sprintf("transaction_count_%s:%d\n", metric, entry.GenerationCount)
+		str := fmt.Sprintf("transaction_%s_total:%d\n", metric, entry.GenerationCount)
 		if _, err := report.WriteString(str); err != nil {
 			return fmt.Errorf("unable to write transaction_count metric: %w", err)
 		}
@@ -164,20 +164,20 @@ func (r *Args) runTest(indexerURL string, generatorURL string) error {
 
 		msg := fmt.Sprintf("%s:%f\n", key, rate)
 		if _, err := out.WriteString(msg); err != nil {
-			return fmt.Errorf("unable to write metric '%s': %w", "starting_rate", err)
+			return fmt.Errorf("unable to write metric '%s': %w", key, err)
 		}
 		return nil
 	}
 
 	// Record a rate from one of the first data points.
 	if len(collector.Data) > 5 {
-		if err := record(2, "starting_rate", report); err != nil {
+		if err := record(2, "starting_block_import_duration_average_seconds", report); err != nil {
 			return err
 		}
 	}
 
 	// Also record the final one.
-	if err := record(uint64(len(collector.Data)-1), "total_rate", report); err != nil {
+	if err := record(uint64(len(collector.Data)-1), "final_import_duration_average_second", report); err != nil {
 		return err
 	}
 
@@ -239,7 +239,7 @@ func startIndexer(indexerBinary string, algodNet string, indexerNet string, post
 
 	// Ensure that the health endpoint can be queried.
 	// The service should start very quickly because the DB is empty.
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(5 * time.Second)
 	resp, err := http.Get(fmt.Sprintf("http://%s/health", indexerNet))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "stdout:\n%s\n", stdout.String())

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -126,8 +126,7 @@ func (r *Args) runTest(indexerURL string, generatorURL string) error {
 		return fmt.Errorf("the process failed to start properly, health endpoint query failed")
 	}
 	defer resp.Body.Close()
-	type GeneratorReport map[string]generator.TxData
-	var generatorReport GeneratorReport
+	var generatorReport generator.Report
 	if err := json.NewDecoder(resp.Body).Decode(&generatorReport); err != nil {
 		return fmt.Errorf("problem decoding generator report: %w", err)
 	}
@@ -144,7 +143,7 @@ func (r *Args) runTest(indexerURL string, generatorURL string) error {
 
 	// Helper to record the import rate.
 	record := func(idx uint64, key string, out *os.File) error {
-		d := collector.Data[2].Data
+		d := collector.Data[idx].Data
 		sum := 0.0
 		count := 0.0
 
@@ -178,7 +177,7 @@ func (r *Args) runTest(indexerURL string, generatorURL string) error {
 	}
 
 	// Also record the final one.
-	if err := record(uint64(len(collector.Data) - 1), "total_rate", report); err != nil {
+	if err := record(uint64(len(collector.Data)-1), "total_rate", report); err != nil {
 		return err
 	}
 

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -135,7 +135,9 @@ func (r *Args) runTest(indexerURL string, generatorURL string) error {
 	}
 
 	// Collect results.
-	durationStr := fmt.Sprintf("test_duration_seconds:%d\n", uint64(r.RunDuration.Seconds()))
+	durationStr := fmt.Sprintf("test_duration_seconds:%d\ntest_duration_actual_seconds:%f\n",
+		uint64(r.RunDuration.Seconds()),
+		time.Since(start).Seconds())
 	if _, err := report.WriteString(durationStr); err != nil {
 		return fmt.Errorf("unable to write duration metric: %w", err)
 	}

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -36,7 +36,7 @@ type Args struct {
 // The test will run against the generator configuration file specified by 'args.Path'.
 // If 'args.Path' is a directory it should contain generator configuration files, a test will run using each file.
 func Run(args Args) error {
-	if _, err := os.Stat(args.ReportDirectory); os.IsExist(err) {
+	if _, err := os.Stat(args.ReportDirectory); !os.IsNotExist(err) {
 		return fmt.Errorf("report directory '%s' already exists", args.ReportDirectory)
 	}
 	os.Mkdir(args.ReportDirectory, os.ModeDir|os.ModePerm)

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -1,0 +1,65 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"github.com/algorand/indexer/cmd/block-generator/generator"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/algorand/indexer/util"
+)
+
+// RunnerArgs are all the things needed to run a performance test.
+type RunnerArgs struct {
+	// Path is a directory when passed to RunBatch, otherwise a file path.
+	Path string
+	IndexerBinary string
+	IndexerPort uint64
+	PostgresConnectionString string
+	RunDuration time.Duration
+	ReportDirectory string
+
+	indexerPort uint64
+}
+
+// Run is a public helper run the tests.
+func Run(args RunnerArgs) error {
+	stat, err := os.Stat(args.Path)
+	util.MaybeFail(err, "Unable to check path.")
+
+	// Batch mode
+	if stat.IsDir() {
+		return filepath.Walk(args.Path, func(path string, info os.FileInfo, err error) error {
+			runnerArgs := args
+			runnerArgs.Path = path
+			return runnerArgs.run()
+		})
+	}
+
+	// Single file mode
+	return args.run()
+}
+
+func (r *RunnerArgs) run() error {
+	port := 11112
+	server, done := generator.StartServer(r.Path, port)
+
+	time.Sleep(r.RunDuration)
+
+	if err := server.Shutdown(context.Background()); err != nil {
+		panic(err) // failure/timeout shutting down the server gracefully
+	}
+
+	// Wait for graceful shutdown or crash.
+	select {
+		case <- done:
+			// continue
+		case <- time.After(10 * time.Second):
+			fmt.Println("Failed to gracefully shutdown generator.")
+			os.Exit(1)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Adds a new subcommand to the block generator to run multiple scenarios and generate reports based on the results.

For testing postgres can be started in a local docker container with:
```
~$ docker run -it --rm --name some-postgres -e POSTGRES_PASSWORD=algorand -e POSTGRES_USER=algorand -e PGPASSWORD=algorand -e POSTGRES_DB=algorand -p 5432:5432 postgres
```

With all binaries built, the new command can be used from the `cmd/block-generator` directory with the following command:
```
~$ ./block-generator runner \
            -d 5m \
            -i ./../algorand-indexer/algorand-indexer \
            -c "host=localhost user=algorand password=algorand dbname=algorand port=5432 sslmode=disable" \
            -r results \
            -s scenarios
```

## Test Plan

Run the command and verify no errors, and that reports are generated.
```
~$ go build && rm -rf results && ./block-generator runner -d 5m -i ./../algorand-indexer/algorand-indexer -c "host=localhost user=algorand password=algorand dbname=algorand port=5432 sslmode=disable" -r results -s scenarios
Running test for configuration 'scenarios/config.asset.close.yml'
Running test for configuration 'scenarios/config.asset.destroy.yml'
Running test for configuration 'scenarios/config.asset.xfer.yml'
Running test for configuration 'scenarios/config.mixed.jumbo.yml'
Running test for configuration 'scenarios/config.mixed.yml'
Running test for configuration 'scenarios/config.payment.full.yml'
Running test for configuration 'scenarios/config.payment.jumbo.yml'
Running test for configuration 'scenarios/config.payment.small.yml'

~$ cat results/config.payment.jumbo.report 
test_duration_seconds: 300
transaction_count_pay:1999323
transaction_count_pay_create:40575
starting_block_import_duration_average_seconds:2.111194
final_import_duration_average_second:2.692307

~$ cat results/config.mixed.jumbo.report 
test_duration_seconds: 300
transaction_count_pay:294032
transaction_count_pay_create:5989
transaction_count_asset_close:34964
transaction_count_asset_create:712
transaction_count_asset_optin:71071
transaction_count_asset_xfer:593182
starting_block_import_duration_average_seconds:4.945975
final_import_duration_average_second:5.672932
```