### PR TITLE
Add devmode support to indexer

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -396,6 +396,13 @@ type (
 
 		// Arbitrary genesis comment string - will be excluded from file if empty
 		Comment string `codec:"comment"`
+
+		// DevMode defines whether this network operates in a developer mode or not. Developer mode networks
+		// are a single node network, that operates without the agreement service being active. In liue of the
+		// agreement service, a new block is generated each time a node receives a transaction group. The
+		// default value for this field is "false", which makes this field empty from it's encoding, and
+		// therefore backward compatible.
+		DevMode bool `codec:"devmode"`
 	}
 
 	// A GenesisAllocation object represents an allocation of algos to


### PR DESCRIPTION
## Summary

Add the `DevMode` to the genesis definition to support devmode nodes.

## Test Plan

Manual testing.
