### PR TITLE
Add missing docker dependencies for go-algorand.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine
 
 # Dependencies
-RUN apk add --update make
+RUN apk add --update make bash libtool git python3
 
 # Install test data
 COPY docker/testdata.tar.bz2 /tmp/testdata.tar.bz2

--- a/docker/Dockerfile.mule
+++ b/docker/Dockerfile.mule
@@ -8,7 +8,7 @@ ENV GOROOT=/usr/local/go
 ENV GOPATH=$HOME/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
-RUN apt-get update && apt-get install -y apt-transport-https awscli ca-certificates build-essential curl git software-properties-common gnupg2 && \
+RUN apt-get update && apt-get install -y apt-transport-https awscli ca-certificates build-essential curl git software-properties-common gnupg2 make bash libtool && \
     curl https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz | tar xzf - && \
     mv go /usr/local && \
     export PATH=/usr/local/go/bin:$PATH && \


### PR DESCRIPTION
Closes https://github.com/algorand/indexer/issues/614.