### PR TITLE
Store next round in import state

### DIFF
--- a/idb/dummy/dummy.go
+++ b/idb/dummy/dummy.go
@@ -42,13 +42,18 @@ func (db *dummyIndexerDb) LoadGenesis(genesis types.Genesis) (err error) {
 	return nil
 }
 
+// GetNextRoundToAccount is part of idb.IndexerDB
+func (db *dummyIndexerDb) GetNextRoundToAccount() (uint64, error) {
+	return 0, nil
+}
+
 // GetMaxRoundAccounted is part of idb.IndexerDB
-func (db *dummyIndexerDb) GetMaxRoundAccounted() (round uint64, err error) {
+func (db *dummyIndexerDb) GetMaxRoundAccounted() (uint64, error) {
 	return 0, nil
 }
 
 // GetNextRoundToLoad is part of idb.IndexerDB
-func (db *dummyIndexerDb) GetNextRoundToLoad() (round uint64, err error) {
+func (db *dummyIndexerDb) GetNextRoundToLoad() (uint64, error) {
 	return 0, nil
 }
 

--- a/idb/dummy/dummy.go
+++ b/idb/dummy/dummy.go
@@ -47,11 +47,6 @@ func (db *dummyIndexerDb) GetNextRoundToAccount() (uint64, error) {
 	return 0, nil
 }
 
-// GetMaxRoundAccounted is part of idb.IndexerDB
-func (db *dummyIndexerDb) GetMaxRoundAccounted() (uint64, error) {
-	return 0, nil
-}
-
 // GetNextRoundToLoad is part of idb.IndexerDB
 func (db *dummyIndexerDb) GetNextRoundToLoad() (uint64, error) {
 	return 0, nil

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -87,8 +87,6 @@ type IndexerDb interface {
 
 	// GetNextRoundToAccount returns ErrorNotInitialized if genesis is not loaded.
 	GetNextRoundToAccount() (uint64, error)
-	// GetMaxRoundAccounted returns ErrorNotInitialized if genesis is not loaded.
-	GetMaxRoundAccounted() (uint64, error)
 	GetNextRoundToLoad() (uint64, error)
 	GetSpecialAccounts() (SpecialAccounts, error)
 	GetDefaultFrozen() (defaultFrozen map[uint64]bool, err error)

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -85,9 +85,11 @@ type IndexerDb interface {
 
 	LoadGenesis(genesis types.Genesis) (err error)
 
-	// GetMaxRoundAccounted returns ErrorNotInitialized if there are no accounted rounds.
-	GetMaxRoundAccounted() (round uint64, err error)
-	GetNextRoundToLoad() (round uint64, err error)
+	// GetNextRoundToAccount returns ErrorNotInitialized if genesis is not loaded.
+	GetNextRoundToAccount() (uint64, error)
+	// GetMaxRoundAccounted returns ErrorNotInitialized if genesis is not loaded.
+	GetMaxRoundAccounted() (uint64, error)
+	GetNextRoundToLoad() (uint64, error)
 	GetSpecialAccounts() (SpecialAccounts, error)
 	GetDefaultFrozen() (defaultFrozen map[uint64]bool, err error)
 

--- a/idb/mocks/IndexerDb.go
+++ b/idb/mocks/IndexerDb.go
@@ -226,6 +226,27 @@ func (_m *IndexerDb) GetMaxRoundAccounted() (uint64, error) {
 	return r0, r1
 }
 
+// GetNextRoundToAccount provides a mock function with given fields:
+func (_m *IndexerDb) GetNextRoundToAccount() (uint64, error) {
+	ret := _m.Called()
+
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func() uint64); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetNextRoundToLoad provides a mock function with given fields:
 func (_m *IndexerDb) GetNextRoundToLoad() (uint64, error) {
 	ret := _m.Called()

--- a/idb/mocks/IndexerDb.go
+++ b/idb/mocks/IndexerDb.go
@@ -205,27 +205,6 @@ func (_m *IndexerDb) GetDefaultFrozen() (map[uint64]bool, error) {
 	return r0, r1
 }
 
-// GetMaxRoundAccounted provides a mock function with given fields:
-func (_m *IndexerDb) GetMaxRoundAccounted() (uint64, error) {
-	ret := _m.Called()
-
-	var r0 uint64
-	if rf, ok := ret.Get(0).(func() uint64); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint64)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetNextRoundToAccount provides a mock function with given fields:
 func (_m *IndexerDb) GetNextRoundToAccount() (uint64, error) {
 	ret := _m.Called()

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -36,8 +36,10 @@ import (
 )
 
 type importState struct {
-	// Last accounted round.
+	// DEPRECATED. Last accounted round.
 	AccountRound *int64 `codec:"account_round"`
+	// Next round to account.
+	NextRoundToAccount *uint64 `codec:"next_account_round"`
 }
 
 const stateMetastateKey = "state"
@@ -334,9 +336,9 @@ func (db *IndexerDb) LoadGenesis(genesis types.Genesis) (err error) {
 		}
 	}
 
-	round := int64(0)
+	nextRound := uint64(0)
 	importstate := importState{
-		AccountRound: &round,
+		NextRoundToAccount: &nextRound,
 	}
 	err = db.setImportState(nil, importstate)
 	if err != nil {
@@ -411,9 +413,9 @@ func (db *IndexerDb) setImportState(tx *sql.Tx, state importState) error {
 	return db.setMetastate(tx, stateMetastateKey, string(encoding.EncodeJSON(state)))
 }
 
-// Returns idb.ErrorNotInitialized if uninitialized.
+// Returns ErrorNotInitialized if genesis is not loaded.
 // If `tx` is nil, use a normal query.
-func (db *IndexerDb) getMaxRoundAccounted(tx *sql.Tx) (uint64, error) {
+func (db *IndexerDb) getNextRoundToAccount(tx *sql.Tx) (uint64, error) {
 	state, err := db.getImportState(tx)
 	if err == idb.ErrorNotInitialized {
 		return 0, err
@@ -422,14 +424,34 @@ func (db *IndexerDb) getMaxRoundAccounted(tx *sql.Tx) (uint64, error) {
 		return 0, fmt.Errorf("getNextRoundToAccount() err: %w", err)
 	}
 
-	if state.AccountRound == nil {
+	if state.NextRoundToAccount == nil {
 		return 0, idb.ErrorNotInitialized
 	}
-	return uint64(*state.AccountRound), nil
+	return *state.NextRoundToAccount, nil
+}
+
+// GetNextRoundToAccount is part of idb.IndexerDB
+// Returns ErrorNotInitialized if genesis is not loaded.
+func (db *IndexerDb) GetNextRoundToAccount() (uint64, error) {
+	return db.getNextRoundToAccount(nil)
+}
+
+// Returns ErrorNotInitialized if genesis is not loaded.
+// If `tx` is nil, use a normal query.
+func (db *IndexerDb) getMaxRoundAccounted(tx *sql.Tx) (uint64, error) {
+	round, err := db.getNextRoundToAccount(tx)
+	if err != nil {
+		return 0, err
+	}
+
+	if round > 0 {
+		round--
+	}
+	return round, nil
 }
 
 // GetMaxRoundAccounted is part of idb.IndexerDB
-// Returns idb.ErrorNotInitialized if uninitialized.
+// Returns ErrorNotInitialized if genesis is not loaded.
 func (db *IndexerDb) GetMaxRoundAccounted() (round uint64, err error) {
 	return db.getMaxRoundAccounted(nil)
 }
@@ -1294,17 +1316,17 @@ ON CONFLICT (addr, assetid) DO UPDATE SET amount = account_asset.amount + EXCLUD
 		return err
 	}
 
-	if importstate.AccountRound == nil {
+	if importstate.NextRoundToAccount == nil {
 		return fmt.Errorf("importstate.AccountRound is nil")
 	}
 
-	if uint64(*importstate.AccountRound) >= round {
+	if uint64(*importstate.NextRoundToAccount) > round {
 		return fmt.Errorf(
-			"metastate round = %d while trying to write round %d",
-			*importstate.AccountRound, round)
+			"next round to account is %d while trying to write round %d",
+			*importstate.NextRoundToAccount, round)
 	}
 
-	*importstate.AccountRound = int64(round)
+	*importstate.NextRoundToAccount = round + 1
 	err = db.setImportState(tx, importstate)
 	if err != nil {
 		return

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -450,12 +450,6 @@ func (db *IndexerDb) getMaxRoundAccounted(tx *sql.Tx) (uint64, error) {
 	return round, nil
 }
 
-// GetMaxRoundAccounted is part of idb.IndexerDB
-// Returns ErrorNotInitialized if genesis is not loaded.
-func (db *IndexerDb) GetMaxRoundAccounted() (round uint64, err error) {
-	return db.getMaxRoundAccounted(nil)
-}
-
 // GetNextRoundToLoad is part of idb.IndexerDB
 func (db *IndexerDb) GetNextRoundToLoad() (uint64, error) {
 	row := db.db.QueryRow(`SELECT max(round) FROM block_header`)
@@ -2975,7 +2969,7 @@ func (db *IndexerDb) Health() (idb.Health, error) {
 
 	data["migration-required"] = migrationRequired
 
-	round, err := db.GetMaxRoundAccounted()
+	round, err := db.getMaxRoundAccounted(nil)
 
 	// We'll just have to set the round to 0
 	if err == idb.ErrorNotInitialized {

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -36,14 +36,14 @@ func TestMaxRoundOnUninitializedDB(t *testing.T) {
 	_, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	db, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
+	db, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	round, err := db.GetNextRoundToAccount()
 	assert.Equal(t, err, idb.ErrorNotInitialized)
 	assert.Equal(t, uint64(0), round)
 
-	round, err = db.GetMaxRoundAccounted()
+	round, err = db.getMaxRoundAccounted(nil)
 	assert.Equal(t, err, idb.ErrorNotInitialized)
 	assert.Equal(t, uint64(0), round)
 
@@ -57,7 +57,7 @@ func TestMaxRoundEmptyMetastate(t *testing.T) {
 	pg, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	db, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
+	db, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 	pg.Exec(`INSERT INTO metastate (k, v) values ('state', '{}')`)
 
@@ -65,7 +65,7 @@ func TestMaxRoundEmptyMetastate(t *testing.T) {
 	assert.Equal(t, err, idb.ErrorNotInitialized)
 	assert.Equal(t, uint64(0), round)
 
-	round, err = db.GetMaxRoundAccounted()
+	round, err = db.getMaxRoundAccounted(nil)
 	assert.Equal(t, err, idb.ErrorNotInitialized)
 	assert.Equal(t, uint64(0), round)
 }
@@ -75,7 +75,7 @@ func TestMaxRound(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
+	pdb, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 	db.Exec(
 		`INSERT INTO metastate (k, v) values ($1, $2)`,
@@ -90,7 +90,7 @@ func TestMaxRound(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(123454322), round)
 
-	round, err = pdb.GetMaxRoundAccounted()
+	round, err = pdb.getMaxRoundAccounted(nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(123454321), round)
 
@@ -103,7 +103,7 @@ func TestAccountedRoundNextRound0(t *testing.T) {
 	db, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
 
-	pdb, err := idb.IndexerDbByName("postgres", connStr, idb.IndexerDbOptions{}, nil)
+	pdb, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 	db.Exec(
 		`INSERT INTO metastate (k, v) values ($1, $2)`,
@@ -114,7 +114,7 @@ func TestAccountedRoundNextRound0(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), round)
 
-	round, err = pdb.GetMaxRoundAccounted()
+	round, err = pdb.getMaxRoundAccounted(nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), round)
 }

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -42,6 +42,7 @@ func init() {
 		{FixFreezeLookupMigration, false, "Fix search by asset freeze address."},
 		{ClearAccountDataMigration, false, "clear account data for accounts that have been closed"},
 		{MakeDeletedNotNullMigration, false, "make all \"deleted\" columns NOT NULL"},
+		{MaxRoundAccountedMigration, true, "change import state format"},
 	}
 }
 
@@ -99,27 +100,16 @@ func needsMigration(state MigrationState) bool {
 	return state.NextMigration < len(migrations)
 }
 
-// upsertMigrationStateTx updates the migration state, and optionally increments the next counter with an existing
-// transaction.
-func upsertMigrationStateTx(tx *sql.Tx, state *MigrationState, incrementNextMigration bool) (err error) {
+// upsertMigrationState updates the migration state, and optionally increments
+// the next counter with an existing transaction.
+// If `tx` is nil, use a normal query.
+func upsertMigrationState(db *IndexerDb, tx *sql.Tx, state *MigrationState, incrementNextMigration bool) error {
 	if incrementNextMigration {
 		state.NextMigration++
 	}
 	migrationStateJSON := encoding.EncodeJSON(state)
-	_, err = tx.Exec(setMetastateUpsert, migrationMetastateKey, migrationStateJSON)
 
-	return err
-}
-
-// upsertMigrationState updates the migration state, and optionally increments the next counter.
-func upsertMigrationState(db *IndexerDb, state *MigrationState, incrementNextMigration bool) (err error) {
-	if incrementNextMigration {
-		state.NextMigration++
-	}
-	migrationStateJSON := encoding.EncodeJSON(state)
-	_, err = db.db.Exec(setMetastateUpsert, migrationMetastateKey, migrationStateJSON)
-
-	return err
+	return db.setMetastate(tx, migrationMetastateKey, string(migrationStateJSON))
 }
 
 func (db *IndexerDb) runAvailableMigrations(migrationStateJSON string) (err error) {
@@ -348,7 +338,7 @@ func FixFreezeLookupMigration(db *IndexerDb, state *MigrationState) error {
 	}
 
 	// Update migration state
-	return upsertMigrationState(db, state, true)
+	return upsertMigrationState(db, nil, state, true)
 }
 
 type account struct {
@@ -537,4 +527,57 @@ func MakeDeletedNotNullMigration(db *IndexerDb, state *MigrationState) error {
 		"ALTER TABLE account_app ALTER COLUMN deleted SET NOT NULL",
 	}
 	return sqlMigration(db, state, queries)
+}
+
+// MaxRoundAccountedMigration converts the import state.
+func MaxRoundAccountedMigration(db *IndexerDb, migrationState *MigrationState) error {
+	db.accountingLock.Lock()
+	defer db.accountingLock.Unlock()
+
+	nextMigrationState := *migrationState
+	nextMigrationState.NextMigration++
+
+	f := func(ctx context.Context, tx *sql.Tx) error {
+		defer tx.Rollback()
+
+		importstate, err := db.getImportState(tx)
+		if err == idb.ErrorNotInitialized {
+			// Leave uninitialized.
+			db.log.Printf("Import state is not initialized, leaving unchanged.")
+		} else if err != nil {
+			return err
+		} else {
+			if importstate.AccountRound == nil {
+				db.log.Printf("Account round is not set, leaving unchanged.")
+			} else {
+				nextRound := uint64(0)
+				if *importstate.AccountRound > 0 {
+					nextRound = uint64(*importstate.AccountRound + 1)
+				}
+				importstate.NextRoundToAccount = &nextRound
+				importstate.AccountRound = nil
+
+				db.log.Printf("Setting import state to %s", encoding.EncodeJSON(importstate))
+
+				err = db.setImportState(tx, importstate)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		err = upsertMigrationState(db, tx, &nextMigrationState, false)
+		if err != nil {
+			return err
+		}
+
+		return tx.Commit()
+	}
+	err := db.txWithRetry(context.Background(), serializable, f)
+	if err != nil {
+		return err
+	}
+
+	*migrationState = nextMigrationState
+	return nil
 }


### PR DESCRIPTION
## Summary

Currently the import state stores the last accounted round which creates ambiguities: we cannot distinguish between the state before accounting round 0 and after. This works because block 0 contains no transactions, and we don't actually do accounting for it. However, with one phase import it will be a problem.

This PR changes the import state to store the next round to account instead, `GetMaxRoundAccounted()` is replaced with `GetNextRoundToAccount()`, and a blocking migration is added.

## Test Plan

Added tests for the migration, and manually tested the migration when max round accounted is 0 and >0.