### PR TITLE
Move signature type logic to `idb`

### DIFF
--- a/accounting/accounting.go
+++ b/accounting/accounting.go
@@ -236,7 +236,11 @@ func (accounting *State) AddTransaction(txnr *idb.TxnRow) (err error) {
 		return ErrWrongRound
 	}
 
-	ktype := idb.SignatureType(&stxn.SignedTxn)
+	ktype, err := idb.SignatureType(&stxn.SignedTxn)
+	if err != nil {
+		return err
+	}
+
 	var isNew bool
 	isNew, err = accounting.accountTypes.set(stxn.Txn.Sender, string(ktype))
 	if err != nil {

--- a/accounting/accounting.go
+++ b/accounting/accounting.go
@@ -238,7 +238,7 @@ func (accounting *State) AddTransaction(txnr *idb.TxnRow) (err error) {
 
 	ktype, err := idb.SignatureType(&stxn.SignedTxn)
 	if err != nil {
-		return err
+		ktype = ""
 	}
 
 	var isNew bool

--- a/accounting/accounting.go
+++ b/accounting/accounting.go
@@ -218,21 +218,6 @@ func (accounting *State) destroyAsset(assetID uint64) {
 	accounting.AssetDestroys = append(accounting.AssetDestroys, assetID)
 }
 
-// TODO: move to go-algorand-sdk as Signature.IsZero()
-func zeroSig(sig sdk_types.Signature) bool {
-	for _, b := range sig {
-		if b != 0 {
-			return false
-		}
-	}
-	return true
-}
-
-// TODO: move to go-algorand-sdk as LogicSig.Blank()
-func blankLsig(lsig sdk_types.LogicSig) bool {
-	return len(lsig.Logic) == 0
-}
-
 // ErrWrongRound is returned when adding a transaction which belongs to a different round
 // than what the State is configured for.
 var ErrWrongRound error = errors.New("wrong round")
@@ -251,27 +236,14 @@ func (accounting *State) AddTransaction(txnr *idb.TxnRow) (err error) {
 		return ErrWrongRound
 	}
 
-	var ktype string
-	if !zeroSig(stxn.Sig) {
-		ktype = "sig"
-	} else if !stxn.Msig.Blank() {
-		ktype = "msig"
-	} else if !blankLsig(stxn.Lsig) {
-		if !zeroSig(stxn.Lsig.Sig) {
-			ktype = "sig"
-		} else if !stxn.Lsig.Msig.Blank() {
-			ktype = "msig"
-		} else {
-			ktype = "lsig"
-		}
-	}
+	ktype := idb.SignatureType(&stxn.SignedTxn)
 	var isNew bool
-	isNew, err = accounting.accountTypes.set(stxn.Txn.Sender, ktype)
+	isNew, err = accounting.accountTypes.set(stxn.Txn.Sender, string(ktype))
 	if err != nil {
 		return fmt.Errorf("error in account type, %v", err)
 	}
 	if isNew {
-		accounting.updateAccountType(stxn.Txn.Sender, ktype)
+		accounting.updateAccountType(stxn.Txn.Sender, string(ktype))
 	}
 
 	accounting.updateAlgo(stxn.Txn.Sender, -int64(stxn.Txn.Fee))

--- a/api/converter_utils.go
+++ b/api/converter_utils.go
@@ -105,17 +105,7 @@ var addressRoleEnumMap = map[string]bool{
 // AddressRoleEnumString is used in error messages to list valid address role values.
 var AddressRoleEnumString string
 
-var sigTypeEnumMap = map[string]int{
-	"sig":  1,
-	"msig": 2,
-	"lsig": 3,
-}
-
-// SigTypeEnumString is used in error messages to list valid sig type values.
-var SigTypeEnumString string
-
 func init() {
-	SigTypeEnumString = util.KeysStringInt(sigTypeEnumMap)
 	AddressRoleEnumString = util.KeysStringBool(addressRoleEnumMap)
 }
 
@@ -131,11 +121,12 @@ func decodeBase64Byte(str *string, field string, errorArr []string) ([]byte, []s
 }
 
 // decodeSigType validates the input string and dereferences it if present, or appends an error to errorArr
-func decodeSigType(str *string, errorArr []string) (string, []string) {
+func decodeSigType(str *string, errorArr []string) (idb.SigType, []string) {
 	if str != nil {
 		sigTypeLc := strings.ToLower(*str)
-		if _, ok := sigTypeEnumMap[sigTypeLc]; ok {
-			return sigTypeLc, errorArr
+		sigtype := idb.SigType(*str)
+		if idb.IsSigTypeValid(sigtype) {
+			return sigtype, errorArr
 		}
 		return "", append(errorArr, fmt.Sprintf("%s: '%s'", errUnknownSigType, sigTypeLc))
 	}

--- a/api/error_messages.go
+++ b/api/error_messages.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 
+	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/importer"
 )
 
@@ -37,5 +38,6 @@ var errUnknownSigType string
 func init() {
 	errUnknownAddressRole = fmt.Sprintf("unknown address role [valid roles: %s]", AddressRoleEnumString)
 	errUnknownTxType = fmt.Sprintf("unknown tx-type [valid types: %s]", importer.TypeEnumString)
-	errUnknownSigType = fmt.Sprintf("unknown sig-type [valid types: %s]", SigTypeEnumString)
+	errUnknownSigType = fmt.Sprintf(
+		"unknown sig-type [valid types: %s, %s, %s]", idb.Sig, idb.Msig, idb.Lsig)
 }

--- a/api/error_messages.go
+++ b/api/error_messages.go
@@ -39,5 +39,5 @@ func init() {
 	errUnknownAddressRole = fmt.Sprintf("unknown address role [valid roles: %s]", AddressRoleEnumString)
 	errUnknownTxType = fmt.Sprintf("unknown tx-type [valid types: %s]", importer.TypeEnumString)
 	errUnknownSigType = fmt.Sprintf(
-		"unknown sig-type [valid types: %s, %s, %s]", idb.Sig, idb.Msig, idb.Lsig)
+		"unknown sig-type [valid types: %s]", idb.SigTypeEnumString)
 }

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -157,7 +157,7 @@ type TransactionFilter struct {
 	Offset     *uint64 // nil for no filter
 	OffsetLT   *uint64 // nil for no filter
 	OffsetGT   *uint64 // nil for no filter
-	SigType    string  // ["", "sig", "msig", "lsig"]
+	SigType    SigType // ["", "sig", "msig", "lsig"]
 	NotePrefix []byte
 	AlgosGT    *uint64 // implictly filters on "pay" txns for Algos > this. This will be a slightly faster query than EffectiveAmountGT.
 	AlgosLT    *uint64

--- a/idb/sig_type.go
+++ b/idb/sig_type.go
@@ -1,19 +1,44 @@
 package idb
 
 import (
+	"fmt"
+	"strings"
+
 	sdk_types "github.com/algorand/go-algorand-sdk/types"
 )
 
+// SigType is signature type.
 type SigType string
 
+// Possible signature types.
 const (
 	Sig  SigType = "sig"
 	Msig SigType = "msig"
 	Lsig SigType = "lsig"
 )
 
+var sigTypeEnumMap = map[SigType]struct{}{
+	Sig:  {},
+	Msig: {},
+	Lsig: {},
+}
+
+func makeSigTypeEnumString() string {
+	keys := make([]string, 0, len(sigTypeEnumMap))
+	for k := range sigTypeEnumMap {
+		keys = append(keys, string(k))
+	}
+	return strings.Join(keys, ", ")
+}
+
+// SigTypeEnumString is a comma-separated list of possible signature types.
+var SigTypeEnumString = makeSigTypeEnumString()
+
+// IsSigTypeValid returns true if and only if `sigtype` is one of the possible
+// signature types.
 func IsSigTypeValid(sigtype SigType) bool {
-	return (sigtype == Sig) || (sigtype == Msig) || (sigtype == Lsig)
+	_, ok := sigTypeEnumMap[sigtype]
+	return ok
 }
 
 func isZeroSig(sig sdk_types.Signature) bool {
@@ -25,18 +50,27 @@ func isZeroSig(sig sdk_types.Signature) bool {
 	return true
 }
 
-func SignatureType(stxn *sdk_types.SignedTxn) SigType {
+func blankLsig(lsig sdk_types.LogicSig) bool {
+	return len(lsig.Logic) == 0
+}
+
+// SignatureType returns the signature type of the given signed transaction.
+func SignatureType(stxn *sdk_types.SignedTxn) (SigType, error) {
 	if !isZeroSig(stxn.Sig) {
-		return Sig
+		return Sig, nil
 	}
 	if !stxn.Msig.Blank() {
-		return Msig
+		return Msig, nil
 	}
-	if !isZeroSig(stxn.Lsig.Sig) {
-		return Sig
+	if !blankLsig(stxn.Lsig) {
+		if !isZeroSig(stxn.Lsig.Sig) {
+			return Sig, nil
+		}
+		if !stxn.Lsig.Msig.Blank() {
+			return Msig, nil
+		}
+		return Lsig, nil
 	}
-	if !stxn.Lsig.Msig.Blank() {
-		return Msig
-	}
-	return Lsig
+
+	return "", fmt.Errorf("unable to determine the signature type")
 }

--- a/idb/sig_type.go
+++ b/idb/sig_type.go
@@ -1,0 +1,42 @@
+package idb
+
+import (
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
+)
+
+type SigType string
+
+const (
+	Sig  SigType = "sig"
+	Msig SigType = "msig"
+	Lsig SigType = "lsig"
+)
+
+func IsSigTypeValid(sigtype SigType) bool {
+	return (sigtype == Sig) || (sigtype == Msig) || (sigtype == Lsig)
+}
+
+func isZeroSig(sig sdk_types.Signature) bool {
+	for _, b := range sig {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func SignatureType(stxn *sdk_types.SignedTxn) SigType {
+	if !isZeroSig(stxn.Sig) {
+		return Sig
+	}
+	if !stxn.Msig.Blank() {
+		return Msig
+	}
+	if !isZeroSig(stxn.Lsig.Sig) {
+		return Sig
+	}
+	if !stxn.Lsig.Msig.Blank() {
+		return Msig
+	}
+	return Lsig
+}


### PR DESCRIPTION
## Summary

Create `SigType` type in `idb/` along with some helper functions.

## Test Plan

Verified that postgres doesn't complain about `SigType` in a query.