### PR TITLE
Add support for running integration tests with an external DB.

### DIFF
--- a/idb/postgres/postgres_integration_common_test.go
+++ b/idb/postgres/postgres_integration_common_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"database/sql"
+	"flag"
 	"fmt"
 	"testing"
 
@@ -17,8 +18,24 @@ import (
 	"github.com/algorand/indexer/util/test"
 )
 
+var testpg = flag.String("test-pg", "", "postgres connection string")
+
 // setupPostgres starts a gnomock postgres DB then returns the connection string and a shutdown function.
 func setupPostgres(t *testing.T) (*sql.DB, string, func()) {
+	if testpg != nil && *testpg != "" {
+		// TODO: Drop schema?
+
+		// use non-docker Postgresql
+		shutdownFunc := func() {
+			// nothing to do, psql db setup/teardown is external
+		}
+		connStr := *testpg
+		db, err := sql.Open("postgres", connStr)
+		require.NoError(t, err, "Error opening pg connection")
+
+		return db, connStr, shutdownFunc
+	}
+
 	p := postgres.Preset(
 		postgres.WithVersion("12.5"),
 		postgres.WithUser("gnomock", "gnomick"),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Didn't want to lose this functionality from the recent non-utf8 work. We should use it on CI to avoid the gnomock overhead.

## Test Plan

