### PR TITLE
Improvements in `idb/postgres/` and `reset.go`

### DIFF
--- a/cmd/algorand-indexer/reset.go
+++ b/cmd/algorand-indexer/reset.go
@@ -31,19 +31,6 @@ var resetCmd = &cobra.Command{
 		}
 		opts := idb.IndexerDbOptions{ReadOnly: true}
 		db := indexerDbFromFlags(opts)
-		timeout := time.Now().Add(5 * time.Second)
-		health, err := db.Health()
-		maybeFail(err, "could not get db health, %v", err)
-		for health.IsMigrating || !health.DBAvailable {
-			if time.Now().After(timeout) {
-				fmt.Fprintf(os.Stderr, "timed out waiting for db to be ready\n")
-				os.Exit(1)
-				return
-			}
-			time.Sleep(100 * time.Millisecond)
-			health, err = db.Health()
-			maybeFail(err, "could not get db health, %v", err)
-		}
 		fmt.Println("Prior to resetting the database make sure no daemons are connected.")
 		fmt.Println("After this command finishes start the daemon again and it will begin to")
 		fmt.Println("re-index the data. This can take hours or days depending on the network")

--- a/cmd/algorand-indexer/reset.go
+++ b/cmd/algorand-indexer/reset.go
@@ -29,7 +29,7 @@ var resetCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "failed to configure logger: %v", err)
 			os.Exit(1)
 		}
-		opts := idb.IndexerDbOptions{NoMigrate: true}
+		opts := idb.IndexerDbOptions{ReadOnly: true}
 		db := indexerDbFromFlags(opts)
 		timeout := time.Now().Add(5 * time.Second)
 		health, err := db.Health()
@@ -66,7 +66,7 @@ var resetCmd = &cobra.Command{
 						fmt.Printf(
 							"Done resetting. Re-building accounting through block %d...",
 							nextRound-1)
-						opts.NoMigrate = false
+						opts.ReadOnly = false
 						// db.Close() // TODO: add Close() to IndxerDb interface?
 						db = indexerDbFromFlags(opts)
 						cache, err := db.GetDefaultFrozen()

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -284,10 +284,6 @@ type ApplicationRow struct {
 // IndexerDbOptions are the options common to all indexer backends.
 type IndexerDbOptions struct {
 	ReadOnly bool
-
-	// NoMigrate indicates to not run any migrations.
-	// Should probably only be used by the `reset` subcommand.
-	NoMigrate bool
 }
 
 // AssetUpdate is used by the accounting and IndexerDb implementations to share modifications in a block.

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -2949,10 +2949,12 @@ func (db *IndexerDb) Health() (idb.Health, error) {
 		blocking = state.Blocking
 	} else {
 		state, err := db.getMigrationState()
-		if err == nil {
-			blocking = migrationStateBlocked(*state)
-			migrationRequired = needsMigration(*state)
+		if err != nil {
+			return idb.Health{}, err
 		}
+
+		blocking = migrationStateBlocked(state)
+		migrationRequired = needsMigration(state)
 	}
 
 	data["migration-required"] = migrationRequired

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -136,11 +136,10 @@ func (db *IndexerDb) txWithRetry(ctx context.Context, opts sql.TxOptions, f func
 }
 
 func (db *IndexerDb) isSetup() (bool, error) {
-	query := `SELECT tablename FROM pg_catalog.pg_tables WHERE tablename = 'metastate'`
+	query := `SELECT 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'metastate'`
 	row := db.db.QueryRow(query)
 
-	var tmp string
-	err := row.Scan(&tmp)
+	err := row.Scan()
 	if err == sql.ErrNoRows {
 		return false, nil
 	}

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -169,10 +169,6 @@ func (db *IndexerDb) init(opts idb.IndexerDbOptions) error {
 		return nil
 	}
 
-	if opts.NoMigrate {
-		return nil
-	}
-
 	// see postgres_migrations.go
 	return db.runAvailableMigrations()
 }

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -139,7 +139,8 @@ func (db *IndexerDb) isSetup() (bool, error) {
 	query := `SELECT 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'metastate'`
 	row := db.db.QueryRow(query)
 
-	err := row.Scan()
+	var tmp int
+	err := row.Scan(&tmp)
 	if err == sql.ErrNoRows {
 		return false, nil
 	}

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -1091,3 +1091,15 @@ func TestInitializationNewDatabase(t *testing.T) {
 
 	assert.Equal(t, len(migrations), state.NextMigration)
 }
+
+// Test that opening the database the second time (after initializing) is successful.
+func TestOpenDbAgain(t *testing.T) {
+	_, connStr, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+
+	_, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	require.NoError(t, err)
+
+	_, err = OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	require.NoError(t, err)
+}

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -174,20 +174,19 @@ func (db *IndexerDb) markMigrationsAsDone() (err error) {
 	return db.setMetastate(nil, migrationMetastateKey, string(migrationStateJSON))
 }
 
-func (db *IndexerDb) getMigrationState() (*MigrationState, error) {
+func (db *IndexerDb) getMigrationState() (MigrationState, error) {
 	migrationStateJSON, err := db.getMetastate(nil, migrationMetastateKey)
-	if err == sql.ErrNoRows {
-		// no previous state, ok
-		return nil, nil
-	} else if err != nil {
-		return nil, fmt.Errorf("getMigrationState() get state err: %w", err)
-	}
-	var txstate MigrationState
-	err = encoding.DecodeJSON([]byte(migrationStateJSON), &txstate)
 	if err != nil {
-		return nil, fmt.Errorf("getMigrationState() decode state err: %w", err)
+		return MigrationState{}, fmt.Errorf("getMigrationState() get state err: %w", err)
 	}
-	return &txstate, nil
+
+	var state MigrationState
+	err = encoding.DecodeJSON([]byte(migrationStateJSON), &state)
+	if err != nil {
+		return MigrationState{}, fmt.Errorf("getMigrationState() decode state err: %w", err)
+	}
+
+	return state, nil
 }
 
 // sqlMigration executes a sql statements as the entire migration.

--- a/idb/postgres/postgres_test.go
+++ b/idb/postgres/postgres_test.go
@@ -14,12 +14,12 @@ func TestAllMigrations(t *testing.T) {
 	for idx, m := range migrations {
 		t.Run(fmt.Sprintf("Test migration %d", idx), func(t *testing.T) {
 			db := MakeMockDB([]*MockStmt{
-				// pg_catalog.pg_tables
+				// INFORMATION_SCHEMA.TABLES
 				MakeMockStmt(
 					0,
-					[]string{"tablename"},
+					[]string{"columnname"},
 					[][]interface{}{
-						{"metastate"},
+						{0},
 					}),
 				// migration state
 				MakeMockStmt(
@@ -55,12 +55,12 @@ func TestAllMigrations(t *testing.T) {
 
 func TestNoMigrationsNeeded(t *testing.T) {
 	db := MakeMockDB([]*MockStmt{
-		// pg_catalog.pg_tables
+		// INFORMATION_SCHEMA.TABLES
 		MakeMockStmt(
 			0,
-			[]string{"tablename"},
+			[]string{"columnname"},
 			[][]interface{}{
-				{"metastate"},
+				{0},
 			}),
 		// migration state
 		MakeMockStmt(

--- a/idb/postgres/postgres_test.go
+++ b/idb/postgres/postgres_test.go
@@ -14,14 +14,14 @@ func TestAllMigrations(t *testing.T) {
 	for idx, m := range migrations {
 		t.Run(fmt.Sprintf("Test migration %d", idx), func(t *testing.T) {
 			db := MakeMockDB([]*MockStmt{
-				// "state"
+				// pg_catalog.pg_tables
 				MakeMockStmt(
-					1,
-					[]string{"v"},
+					0,
+					[]string{"tablename"},
 					[][]interface{}{
-						{`{"account_round": 9000000}`},
+						{"metastate"},
 					}),
-				// "migration"
+				// migration state
 				MakeMockStmt(
 					1,
 					[]string{"v"},
@@ -55,19 +55,19 @@ func TestAllMigrations(t *testing.T) {
 
 func TestNoMigrationsNeeded(t *testing.T) {
 	db := MakeMockDB([]*MockStmt{
-		// "state"
+		// pg_catalog.pg_tables
 		MakeMockStmt(
-			1,
-			[]string{"v"},
+			0,
+			[]string{"tablename"},
 			[][]interface{}{
-				{`{"account_round": 9000000}`},
+				{"metastate"},
 			}),
-		// "migration"
+		// migration state
 		MakeMockStmt(
 			1,
 			[]string{"v"},
 			[][]interface{}{
-				{fmt.Sprintf(`{"next": %d}`, len(migrations)+1)},
+				{fmt.Sprintf(`{"next": %d}`, len(migrations))},
 			}),
 	})
 


### PR DESCRIPTION
## Summary

- If we can't read the migration state, we should return an error in `Health()`
- `getMigrationState()` now returns `idb.ErrorNotInitialized` when migration state is not found; this is ok, because postgres `init()` initializes the migration state
- `getMetastate()` now returns `idb.ErrorNotInitialized` when key is not found instead of no error
- before `init()` fetched import and migration metastate without checking the returned errors; now we only check that the `metastate` table exists to determine if need to set up the database
- fix a bug in init(): if `opts.NoMigrate` is true, `init()` would mark migrations as done; currently this is insignificant because this `NoMigrate` is only used for resetting a database, but could become a bug some day
- `db.GetSpecialAccounts()` to initialize cache is now not called in `init()` because it is strange; if we wanted to initialize cache in advance, we would do it when importing block 0
- No need to wait for db to be available in `reset.go`

## Test Plan

Manual testing:
- Verified that indexer initializes the database
- Verified that the health endpoint works