### PR TITLE
Allow overriding OS_TYPE and ARCH. This will allow signing locally on e.g. mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SRCPATH		:= $(shell pwd)
 VERSION		:= $(shell $(SRCPATH)/mule/scripts/compute_build_number.sh)
 OS_TYPE		?= $(shell $(SRCPATH)/mule/scripts/ostype.sh)
-ARCH			:= $(shell $(SRCPATH)/mule/scripts/archtype.sh)
+ARCH			?= $(shell $(SRCPATH)/mule/scripts/archtype.sh)
 PKG_DIR		= $(SRCPATH)/tmp/node_pkgs/$(OS_TYPE)/$(ARCH)/$(VERSION)
 
 # TODO: ensure any additions here are mirrored in misc/release.py

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SRCPATH		:= $(shell pwd)
 VERSION		:= $(shell $(SRCPATH)/mule/scripts/compute_build_number.sh)
-OS_TYPE		:= $(shell $(SRCPATH)/mule/scripts/ostype.sh)
+OS_TYPE		?= $(shell $(SRCPATH)/mule/scripts/ostype.sh)
 ARCH			:= $(shell $(SRCPATH)/mule/scripts/archtype.sh)
 PKG_DIR		= $(SRCPATH)/tmp/node_pkgs/$(OS_TYPE)/$(ARCH)/$(VERSION)
 

--- a/mule/sign.sh
+++ b/mule/sign.sh
@@ -8,7 +8,7 @@ date "+build_indexer begin SIGN stage %Y%m%d_%H%M%S"
 echo
 
 ARCH=$(./mule/scripts/archtype.sh)
-OS_TYPE=$(./mule/scripts/ostype.sh)
+OS_TYPE=${OS_TYPE:-$(./mule/scripts/ostype.sh)}
 VERSION=$(./mule/scripts/compute_build_number.sh)
 PKG_DIR="./tmp/node_pkgs/$OS_TYPE/$ARCH/$VERSION"
 SIGNING_KEY_ADDR=dev@algorand.com

--- a/mule/sign.sh
+++ b/mule/sign.sh
@@ -7,7 +7,7 @@ echo
 date "+build_indexer begin SIGN stage %Y%m%d_%H%M%S"
 echo
 
-ARCH=$(./mule/scripts/archtype.sh)
+ARCH=${ARCH:-(./mule/scripts/archtype.sh)}
 OS_TYPE=${OS_TYPE:-$(./mule/scripts/ostype.sh)}
 VERSION=$(./mule/scripts/compute_build_number.sh)
 PKG_DIR="./tmp/node_pkgs/$OS_TYPE/$ARCH/$VERSION"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

To execute `make sign` you need to be able to issue the signing command. There is a script for this, but it presumes that the architecture you're signing for is the same as what you're running.

This is problematic if you are on mac, as OS_TYPE will register as darwin. To override this, we allow you to override OS_TYPE, e.g. set it to linux. We will also allow overriding ARCH, since this may be set to arm64 on newer macs.

## Test Plan

Verify signing works with these new changes, e.g.:

`ARCH=amd64 OS_TYPE=linux make sign`
