### PR TITLE
Copy the byte array in bytePtr()

### DIFF
--- a/api/pointer_utils.go
+++ b/api/pointer_utils.go
@@ -59,7 +59,9 @@ func bytePtr(x []byte) *[]byte {
 	// Don't return if it's all zero.
 	for _, v := range x {
 		if v != 0 {
-			return &x
+			xx := make([]byte, len(x))
+			copy(xx, x)
+			return &xx
 		}
 	}
 

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -2360,9 +2360,10 @@ func baPtr(x []byte) *[]byte {
 	if allzero {
 		return nil
 	}
-	out := new([]byte)
-	*out = x
-	return out
+
+	xx := make([]byte, len(x))
+	copy(xx, x)
+	return &xx
 }
 
 func allZero(x []byte) bool {


### PR DESCRIPTION
In the new accounting code this function triggered a bug due to calling this function in a loop in `api/converter_utils.go` `msigToTransactionMsig()`.