### PR TITLE
Run e2e test with nightly channel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,10 @@ script:
 - make check
 - make integration
 - make test
-# e2e tests can't run without installing algod.
-#- make e2e
 #- ./test/perf.sh "$TEST_CONNECTION_STRING_1" && ./test/perf.sh "$TEST_CONNECTION_STRING_2"
 - make fakepackage
-# TODO: Remove mule stuff after getting 'make e2e' to run.
-- docker build -t e2e_tests -f docker/Dockerfile.mule .
-- docker run --rm -t e2e_tests mule/e2e.sh
+# e2elive.py runs with the docker-compose file in misc
+- cd misc && docker-compose build && docker-compose up --exit-code-from e2e
 
 after_success:
   - scripts/upload_coverage.sh || true

--- a/misc/Dockerfile
+++ b/misc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.4
+FROM golang:1.14.7
 
 # Misc dependencies
 ENV HOME /opt    

--- a/misc/Dockerfile
+++ b/misc/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.15.4
 # Misc dependencies
 ENV HOME /opt    
 ENV DEBIAN_FRONTEND noninteractive    
-RUN apt-get update && apt-get install -y apt-utils curl git git-core bsdmainutils python3 python3-pip
+RUN apt-get update && apt-get install -y apt-utils curl git git-core bsdmainutils python3 python3-pip make
 
 # Install algod nightly binaries to the path
 RUN mkdir -p /opt/algorand/{bin,data}
@@ -18,6 +18,8 @@ ENV PATH="/opt/algorand/bin:${PATH}"
 run mkdir -p /opt/go/indexer
 COPY . /opt/go/indexer
 WORKDIR /opt/go/indexer
+RUN rm /opt/go/indexer/cmd/algorand-indexer/algorand-indexer
+RUN make
 RUN pip3 install -r misc/requirements.txt
 
 # Run test script

--- a/misc/Dockerfile
+++ b/misc/Dockerfile
@@ -17,8 +17,9 @@ ENV PATH="/opt/algorand/bin:${PATH}"
 # Setup files for test
 run mkdir -p /opt/go/indexer
 COPY . /opt/go/indexer
+COPY cmd/algorand-indexer/algorand-indexer /opt/go/indexer/indexerbin
 WORKDIR /opt/go/indexer
 RUN pip3 install -r misc/requirements.txt
 
 # Run test script
-ENTRYPOINT ["/bin/bash", "-c", "sleep 5 && python3 misc/e2elive.py --connection-string \"$CONNECTION_STRING\" --indexer-bin cmd/algorand-indexer/algorand-indexer --indexer-port 9890"]
+ENTRYPOINT ["/bin/bash", "-c", "sleep 5 && python3 misc/e2elive.py --connection-string \"$CONNECTION_STRING\" --indexer-bin ./indexerbin --indexer-port 9890"]

--- a/misc/Dockerfile
+++ b/misc/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.15.4
+
+# Misc dependencies
+ENV HOME /opt    
+ENV DEBIAN_FRONTEND noninteractive    
+RUN apt-get update && apt-get install -y apt-utils curl git git-core bsdmainutils python3 python3-pip
+
+# Install algod nightly binaries to the path
+RUN mkdir -p /opt/algorand/{bin,data}
+ADD https://github.com/algorand/go-algorand/raw/1e1474216421da27008726c44ebe0a5ba2fb6a08/cmd/updater/update.sh /opt/algorand/bin/update.sh
+RUN chmod 755 /opt/algorand/bin/update.sh
+WORKDIR /opt/algorand/bin
+RUN ./update.sh -i -c nightly -p /opt/algorand/bin -d /opt/algorand/data -n
+RUN find /opt/algorand
+ENV PATH="/opt/algorand/bin:${PATH}"
+
+# Setup files for test
+run mkdir -p /opt/go/indexer
+COPY . /opt/go/indexer
+WORKDIR /opt/go/indexer
+RUN pip3 install -r misc/requirements.txt
+
+# Run test script
+ENTRYPOINT ["/bin/bash", "-c", "sleep 5 && python3 misc/e2elive.py --connection-string \"$CONNECTION_STRING\" --indexer-bin cmd/algorand-indexer/algorand-indexer --indexer-port 9890"]

--- a/misc/Dockerfile
+++ b/misc/Dockerfile
@@ -17,9 +17,8 @@ ENV PATH="/opt/algorand/bin:${PATH}"
 # Setup files for test
 run mkdir -p /opt/go/indexer
 COPY . /opt/go/indexer
-COPY cmd/algorand-indexer/algorand-indexer /opt/go/indexer/indexerbin
 WORKDIR /opt/go/indexer
 RUN pip3 install -r misc/requirements.txt
 
 # Run test script
-ENTRYPOINT ["/bin/bash", "-c", "sleep 5 && python3 misc/e2elive.py --connection-string \"$CONNECTION_STRING\" --indexer-bin ./indexerbin --indexer-port 9890"]
+ENTRYPOINT ["/bin/bash", "-c", "sleep 5 && python3 misc/e2elive.py --connection-string \"$CONNECTION_STRING\" --indexer-bin /opt/go/indexer/cmd/algorand-indexer/algorand-indexer --indexer-port 9890"]

--- a/misc/docker-compose.yml
+++ b/misc/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'    
+    
+services:    
+  e2e:    
+    build:    
+      context: ../.
+      dockerfile: ./misc/Dockerfile    
+    environment:
+      CONNECTION_STRING: "host=e2e-db port=5432 user=algorand password=algorand dbname=indexer_db sslmode=disable"
+
+  e2e-db:
+    image: "postgres:13-alpine"
+    ports:
+      - 5433:5432
+    environment:
+      POSTGRES_USER: algorand
+      POSTGRES_PASSWORD: algorand
+      POSTGRES_DB: indexer_db
+
+


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

When indexer is implementing a new algod feature, we need to use the nightly channel. This configuration uses a simple docker-compose environment to setup this environment.

## Test Plan

CI