### PR TITLE
Make `--test-pg` flag correct when running multiple tests

### DIFF
--- a/idb/postgres/internal/testing/testing.go
+++ b/idb/postgres/internal/testing/testing.go
@@ -11,21 +11,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testpg = flag.String("test-pg", "", "postgres connection string")
+var testpg = flag.String(
+	"test-pg", "", "postgres connection string; resets the database")
 
 // SetupPostgres starts a gnomock postgres DB then returns the database object,
 // the connection string and a shutdown function.
 func SetupPostgres(t *testing.T) (*sql.DB, string, func()) {
 	if testpg != nil && *testpg != "" {
-		// TODO: Drop schema?
-
 		// use non-docker Postgresql
 		shutdownFunc := func() {
 			// nothing to do, psql db setup/teardown is external
 		}
 		connStr := *testpg
+
 		db, err := sql.Open("postgres", connStr)
 		require.NoError(t, err, "Error opening pg connection")
+
+		_, err = db.Exec(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`)
+		require.NoError(t, err)
 
 		return db, connStr, shutdownFunc
 	}

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -987,7 +987,6 @@ func TestNonDisplayableUTF8(t *testing.T) {
 		url := testcase.AssetURL
 
 		t.Run(testcase.Name, func(t *testing.T) {
-			t.Parallel()
 			db, shutdownFunc := setupIdb(t, test.MakeGenesis(), test.MakeGenesisBlock())
 			defer shutdownFunc()
 


### PR DESCRIPTION
## Summary

`--test-pg` flag was not suitable for running multiple tests because it didn't reset the database. This PR resets the database and disables parallel test execution.

## Test Plan

`go test -v -args --test-pg "..."` works in `idb/postgres`.