### PR TITLE
Add more prometheus metrics.

### DIFF
--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -188,7 +188,6 @@ func (bih *blockImporterHandler) HandleBlock(block *types.EncodedBlockCert) {
 	maybeFail(err, "ImportDecodedBlock %d", block.Block.Round)
 	dtUpload := time.Now().Sub(start)
 	metrics.BlockUploadTime.Observe(dtUpload.Seconds())
-	metrics.CumulativeBlockUploadTime.Add(dtUpload.Seconds())
 	startRound, err := bih.db.GetNextRoundToAccount()
 	maybeFail(err, "failed to get next round to account")
 	// During normal operation StartRound and MaxRound will be the same round.
@@ -202,10 +201,8 @@ func (bih *blockImporterHandler) HandleBlock(block *types.EncodedBlockCert) {
 	// Ignore calls that update >1 round (sneaky migration) and round 0
 	if rounds <= 1 && startRound != 0 {
 		metrics.BlockImportTimeSeconds.Observe(dt.Seconds())
-		metrics.CumulativeImportTime.Add(dt.Seconds())
 		metrics.ImportedTxnsPerBlock.Observe(float64(txns))
-		metrics.CumulativeTxns.Add(float64(txns))
-		metrics.CurrentRoundGauge.Set(float64(startRound))
+		metrics.ImportedRoundGauge.Set(float64(startRound))
 	}
 
 	logger.Infof("round r=%d (%d txn) imported in %s", block.Block.Round, len(block.Block.Payset), dt.String())

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -31,23 +30,12 @@ var (
 	tokenString      string
 )
 
-// importTimeHistogramSeconds is used to record the block import time metric.
-var importTimeHistogramSeconds = prometheus.NewSummary(
-	prometheus.SummaryOpts{
-		Subsystem: "indexer_daemon",
-		Name:      "import_time_sec",
-		Help:      "Block import and processing time in seconds.",
-	})
-
 var daemonCmd = &cobra.Command{
 	Use:   "daemon",
 	Short: "run indexer daemon",
 	Long:  "run indexer daemon. Serve api on HTTP.",
 	//Args:
 	Run: func(cmd *cobra.Command, args []string) {
-		// register metric with global prometheus metrics handler
-		prometheus.Register(importTimeHistogramSeconds)
-
 		var err error
 		config.BindFlags(cmd)
 		err = configureLogger()
@@ -206,7 +194,6 @@ func (bih *blockImporterHandler) HandleBlock(block *types.EncodedBlockCert) {
 	}
 	importer.UpdateAccounting(bih.db, bih.cache, filter, logger)
 	dt := time.Now().Sub(start)
-	// record metric
-	importTimeHistogramSeconds.Observe(dt.Seconds())
+
 	logger.Infof("round r=%d (%d txn) imported in %s", block.Block.Round, len(block.Block.Payset), dt.String())
 }

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -187,7 +187,7 @@ func (bih *blockImporterHandler) HandleBlock(block *types.EncodedBlockCert) {
 	_, err := bih.imp.ImportDecodedBlock(block)
 	maybeFail(err, "ImportDecodedBlock %d", block.Block.Round)
 	dtUpload := time.Now().Sub(start)
-	metrics.BlockUploadTime.Observe(dtUpload.Seconds())
+	metrics.BlockUploadTimeSeconds.Observe(dtUpload.Seconds())
 	startRound, err := bih.db.GetNextRoundToAccount()
 	maybeFail(err, "failed to get next round to account")
 	// During normal operation StartRound and MaxRound will be the same round.

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/idb/dummy"
 	_ "github.com/algorand/indexer/idb/postgres"
+	"github.com/algorand/indexer/util/metrics"
 	"github.com/algorand/indexer/version"
 )
 
@@ -141,6 +142,9 @@ func init() {
 
 	viper.SetEnvPrefix(config.EnvPrefix)
 	viper.AutomaticEnv()
+
+	// Register metrics with the global prometheus handler.
+	metrics.RegisterPrometheusMetrics()
 }
 
 func configureLogger() error {

--- a/cmd/block-generator/runner/metrics_collector.go
+++ b/cmd/block-generator/runner/metrics_collector.go
@@ -23,8 +23,8 @@ type Entry struct {
 }
 
 // Collect fetches the metrics.
-func (r *MetricsCollector) Collect(prefix string) error {
-	metrics, err := r.getMetrics(prefix)
+func (r *MetricsCollector) Collect(substrings ...string) error {
+	metrics, err := r.getMetrics(substrings...)
 	if err != nil {
 		return err
 	}
@@ -40,7 +40,7 @@ func (r *MetricsCollector) Collect(prefix string) error {
 	return nil
 }
 
-func (r MetricsCollector) getMetrics(prefix string) (result []string, err error) {
+func (r MetricsCollector) getMetrics(substrings ...string) (result []string, err error) {
 	resp, err := http.Get(r.MetricsURL)
 	if err != nil {
 		err = fmt.Errorf("unable to read metrics url '%s'", r.MetricsURL)
@@ -56,8 +56,11 @@ func (r MetricsCollector) getMetrics(prefix string) (result []string, err error)
 			continue
 		}
 
-		if strings.HasPrefix(str, prefix) {
-			result = append(result, str)
+		for _, substring := range substrings {
+			if strings.Contains(str, substring) {
+				result = append(result, str)
+				break
+			}
 		}
 	}
 

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -277,13 +277,13 @@ func (r *Args) runTest(indexerURL string, generatorURL string) error {
 
 	// Record a rate from one of the first data points.
 	if len(collector.Data) > 5 {
-		if err := recordDataToFile(collector.Data[2], "starting",  report); err != nil {
+		if err := recordDataToFile(collector.Data[2], "starting", report); err != nil {
 			return err
 		}
 	}
 
 	// Also record the final one.
-	if err := recordDataToFile(collector.Data[len(collector.Data)-1], "final",  report); err != nil {
+	if err := recordDataToFile(collector.Data[len(collector.Data)-1], "final", report); err != nil {
 		return err
 	}
 

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -93,7 +93,6 @@ const (
 
 // Helper to record metrics. Supports rates (sum/count) and counters.
 func recordDataToFile(start time.Time, entry Entry, prefix string, out *os.File) error {
-	num := 0
 	var writeErrors strings.Builder
 	var writeErr error
 	record := func(prefix2, name string, t metricType) {
@@ -105,7 +104,6 @@ func recordDataToFile(start time.Time, entry Entry, prefix string, out *os.File)
 			}
 			writeErrors.WriteString(name)
 		}
-		num++
 	}
 
 	record("_average", metrics.BlockImportTimeName, rate)
@@ -214,7 +212,7 @@ func getMetric(entry Entry, suffix string, rateMetric bool) (float64, error) {
 		}
 	}
 
-	return 0.0, fmt.Errorf("metric not found: %s", suffix)
+	return 0.0, fmt.Errorf("metric incomplete or not found: %s", suffix)
 }
 
 // Run the test for 'RunDuration', collect metrics and write them to the 'ReportDirectory'

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -98,7 +98,7 @@ func recordDataToFile(entry Entry, prefix string, out *os.File) error {
 	var writeErr error
 	record := func(prefix2, name string, t metricType) {
 		key := fmt.Sprintf("%s%s_%s", prefix, prefix2, name)
-		if err := recordMetricToFile(entry, out, key, name, t); err != nil {
+		if err := recordMetricToFile(entry, key, name, t, out); err != nil {
 			writeErr = err
 			if writeErrors.Len() > 0 {
 				writeErrors.WriteString(", ")
@@ -140,7 +140,7 @@ func recordDataToFile(entry Entry, prefix string, out *os.File) error {
 	return nil
 }
 
-func recordMetricToFile(entry Entry, out *os.File, outputKey, metricSuffix string, t metricType) error {
+func recordMetricToFile(entry Entry, outputKey, metricSuffix string, t metricType, out *os.File) error {
 	value, err := getMetric(entry, metricSuffix, t)
 	if err != nil {
 		return err

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -203,7 +203,7 @@ func getMetric(entry Entry, suffix string, rateMetric bool) (float64, error) {
 
 			if rateMetric && hasSum && hasCount {
 				return sum / count, nil
-			} else if rateMetric {
+			} else if !rateMetric {
 				if hasSum {
 					return sum, nil
 				}

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -233,8 +233,7 @@ func (r *Args) runTest(indexerURL string, generatorURL string) error {
 	}
 
 	// Also record the final one.
-	//if err := recordDataToFile(collector.Data[len(collector.Data)-1], mPair, report); err != nil {
-	if err := recordDataToFile(collector.Data[2], "final",  report); err != nil {
+	if err := recordDataToFile(collector.Data[len(collector.Data)-1], "final",  report); err != nil {
 		return err
 	}
 

--- a/importer/helper.go
+++ b/importer/helper.go
@@ -268,12 +268,10 @@ func updateAccounting(db idb.IndexerDb, frozenCache map[uint64]bool, filter idb.
 	var blockHeaderPtr *types.BlockHeader = nil
 
 	commit := func() {
-		if blockHeaderPtr != nil {
-			// Don't commit if there were no transactions.
-			if txnForRound > 0 {
-				err := db.CommitRoundAccounting(act.RoundUpdates, currentRound, blockHeaderPtr)
-				maybeFail(err, l, "failed to commit round accounting")
-			}
+		// Don't commit if there were no transactions.
+		if blockHeaderPtr != nil && txnForRound > 0 {
+			err := db.CommitRoundAccounting(act.RoundUpdates, currentRound, blockHeaderPtr)
+			maybeFail(err, l, "failed to commit round accounting")
 		}
 	}
 

--- a/importer/helper.go
+++ b/importer/helper.go
@@ -278,7 +278,6 @@ func updateAccounting(db idb.IndexerDb, frozenCache map[uint64]bool, filter idb.
 	}
 
 	for txn := range txns {
-		fmt.Println("processing a transaction")
 		maybeFail(txn.Error, l, "updateAccounting txn fetch, %v", txn.Error)
 		if txn.Round != currentRound {
 			commit()

--- a/importer/helper.go
+++ b/importer/helper.go
@@ -281,10 +281,11 @@ func updateAccounting(db idb.IndexerDb, frozenCache map[uint64]bool, filter idb.
 			now := time.Now()
 			dt := now.Sub(roundStart)
 			roundStart = now
-			metrics.ImportTimeHistogramSeconds.Observe(dt.Seconds())
-			metrics.ImportTimeCounter.Add(float64(dt.Milliseconds()))
-			metrics.ImportedTransactionsHistogram.Observe(float64(txnForRound))
-			metrics.ImportedTransactionsCounter.Add(float64(txnForRound))
+			metrics.BlockImportTimeHistogramSeconds.Observe(dt.Seconds())
+			metrics.CumulativeImportTimeCounter.Add(dt.Seconds())
+			metrics.ImportedTransactionsPerBlockHistogram.Observe(float64(txnForRound))
+			metrics.CumulativeTransactionsCounter.Add(float64(txnForRound))
+			metrics.CurrentRoundGauge.Set(float64(currentRound))
 		}
 	}
 	for txn := range txns {

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -1,0 +1,48 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+func RegisterPrometheusMetrics() {
+	prometheus.Register(ImportTimeHistogramSeconds)
+	prometheus.Register(ImportTimeCounter)
+	prometheus.Register(ImportedTransactionsCounter)
+	prometheus.Register(ImportedTransactionsHistogram)
+}
+
+const ImportTimeHistogramName = "import_time_sec"
+const ImportTimeCounterName = "cumulative_import_time_milli_sec"
+const ImportedTransactionsHistogramName = "imported_tx_per_sec"
+const ImportedTransactionsCounterName = "cumulative_imported_tx"
+
+// ImportTimeHistogramSeconds average block import duration in seconds.
+var ImportTimeHistogramSeconds = prometheus.NewSummary(
+	prometheus.SummaryOpts{
+		Subsystem: "indexer_daemon",
+		Name:      ImportTimeHistogramName,
+		Help:      "Block import and processing time in seconds.",
+	})
+
+// ImportTimeCounter total time spent importing blocks since indexer was launched.
+var ImportTimeCounter = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Subsystem: "indexer_daemon",
+		Name:      ImportTimeCounterName,
+		Help:      "Total time spent importing blocks in milli seconds.",
+	})
+
+// ImportedTransactionsHistogram average number of transactions per block.
+var ImportedTransactionsHistogram = prometheus.NewSummary(
+	prometheus.SummaryOpts{
+		Subsystem: "indexer_daemon",
+		Name:      ImportedTransactionsHistogramName,
+		Help:      "Block import and processing time in seconds.",
+	})
+
+// ImportedTransactionsCounter total number of transactions imported since indexer was launched.
+var ImportedTransactionsCounter = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Subsystem: "indexer_daemon",
+		Name:      ImportedTransactionsCounterName,
+		Help:      "Total transactions imported.",
+	})
+

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -8,7 +8,7 @@ func RegisterPrometheusMetrics() {
 	prometheus.Register(BlockImportTimeSeconds)
 	prometheus.Register(ImportedTxnsPerBlock)
 	prometheus.Register(ImportedRoundGauge)
-	prometheus.Register(BlockUploadTime)
+	prometheus.Register(BlockUploadTimeSeconds)
 }
 
 // Prometheus metric names broken out for reuse.
@@ -36,7 +36,7 @@ var (
 			Help:      "Total block upload and processing time in seconds.",
 		})
 
-	BlockUploadTime = prometheus.NewSummary(
+	BlockUploadTimeSeconds = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Subsystem: "indexer_daemon",
 			Name:      BlockUploadTimeName,

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -25,6 +25,7 @@ const (
 	CurrentRoundGaugeName         = "current_round"
 )
 
+// Initialize the prometheus objects.
 var (
 	// AllMetricNames is a reference for all the custom metric names.
 	AllMetricNames = []string{
@@ -36,7 +37,6 @@ var (
 		CumulativeTxnsName,
 		CurrentRoundGaugeName}
 
-	// BlockImportTimeSeconds average block import duration in seconds.
 	BlockImportTimeSeconds = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Subsystem: "indexer_daemon",
@@ -44,7 +44,6 @@ var (
 			Help:      "Total block upload and processing time in seconds.",
 		})
 
-	// CumulativeImportTime total time spent importing blocks since indexer was launched.
 	CumulativeImportTime = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Subsystem: "indexer_daemon",
@@ -52,7 +51,6 @@ var (
 			Help:      "Total time in seconds spent uploading and processing blocks.",
 		})
 
-	// BlockUploadTime average block upload duration in seconds.
 	BlockUploadTime = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Subsystem: "indexer_daemon",
@@ -60,7 +58,6 @@ var (
 			Help:      "Block upload time in seconds.",
 		})
 
-	// CumulativeBlockUploadTime total time spent importing blocks since indexer was launched.
 	CumulativeBlockUploadTime = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Subsystem: "indexer_daemon",
@@ -68,7 +65,6 @@ var (
 			Help:      "Total time in seconds spent uploading blocks.",
 		})
 
-	// ImportedTxnsPerBlock average number of transactions per block.
 	ImportedTxnsPerBlock = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Subsystem: "indexer_daemon",
@@ -76,7 +72,6 @@ var (
 			Help:      "Transactions per block.",
 		})
 
-	// CumulativeTxns total number of transactions imported since indexer was launched.
 	CumulativeTxns = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Subsystem: "indexer_daemon",
@@ -84,7 +79,6 @@ var (
 			Help:      "Cumulative transactions imported.",
 		})
 
-	// CurrentRoundGauge current processed round.
 	CurrentRoundGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Subsystem: "indexer_daemon",

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -5,57 +5,82 @@ import "github.com/prometheus/client_golang/prometheus"
 // RegisterPrometheusMetrics register all prometheus metrics with the global
 // metrics handler.
 func RegisterPrometheusMetrics() {
-	prometheus.Register(BlockImportTimeHistogramSeconds)
-	prometheus.Register(CumulativeImportTimeCounter)
-	prometheus.Register(CumulativeTransactionsCounter)
-	prometheus.Register(ImportedTransactionsPerBlockHistogram)
+	prometheus.Register(BlockImportTimeSeconds)
+	prometheus.Register(CumulativeImportTime)
+	prometheus.Register(CumulativeTxns)
+	prometheus.Register(ImportedTxnsPerBlock)
 	prometheus.Register(CurrentRoundGauge)
+	prometheus.Register(CumulativeBlockUploadTime)
+	prometheus.Register(BlockUploadTime)
 }
 
+// Prometheus metric names broken out for reuse.
 const (
-
-	// ImportTimePerBlockHistogramName metric name.
-	ImportTimePerBlockHistogramName = "average_import_time_sec"
-	// ImportTimeCounterName metric name.
-	ImportTimeCounterName = "cumulative_import_time_sec"
-	// TransactionsPerBlockHistogramName metric name.
-	TransactionsPerBlockHistogramName = "average_imported_tx_per_block"
-	// ImportedTransactionsCounterName metric name.
-	ImportedTransactionsCounterName = "cumulative_imported_tx"
-	// CurrentRoundGaugeName metric name.
-	CurrentRoundGaugeName = "current_round"
+	BlockImportTimeName           = "average_import_time_sec"
+	CumulativeImportTimeName      = "cumulative_import_time_sec"
+	BlockUploadTimeName           = "average_block_upload_time_sec"
+	CumulativeBlockUploadTimeName = "cumulative_block_upload_time_sec"
+	ImportedTxnsPerBlockName      = "average_imported_tx_per_block"
+	CumulativeTxnsName            = "cumulative_imported_tx"
+	CurrentRoundGaugeName         = "current_round"
 )
 
 var (
-	// BlockImportTimeHistogramSeconds average block import duration in seconds.
-	BlockImportTimeHistogramSeconds = prometheus.NewSummary(
+	// AllMetricNames is a reference for all the custom metric names.
+	AllMetricNames = []string{
+		BlockImportTimeName,
+		CumulativeImportTimeName,
+		BlockUploadTimeName,
+		CumulativeBlockUploadTimeName,
+		ImportedTxnsPerBlockName,
+		CumulativeTxnsName,
+		CurrentRoundGaugeName}
+
+	// BlockImportTimeSeconds average block import duration in seconds.
+	BlockImportTimeSeconds = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Subsystem: "indexer_daemon",
-			Name:      ImportTimePerBlockHistogramName,
-			Help:      "Block import and processing time in seconds.",
+			Name:      BlockImportTimeName,
+			Help:      "Total block upload and processing time in seconds.",
 		})
 
-	// CumulativeImportTimeCounter total time spent importing blocks since indexer was launched.
-	CumulativeImportTimeCounter = prometheus.NewCounter(
+	// CumulativeImportTime total time spent importing blocks since indexer was launched.
+	CumulativeImportTime = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Subsystem: "indexer_daemon",
-			Name:      ImportTimeCounterName,
-			Help:      "Total time spent importing blocks in seconds.",
+			Name:      CumulativeImportTimeName,
+			Help:      "Total time in seconds spent uploading and processing blocks.",
 		})
 
-	// ImportedTransactionsPerBlockHistogram average number of transactions per block.
-	ImportedTransactionsPerBlockHistogram = prometheus.NewSummary(
+	// BlockUploadTime average block upload duration in seconds.
+	BlockUploadTime = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Subsystem: "indexer_daemon",
-			Name:      TransactionsPerBlockHistogramName,
+			Name:      BlockUploadTimeName,
+			Help:      "Block upload time in seconds.",
+		})
+
+	// CumulativeBlockUploadTime total time spent importing blocks since indexer was launched.
+	CumulativeBlockUploadTime = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: "indexer_daemon",
+			Name:      CumulativeBlockUploadTimeName,
+			Help:      "Total time in seconds spent uploading blocks.",
+		})
+
+	// ImportedTxnsPerBlock average number of transactions per block.
+	ImportedTxnsPerBlock = prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Subsystem: "indexer_daemon",
+			Name:      ImportedTxnsPerBlockName,
 			Help:      "Transactions per block.",
 		})
 
-	// CumulativeTransactionsCounter total number of transactions imported since indexer was launched.
-	CumulativeTransactionsCounter = prometheus.NewCounter(
+	// CumulativeTxns total number of transactions imported since indexer was launched.
+	CumulativeTxns = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Subsystem: "indexer_daemon",
-			Name:      ImportedTransactionsCounterName,
+			Name:      CumulativeTxnsName,
 			Help:      "Cumulative transactions imported.",
 		})
 

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -3,46 +3,59 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 func RegisterPrometheusMetrics() {
-	prometheus.Register(ImportTimeHistogramSeconds)
-	prometheus.Register(ImportTimeCounter)
-	prometheus.Register(ImportedTransactionsCounter)
-	prometheus.Register(ImportedTransactionsHistogram)
+	prometheus.Register(BlockImportTimeHistogramSeconds)
+	prometheus.Register(CumulativeImportTimeCounter)
+	prometheus.Register(CumulativeTransactionsCounter)
+	prometheus.Register(ImportedTransactionsPerBlockHistogram)
+	prometheus.Register(CurrentRoundGauge)
 }
 
-const ImportTimeHistogramName = "import_time_sec"
-const ImportTimeCounterName = "cumulative_import_time_milli_sec"
-const ImportedTransactionsHistogramName = "imported_tx_per_sec"
-const ImportedTransactionsCounterName = "cumulative_imported_tx"
+const (
+	ImportTimePerBlockHistogramName = "average_import_time_sec"
+	ImportTimeCounterName = "cumulative_import_time_sec"
+	TransactionsPerBlockHistogramName = "average_imported_tx_per_block"
+	ImportedTransactionsCounterName = "cumulative_imported_tx"
+	CurrentRoundGaugeName = "current_round"
+)
 
-// ImportTimeHistogramSeconds average block import duration in seconds.
-var ImportTimeHistogramSeconds = prometheus.NewSummary(
-	prometheus.SummaryOpts{
-		Subsystem: "indexer_daemon",
-		Name:      ImportTimeHistogramName,
-		Help:      "Block import and processing time in seconds.",
-	})
+var (
+	// BlockImportTimeHistogramSeconds average block import duration in seconds.
+	BlockImportTimeHistogramSeconds = prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Subsystem: "indexer_daemon",
+			Name:      ImportTimePerBlockHistogramName,
+			Help:      "Block import and processing time in seconds.",
+		})
 
-// ImportTimeCounter total time spent importing blocks since indexer was launched.
-var ImportTimeCounter = prometheus.NewCounter(
-	prometheus.CounterOpts{
-		Subsystem: "indexer_daemon",
-		Name:      ImportTimeCounterName,
-		Help:      "Total time spent importing blocks in milli seconds.",
-	})
+	// CumulativeImportTimeCounter total time spent importing blocks since indexer was launched.
+	CumulativeImportTimeCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: "indexer_daemon",
+			Name:      ImportTimeCounterName,
+			Help:      "Total time spent importing blocks in seconds.",
+		})
 
-// ImportedTransactionsHistogram average number of transactions per block.
-var ImportedTransactionsHistogram = prometheus.NewSummary(
-	prometheus.SummaryOpts{
-		Subsystem: "indexer_daemon",
-		Name:      ImportedTransactionsHistogramName,
-		Help:      "Block import and processing time in seconds.",
-	})
+	// ImportedTransactionsPerBlockHistogram average number of transactions per block.
+	ImportedTransactionsPerBlockHistogram = prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Subsystem: "indexer_daemon",
+			Name:      TransactionsPerBlockHistogramName,
+			Help:      "Transactions per block.",
+		})
 
-// ImportedTransactionsCounter total number of transactions imported since indexer was launched.
-var ImportedTransactionsCounter = prometheus.NewCounter(
-	prometheus.CounterOpts{
-		Subsystem: "indexer_daemon",
-		Name:      ImportedTransactionsCounterName,
-		Help:      "Total transactions imported.",
-	})
+	// CumulativeTransactionsCounter total number of transactions imported since indexer was launched.
+	CumulativeTransactionsCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: "indexer_daemon",
+			Name:      ImportedTransactionsCounterName,
+			Help:      "Cumulative transactions imported.",
+		})
 
+	// CurrentRoundGauge current processed round.
+	CurrentRoundGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: "indexer_daemon",
+			Name:      CurrentRoundGaugeName,
+			Help:      "The most recent round indexer has imported.",
+		})
+)

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -6,34 +6,25 @@ import "github.com/prometheus/client_golang/prometheus"
 // metrics handler.
 func RegisterPrometheusMetrics() {
 	prometheus.Register(BlockImportTimeSeconds)
-	prometheus.Register(CumulativeImportTime)
-	prometheus.Register(CumulativeTxns)
 	prometheus.Register(ImportedTxnsPerBlock)
-	prometheus.Register(CurrentRoundGauge)
-	prometheus.Register(CumulativeBlockUploadTime)
+	prometheus.Register(ImportedRoundGauge)
 	prometheus.Register(BlockUploadTime)
 }
 
 // Prometheus metric names broken out for reuse.
 const (
-	BlockImportTimeName           = "average_import_time_sec"
-	CumulativeImportTimeName      = "cumulative_import_time_sec"
-	BlockUploadTimeName           = "average_block_upload_time_sec"
-	CumulativeBlockUploadTimeName = "cumulative_block_upload_time_sec"
-	ImportedTxnsPerBlockName      = "average_imported_tx_per_block"
-	CumulativeTxnsName            = "cumulative_imported_tx"
-	CurrentRoundGaugeName         = "current_round"
+	BlockImportTimeName      = "import_time_sec"
+	BlockUploadTimeName      = "block_upload_time_sec"
+	ImportedTxnsPerBlockName = "imported_tx_per_block"
+	ImportedRoundGaugeName   = "imported_round"
 )
 
 // AllMetricNames is a reference for all the custom metric names.
 var AllMetricNames = []string{
 	BlockImportTimeName,
-	CumulativeImportTimeName,
 	BlockUploadTimeName,
-	CumulativeBlockUploadTimeName,
 	ImportedTxnsPerBlockName,
-	CumulativeTxnsName,
-	CurrentRoundGaugeName,
+	ImportedRoundGaugeName,
 }
 
 // Initialize the prometheus objects.
@@ -45,25 +36,11 @@ var (
 			Help:      "Total block upload and processing time in seconds.",
 		})
 
-	CumulativeImportTime = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Subsystem: "indexer_daemon",
-			Name:      CumulativeImportTimeName,
-			Help:      "Total time in seconds spent uploading and processing blocks.",
-		})
-
 	BlockUploadTime = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Subsystem: "indexer_daemon",
 			Name:      BlockUploadTimeName,
 			Help:      "Block upload time in seconds.",
-		})
-
-	CumulativeBlockUploadTime = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Subsystem: "indexer_daemon",
-			Name:      CumulativeBlockUploadTimeName,
-			Help:      "Total time in seconds spent uploading blocks.",
 		})
 
 	ImportedTxnsPerBlock = prometheus.NewSummary(
@@ -73,17 +50,10 @@ var (
 			Help:      "Transactions per block.",
 		})
 
-	CumulativeTxns = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Subsystem: "indexer_daemon",
-			Name:      CumulativeTxnsName,
-			Help:      "Cumulative transactions imported.",
-		})
-
-	CurrentRoundGauge = prometheus.NewGauge(
+	ImportedRoundGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Subsystem: "indexer_daemon",
-			Name:      CurrentRoundGaugeName,
+			Name:      ImportedRoundGaugeName,
 			Help:      "The most recent round indexer has imported.",
 		})
 )

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -25,18 +25,19 @@ const (
 	CurrentRoundGaugeName         = "current_round"
 )
 
+// AllMetricNames is a reference for all the custom metric names.
+var AllMetricNames = []string{
+	BlockImportTimeName,
+	CumulativeImportTimeName,
+	BlockUploadTimeName,
+	CumulativeBlockUploadTimeName,
+	ImportedTxnsPerBlockName,
+	CumulativeTxnsName,
+	CurrentRoundGaugeName,
+}
+
 // Initialize the prometheus objects.
 var (
-	// AllMetricNames is a reference for all the custom metric names.
-	AllMetricNames = []string{
-		BlockImportTimeName,
-		CumulativeImportTimeName,
-		BlockUploadTimeName,
-		CumulativeBlockUploadTimeName,
-		ImportedTxnsPerBlockName,
-		CumulativeTxnsName,
-		CurrentRoundGaugeName}
-
 	BlockImportTimeSeconds = prometheus.NewSummary(
 		prometheus.SummaryOpts{
 			Subsystem: "indexer_daemon",

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -2,6 +2,8 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
+// RegisterPrometheusMetrics register all prometheus metrics with the global
+// metrics handler.
 func RegisterPrometheusMetrics() {
 	prometheus.Register(BlockImportTimeHistogramSeconds)
 	prometheus.Register(CumulativeImportTimeCounter)
@@ -11,10 +13,16 @@ func RegisterPrometheusMetrics() {
 }
 
 const (
+
+	// ImportTimePerBlockHistogramName metric name.
 	ImportTimePerBlockHistogramName = "average_import_time_sec"
+	// ImportTimeCounterName metric name.
 	ImportTimeCounterName = "cumulative_import_time_sec"
+	// TransactionsPerBlockHistogramName metric name.
 	TransactionsPerBlockHistogramName = "average_imported_tx_per_block"
+	// ImportedTransactionsCounterName metric name.
 	ImportedTransactionsCounterName = "cumulative_imported_tx"
+	// CurrentRoundGaugeName metric name.
 	CurrentRoundGaugeName = "current_round"
 )
 


### PR DESCRIPTION
## Summary

Added some new metrics to go along with `indexer_daemon_import_time_sec`:
-  block_upload_time_sec
-  imported_tx_per_block
-  imported_round

Also moved the location where metrics are collected, previously they did not represent exactly one round worth of data.

Updated the block generator import test runner to capture the new metrics.

New report output
```
cat cmd/block-generator/results/config.asset.close.report
test_duration_seconds:3600
test_duration_actual_seconds:3600.027172
transaction_asset_create_total:2134
transaction_asset_optin_total:1065726
transaction_asset_xfer_total:208325
transaction_asset_close_total:843815
early_average_import_time_sec:8.17
early_cumulative_import_time_sec:1054.50
early_average_imported_tx_per_block:5000.00
early_cumulative_imported_tx_per_block:645000
early_average_block_upload_time_sec:0.36
early_cumulative_block_upload_time_sec:47.54
early_imported_round:130
early_overall_transactions_per_second:611.67
early_uptime_seconds:3600.03
final_average_import_time_sec:8.42
final_cumulative_import_time_sec:3554.10
final_average_imported_tx_per_block:5000.00
final_cumulative_imported_tx_per_block:2110000
final_average_block_upload_time_sec:0.37
final_cumulative_block_upload_time_sec:155.84
final_imported_round:423
final_overall_transactions_per_second:593.68
final_uptime_seconds:3600.03
```

## Test Plan

Run the test runner and observed that the metrics look about right.
