### PR TITLE
Shutdown daemon gracefully

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -69,6 +69,9 @@ func Serve(ctx context.Context, serveAddr string, db idb.IndexerDb, fetcherError
 	generated.RegisterHandlers(e, &api, middleware...)
 	common.RegisterHandlers(e, &api)
 
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	getctx := func(l net.Listener) context.Context {
 		return ctx
 	}

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	// Load the postgres sql.DB implementation
@@ -358,7 +359,7 @@ func startIndexer(logfile string, loglevel string, indexerBinary string, algodNe
 	resp.Body.Close()
 
 	return func() error {
-		if err := cmd.Process.Kill(); err != nil {
+		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
 			return fmt.Errorf("failed to kill indexer process: %w", err)
 		}
 


### PR DESCRIPTION
## Summary

Shutdown the daemon gracefully to allow the post-run hook in `main.go` to write the CPU profile to disk. Also, send a more polite signal to indexer from block generator.

## Test Plan

Tested manually.
