### PR TITLE
daemon: replace a sleep loop with a channel.

### DIFF
--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -79,30 +79,31 @@ var daemonCmd = &cobra.Command{
 		if noAlgod && !allowMigration {
 			opts.ReadOnly = true
 		}
-		db := indexerDbFromFlags(opts)
+		db, availableCh := indexerDbFromFlags(opts)
 		if bot != nil {
-			logger.Info("Initializing block import handler.")
-
-			nextRound, err := db.GetNextRoundToLoad()
-			maybeFail(err, "failed to get next round, %v", err)
-			bot.SetNextRound(nextRound)
-
-			cache, err := db.GetDefaultFrozen()
-			maybeFail(err, "failed to get default frozen cache")
-
-			bih := blockImporterHandler{
-				imp:   importer.NewDBImporter(db),
-				db:    db,
-				cache: cache,
-			}
-			bot.AddBlockHandler(&bih)
-			bot.SetContext(ctx)
-
 			go func() {
-				waitForDBAvailable(db)
+				// Wait until the database is available.
+				<-availableCh
 
 				// Initial import if needed.
 				importer.InitialImport(db, genesisJSONPath, bot.Algod(), logger)
+
+				logger.Info("Initializing block import handler.")
+
+				nextRound, err := db.GetNextRoundToLoad()
+				maybeFail(err, "failed to get next round, %v", err)
+				bot.SetNextRound(nextRound)
+
+				cache, err := db.GetDefaultFrozen()
+				maybeFail(err, "failed to get default frozen cache")
+
+				bih := blockImporterHandler{
+					imp:   importer.NewDBImporter(db),
+					db:    db,
+					cache: cache,
+				}
+				bot.AddBlockHandler(&bih)
+				bot.SetContext(ctx)
 
 				logger.Info("Starting block importer.")
 				bot.Run()
@@ -117,35 +118,6 @@ var daemonCmd = &cobra.Command{
 		logger.Infof("serving on %s", daemonServerAddr)
 		api.Serve(ctx, daemonServerAddr, db, bot, logger, makeOptions())
 	},
-}
-
-// waitForDBAvailable wait for the IndexerDb to report that it is available.
-func waitForDBAvailable(db idb.IndexerDb) {
-	statusInterval := 5 * time.Minute
-	checkInterval := 5 * time.Second
-	var now time.Time
-	nextStatusTime := time.Now()
-	for true {
-		now = time.Now()
-		health, err := db.Health()
-		if err != nil {
-			logger.WithError(err).Errorf("Problem fetching database health.")
-			os.Exit(1)
-		}
-
-		// Exit function when the database is available
-		if health.DBAvailable {
-			return
-		}
-
-		// Log status periodically
-		if nextStatusTime.Sub(now) <= 0 {
-			logger.Info("Block importer waiting for database to become available.")
-			nextStatusTime = nextStatusTime.Add(statusInterval)
-		}
-
-		time.Sleep(checkInterval)
-	}
 }
 
 func init() {

--- a/cmd/algorand-indexer/import.go
+++ b/cmd/algorand-indexer/import.go
@@ -23,7 +23,8 @@ var importCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		db := indexerDbFromFlags(idb.IndexerDbOptions{})
+		db, availableCh := indexerDbFromFlags(idb.IndexerDbOptions{})
+		<-availableCh
 
 		cache, err := db.GetDefaultFrozen()
 		if err != nil {

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -84,18 +84,18 @@ var (
 	logger         *log.Logger
 )
 
-func indexerDbFromFlags(opts idb.IndexerDbOptions) (db idb.IndexerDb) {
+func indexerDbFromFlags(opts idb.IndexerDbOptions) (idb.IndexerDb, chan struct{}) {
 	if postgresAddr != "" {
-		var err error
-		db, err = idb.IndexerDbByName("postgres", postgresAddr, opts, logger)
+		db, ch, err := idb.IndexerDbByName("postgres", postgresAddr, opts, logger)
 		maybeFail(err, "could not init db, %v", err)
-	} else if dummyIndexerDb {
-		db = dummy.IndexerDb()
-	} else {
-		logger.Errorf("no import db set")
-		os.Exit(1)
+		return db, ch
 	}
-	return db
+	if dummyIndexerDb {
+		return dummy.IndexerDb(), nil
+	}
+	logger.Errorf("no import db set")
+	os.Exit(1)
+	return nil, nil
 }
 
 func init() {

--- a/cmd/e2equeries/main.go
+++ b/cmd/e2equeries/main.go
@@ -34,8 +34,9 @@ func main() {
 	flag.Parse()
 	testutil.SetQuiet(quiet)
 
-	db, err := idb.IndexerDbByName("postgres", pgdb, idb.IndexerDbOptions{ReadOnly: true}, nil)
+	db, availableCh, err := idb.IndexerDbByName("postgres", pgdb, idb.IndexerDbOptions{ReadOnly: true}, nil)
 	maybeFail(err, "open postgres, %v", err)
+	<-availableCh
 
 	rekeyTxnQuery := idb.TransactionFilter{RekeyTo: &truev, Limit: 1}
 	printTxnQuery(db, rekeyTxnQuery)

--- a/cmd/idbtest/idbtest.go
+++ b/cmd/idbtest/idbtest.go
@@ -126,8 +126,10 @@ func main() {
 	flag.Parse()
 	testutil.SetQuiet(quiet)
 
-	db, err := idb.IndexerDbByName("postgres", pgdb, idb.IndexerDbOptions{}, nil)
+	db, availableCh, err :=
+		idb.IndexerDbByName("postgres", pgdb, idb.IndexerDbOptions{}, nil)
 	maybeFail(err, "open postgres, %v", err)
+	<-availableCh
 
 	if accounttest {
 		printAccountQuery(db, idb.AccountQueryOptions{IncludeAssetHoldings: true, IncludeAssetParams: true, AlgosGreaterThan: uint64Ptr(10000000000), Limit: 20})

--- a/idb/dummy/dummy_factory.go
+++ b/idb/dummy/dummy_factory.go
@@ -15,8 +15,8 @@ func (df dummyFactory) Name() string {
 }
 
 // Build is part of the IndexerFactory interface.
-func (df dummyFactory) Build(arg string, opts idb.IndexerDbOptions, log *log.Logger) (idb.IndexerDb, error) {
-	return &dummyIndexerDb{log: log}, nil
+func (df dummyFactory) Build(arg string, opts idb.IndexerDbOptions, log *log.Logger) (idb.IndexerDb, chan struct{}, error) {
+	return &dummyIndexerDb{log: log}, nil, nil
 }
 
 func init() {

--- a/idb/idb_factory.go
+++ b/idb/idb_factory.go
@@ -9,7 +9,7 @@ import (
 // IndexerDbFactory is used to install an IndexerDb implementation.
 type IndexerDbFactory interface {
 	Name() string
-	Build(arg string, opts IndexerDbOptions, log *log.Logger) (IndexerDb, error)
+	Build(arg string, opts IndexerDbOptions, log *log.Logger) (IndexerDb, chan struct{}, error)
 }
 
 // This layer of indirection allows for different db integrations to be compiled in or compiled out by `go build --tags ...`
@@ -23,11 +23,11 @@ func RegisterFactory(name string, factory IndexerDbFactory) {
 }
 
 // IndexerDbByName is used to construct an IndexerDb object by name.
-func IndexerDbByName(name, arg string, opts IndexerDbOptions, log *log.Logger) (IndexerDb, error) {
+func IndexerDbByName(name, arg string, opts IndexerDbOptions, log *log.Logger) (IndexerDb, chan struct{}, error) {
 	if val, ok := indexerFactories[name]; ok {
 		return val.Build(arg, opts, log)
 	}
-	return nil, fmt.Errorf("no IndexerDb factory for %s", name)
+	return nil, nil, fmt.Errorf("no IndexerDb factory for %s", name)
 }
 
 func init() {

--- a/idb/idb_factory.go
+++ b/idb/idb_factory.go
@@ -23,6 +23,8 @@ func RegisterFactory(name string, factory IndexerDbFactory) {
 }
 
 // IndexerDbByName is used to construct an IndexerDb object by name.
+// Returns an IndexerDb object, an availability channel that closes when the database
+// becomes available, and an error object.
 func IndexerDbByName(name, arg string, opts IndexerDbOptions, log *log.Logger) (IndexerDb, chan struct{}, error) {
 	if val, ok := indexerFactories[name]; ok {
 		return val.Build(arg, opts, log)

--- a/idb/migration/migration_test.go
+++ b/idb/migration/migration_test.go
@@ -332,8 +332,7 @@ func TestSuccessfulMigration(t *testing.T) {
 }
 
 // TestAvailabilityChannelCloses tests that the migration object closes the availability
-// channel when blocking migrations finish. If it is not the case, this test will deadlock
-// (and timeout).
+// channel when blocking migrations finish.
 func TestAvailabilityChannelCloses(t *testing.T) {
 	// Migration 2 reads on this channel.
 	migrationTwoChannel := make(chan struct{})
@@ -362,8 +361,12 @@ func TestAvailabilityChannelCloses(t *testing.T) {
 	require.NoError(t, err)
 
 	availableCh := m.RunMigrations()
-	_, ok := <-availableCh
-	assert.False(t, ok)
+	select {
+	case _, ok := <-availableCh:
+		assert.False(t, ok)
+	case <-time.After(10 * time.Millisecond):
+		assert.Fail(t, "channel must be closed")
+	}
 }
 
 // TestAvailabilityChannelClosesNoMigrations tests that the migration object closes
@@ -384,8 +387,12 @@ func TestAvailabilityChannelClosesNoMigrations(t *testing.T) {
 	require.NoError(t, err)
 
 	availableCh := m.RunMigrations()
-	_, ok := <-availableCh
-	assert.False(t, ok)
+	select {
+	case _, ok := <-availableCh:
+		assert.False(t, ok)
+	case <-time.After(10 * time.Millisecond):
+		assert.Fail(t, "channel must be closed")
+	}
 }
 
 // TestAvailabilityChannelClosesBlockingMigrationLast tests that the migration object
@@ -396,8 +403,12 @@ func TestAvailabilityChannelClosesBlockingMigrationLast(t *testing.T) {
 	require.NoError(t, err)
 
 	availableCh := m.RunMigrations()
-	_, ok := <-availableCh
-	assert.False(t, ok)
+	select {
+	case _, ok := <-availableCh:
+		assert.False(t, ok)
+	case <-time.After(10 * time.Millisecond):
+		assert.Fail(t, "channel must be closed")
+	}
 }
 
 // TestAvailabilityChannelDoesNotCloseEarly tests that the migration object closes the availability

--- a/idb/migration/migration_test.go
+++ b/idb/migration/migration_test.go
@@ -371,7 +371,6 @@ func TestAvailabilityChannelCloses(t *testing.T) {
 
 // TestAvailabilityChannelClosesNoMigrations tests that the migration object closes
 // the availability channel when last migration, which is blocking, finishes.
-// If it is not the case, this test will deadlock (and timeout).
 func TestAvailabilityChannelClosesNoMigrations(t *testing.T) {
 	tasks := []Task{
 		{
@@ -396,8 +395,7 @@ func TestAvailabilityChannelClosesNoMigrations(t *testing.T) {
 }
 
 // TestAvailabilityChannelClosesBlockingMigrationLast tests that the migration object
-// closes when there are no migrations. If it is not the case, this test will
-// deadlock (and timeout).
+// closes when there are no migrations.
 func TestAvailabilityChannelClosesBlockingMigrationLast(t *testing.T) {
 	m, err := MakeMigration([]Task{}, nil)
 	require.NoError(t, err)

--- a/idb/migration/migration_test.go
+++ b/idb/migration/migration_test.go
@@ -337,6 +337,9 @@ func TestSuccessfulMigration(t *testing.T) {
 func TestAvailabilityChannelCloses(t *testing.T) {
 	// Migration 2 reads on this channel.
 	migrationTwoChannel := make(chan struct{})
+	defer func() {
+		migrationTwoChannel <- struct{}{}
+	}()
 
 	tasks := []Task{
 		{
@@ -361,9 +364,6 @@ func TestAvailabilityChannelCloses(t *testing.T) {
 	availableCh := m.RunMigrations()
 	_, ok := <-availableCh
 	assert.False(t, ok)
-
-	// This will block until migration 1 reads from the channel.
-	migrationTwoChannel <- struct{}{}
 }
 
 // TestAvailabilityChannelClosesNoMigrations tests that the migration object closes

--- a/idb/migration/migration_test.go
+++ b/idb/migration/migration_test.go
@@ -424,11 +424,9 @@ func TestAvailabilityChannelDoesNotCloseEarly(t *testing.T) {
 	require.NoError(t, err)
 
 	availableCh := m.RunMigrations()
-
-	time.Sleep(5 * time.Millisecond)
 	select {
 	case <-availableCh:
 		assert.Fail(t, "availability channel closed before migrations finish running")
-	default:
+	case <-time.After(5 * time.Millisecond):
 	}
 }

--- a/idb/postgres/postgres_factory.go
+++ b/idb/postgres/postgres_factory.go
@@ -13,7 +13,7 @@ func (df postgresFactory) Name() string {
 	return "postgres"
 }
 
-func (df postgresFactory) Build(arg string, opts idb.IndexerDbOptions, log *log.Logger) (idb.IndexerDb, error) {
+func (df postgresFactory) Build(arg string, opts idb.IndexerDbOptions, log *log.Logger) (idb.IndexerDb, chan struct{}, error) {
 	return OpenPostgres(arg, opts, log)
 }
 

--- a/idb/postgres/postgres_integration_common_test.go
+++ b/idb/postgres/postgres_integration_common_test.go
@@ -47,7 +47,7 @@ func setupPostgres(t *testing.T) (*sql.DB, string, func()) {
 func setupIdb(t *testing.T, genesis types.Genesis) (*IndexerDb /*db*/, func() /*shutdownFunc*/) {
 	_, connStr, shutdownFunc := setupPostgres(t)
 
-	idb, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	idb, _, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	require.NoError(t, err)
 
 	err = idb.LoadGenesis(genesis)

--- a/idb/postgres/postgres_migrations_integration_test.go
+++ b/idb/postgres/postgres_migrations_integration_test.go
@@ -32,7 +32,7 @@ type oldImportState struct {
 func TestMaxRoundAccountedMigrationAccountRound0(t *testing.T) {
 	_, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
-	db, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	db, _, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	round := int64(0)
@@ -64,7 +64,7 @@ func TestMaxRoundAccountedMigrationAccountRound0(t *testing.T) {
 func TestMaxRoundAccountedMigrationAccountRoundPositive(t *testing.T) {
 	_, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
-	db, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	db, _, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	round := int64(2)
@@ -96,7 +96,7 @@ func TestMaxRoundAccountedMigrationAccountRoundPositive(t *testing.T) {
 func TestMaxRoundAccountedMigrationUninitialized(t *testing.T) {
 	_, connStr, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()
-	db, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	db, _, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 
 	migrationState := MigrationState{NextMigration: 4}

--- a/idb/postgres/postgres_test.go
+++ b/idb/postgres/postgres_test.go
@@ -31,7 +31,7 @@ func TestAllMigrations(t *testing.T) {
 			})
 
 			// This automatically runs migrations
-			pdb, err := openPostgres(db, idb.IndexerDbOptions{
+			pdb, _, err := openPostgres(db, idb.IndexerDbOptions{
 				ReadOnly: false,
 			}, nil)
 			require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestNoMigrationsNeeded(t *testing.T) {
 	})
 
 	// This automatically runs migraions
-	pdb, err := openPostgres(db, idb.IndexerDbOptions{
+	pdb, _, err := openPostgres(db, idb.IndexerDbOptions{
 		ReadOnly: false,
 	}, nil)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary

Currently, `daemon.go` has a sleep loop calls `idb.Health()` until it reports that the database is available (blocking migrations have run successfully). A sleep loop is not elegant, and `idb.Health()` might return an error because it can't parse data from the database before blocking migrations have run. Particularly now it is possible that `idb.Health()` is run before the blocking migration that changes the import state format, in which case indexer will crash.

This PR replaces the sleep loop with a channel that is closed by the migration object as soon as all blocking migrations have finished running successfully.

## Test Plan

Added tests for the `Migration` type.

Tested manually that
- Indexer runs normally with an empty database
- Indexer runs normally with a database that already has some blocks (from previous scenario)
- When upgrading from 2.5.0, Indexer starts importing blocks only after the blocking migration finishes.