### PR TITLE
Implement the new `indexerLedgerForEval` interface in go-algorand

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/algorand/indexer
 
 go 1.13
 
-replace github.com/algorand/go-algorand => ./third_party/go-algorand
+replace github.com/algorand/go-algorand => ../go-algorand
 
 require (
 	github.com/algorand/go-algorand v0.0.0-20210803210013-358a2e1609c9

--- a/idb/postgres/internal/ledger_for_evaluator/ledger_for_evaluator.go
+++ b/idb/postgres/internal/ledger_for_evaluator/ledger_for_evaluator.go
@@ -2,11 +2,8 @@ package ledgerforevaluator
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
-	"github.com/algorand/go-algorand/config"
-	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -44,25 +41,21 @@ var statements = map[string]string{
 		"WHERE addr = $1 AND NOT deleted",
 }
 
-// LedgerForEvaluator implements the ledgerForEvaluator interface from
+// LedgerForEvaluator implements the indexerLedgerForEval interface from
 // go-algorand ledger/eval.go and is used for accounting.
 type LedgerForEvaluator struct {
 	tx          pgx.Tx
-	genesisHash crypto.Digest
 	// Indexer currently does not store the balances of special account, but
 	// go-algorand's eval checks that they satisfy the minimum balance. We thus return
 	// a fake amount.
 	// TODO: remove.
 	specialAddresses transactions.SpecialAddresses
-	// Value is nil if account was looked up but not found.
-	preloadedAccountData map[basics.Address]*basics.AccountData
 }
 
 // MakeLedgerForEvaluator creates a LedgerForEvaluator object.
-func MakeLedgerForEvaluator(tx pgx.Tx, genesisHash crypto.Digest, specialAddresses transactions.SpecialAddresses) (LedgerForEvaluator, error) {
+func MakeLedgerForEvaluator(tx pgx.Tx, specialAddresses transactions.SpecialAddresses) (LedgerForEvaluator, error) {
 	l := LedgerForEvaluator{
 		tx:               tx,
-		genesisHash:      genesisHash,
 		specialAddresses: specialAddresses,
 	}
 
@@ -84,7 +77,7 @@ func (l *LedgerForEvaluator) Close() {
 	}
 }
 
-// BlockHdr is part of go-algorand's ledgerForEvaluator interface.
+// BlockHdr is part of go-algorand's indexerLedgerForEval interface.
 func (l LedgerForEvaluator) BlockHdr(round basics.Round) (bookkeeping.BlockHeader, error) {
 	row := l.tx.QueryRow(context.Background(), blockHeaderStmtName, uint64(round))
 
@@ -100,12 +93,6 @@ func (l LedgerForEvaluator) BlockHdr(round basics.Round) (bookkeeping.BlockHeade
 	}
 
 	return res, nil
-}
-
-// CheckDup is part of go-algorand's ledgerForEvaluator interface.
-func (l LedgerForEvaluator) CheckDup(config.ConsensusParams, basics.Round, basics.Round, basics.Round, transactions.Txid, ledger.TxLease) error {
-	// This function is not used by evaluator.
-	return errors.New("CheckDup() not implemented")
 }
 
 func (l *LedgerForEvaluator) isSpecialAddress(address basics.Address) bool {
@@ -248,8 +235,8 @@ func (l *LedgerForEvaluator) parseAccountAppTable(address basics.Address, rows p
 	return res, nil
 }
 
-// Load rows from the account table for the given addresses. nil is stored for those
-// accounts that were not found. Uses batching.
+// Load rows from the account table for the given addresses except the special accounts.
+// nil is stored for those accounts that were not found. Uses batching.
 func (l *LedgerForEvaluator) loadAccountTable(addresses map[basics.Address]struct{}) (map[basics.Address]*basics.AccountData, error) {
 	addressesArr := make([]basics.Address, 0, len(addresses))
 	for address := range addresses {
@@ -369,9 +356,8 @@ func (l *LedgerForEvaluator) loadCreatables(accountDataMap *map[basics.Address]*
 	return nil
 }
 
-// Return a map with all accounts for the given addresses, with nil for those accounts
-// that do not exist.
-func (l *LedgerForEvaluator) loadAccounts(addresses map[basics.Address]struct{}) (map[basics.Address]*basics.AccountData, error) {
+// LookupWithoutRewards is part of go-algorand's indexerLedgerForEval interface.
+func (l LedgerForEvaluator) LookupWithoutRewards(addresses map[basics.Address]struct{}) (map[basics.Address]*basics.AccountData, error) {
 	res, err := l.loadAccountTable(addresses)
 	if err != nil {
 		return nil, fmt.Errorf("loadAccounts() err: %w", err)
@@ -382,73 +368,31 @@ func (l *LedgerForEvaluator) loadAccounts(addresses map[basics.Address]struct{})
 		return nil, fmt.Errorf("loadAccounts() err: %w", err)
 	}
 
+	// Add special accounts if needed.
+	for address := range addresses {
+		if l.isSpecialAddress(address) {
+			// The balance of a special address must pass the minimum balance check in
+			// go-algorand's evaluator, so return a sufficiently large balance.
+			var balance uint64 = 1000 * 1000 * 1000 * 1000 * 1000
+			accountData := new(basics.AccountData)
+			*accountData = basics.AccountData{
+				MicroAlgos: basics.MicroAlgos{Raw: balance},
+			}
+			res[address] = accountData
+		}
+	}
+
 	return res, nil
 }
 
-// PreloadAccounts loads the account data for the given addresses and stores them
-// in the internal cache.
-func (l *LedgerForEvaluator) PreloadAccounts(addresses map[basics.Address]struct{}) error {
-	accountData, err := l.loadAccounts(addresses)
-	if err != nil {
-		return err
-	}
-
-	l.preloadedAccountData = accountData
-	return nil
-}
-
-// LookupWithoutRewards is part of go-algorand's ledgerForEvaluator interface.
-func (l LedgerForEvaluator) LookupWithoutRewards(round basics.Round, address basics.Address) (basics.AccountData, basics.Round, error) {
-	// The balance of a special address must pass the minimum balance check in
-	// go-algorand's evaluator, so return a sufficiently large balance.
-	if l.isSpecialAddress(address) {
-		var balance uint64 = 1000 * 1000 * 1000 * 1000 * 1000
-		accountData := basics.AccountData{
-			MicroAlgos: basics.MicroAlgos{Raw: balance},
-		}
-		return accountData, round, nil
-	}
-
-	if accountData, ok := l.preloadedAccountData[address]; ok {
-		if accountData == nil {
-			return basics.AccountData{}, round, nil
-		}
-		return *accountData, round, nil
-	}
-
-	// Account was not preloaded.
-	accountDataMap, err := l.loadAccounts(map[basics.Address]struct{}{address: {}})
-	if err != nil {
-		return basics.AccountData{}, basics.Round(0), err
-	}
-	accountData := accountDataMap[address]
-
-	if accountData == nil {
-		return basics.AccountData{}, round, nil
-	}
-	return *accountData, round, nil
-}
-
-// GetCreatorForRound is part of go-algorand's ledgerForEvaluator interface.
-func (l LedgerForEvaluator) GetCreatorForRound(_ basics.Round, cindex basics.CreatableIndex, ctype basics.CreatableType) (basics.Address, bool, error) {
-	var row pgx.Row
-
-	switch ctype {
-	case basics.AssetCreatable:
-		row = l.tx.QueryRow(context.Background(), assetCreatorStmtName, uint64(cindex))
-	case basics.AppCreatable:
-		row = l.tx.QueryRow(context.Background(), appCreatorStmtName, uint64(cindex))
-	default:
-		panic("unknown creatable type")
-	}
-
+func (l* LedgerForEvaluator) parseAddress(row pgx.Row) (basics.Address, bool /*exists*/, error) {
 	var buf []byte
 	err := row.Scan(&buf)
 	if err == pgx.ErrNoRows {
 		return basics.Address{}, false, nil
 	}
 	if err != nil {
-		return basics.Address{}, false, fmt.Errorf("GetCreatorForRound() err: %w", err)
+		return basics.Address{}, false, fmt.Errorf("parseAddress() err: %w", err)
 	}
 
 	var address basics.Address
@@ -457,21 +401,68 @@ func (l LedgerForEvaluator) GetCreatorForRound(_ basics.Round, cindex basics.Cre
 	return address, true, nil
 }
 
-// GenesisHash is part of go-algorand's ledgerForEvaluator interface.
-func (l LedgerForEvaluator) GenesisHash() crypto.Digest {
-	return l.genesisHash
+// GetAssetCreator is part of go-algorand's indexerLedgerForEval interface.
+func (l LedgerForEvaluator) GetAssetCreator(indices map[basics.AssetIndex]struct{}) (map[basics.AssetIndex]ledger.FoundAddress, error) {
+	indicesArr := make([]basics.AssetIndex, 0, len(indices))
+	for index := range indices {
+		indicesArr = append(indicesArr, index)
+	}
+
+	var batch pgx.Batch
+	for _, index := range indicesArr {
+		batch.Queue(assetCreatorStmtName, uint64(index))
+	}
+
+	results := l.tx.SendBatch(context.Background(), &batch)
+	res := make(map[basics.AssetIndex]ledger.FoundAddress, len(indices))
+	for _, index := range indicesArr {
+		row := results.QueryRow()
+
+		address, exists, err := l.parseAddress(row)
+		if err != nil {
+			return nil, fmt.Errorf("GetAssetCreator() err: %w", err)
+		}
+
+		res[index] = ledger.FoundAddress{Address: address, Exists: exists}
+	}
+	results.Close()
+
+	return res, nil
 }
 
-// Totals is part of go-algorand's ledgerForEvaluator interface.
-func (l LedgerForEvaluator) Totals(round basics.Round) (ledgercore.AccountTotals, error) {
+// GetAppCreator is part of go-algorand's indexerLedgerForEval interface.
+func (l LedgerForEvaluator) GetAppCreator(indices map[basics.AppIndex]struct{}) (map[basics.AppIndex]ledger.FoundAddress, error) {
+	indicesArr := make([]basics.AppIndex, 0, len(indices))
+	for index := range indices {
+		indicesArr = append(indicesArr, index)
+	}
+
+	var batch pgx.Batch
+	for _, index := range indicesArr {
+		batch.Queue(appCreatorStmtName, uint64(index))
+	}
+
+	results := l.tx.SendBatch(context.Background(), &batch)
+	res := make(map[basics.AppIndex]ledger.FoundAddress, len(indices))
+	for _, index := range indicesArr {
+		row := results.QueryRow()
+
+		address, exists, err := l.parseAddress(row)
+		if err != nil {
+			return nil, fmt.Errorf("GetAppCreator() err: %w", err)
+		}
+
+		res[index] = ledger.FoundAddress{Address: address, Exists: exists}
+	}
+	results.Close()
+
+	return res, nil
+}
+
+// Totals is part of go-algorand's indexerLedgerForEval interface.
+func (l LedgerForEvaluator) Totals() (ledgercore.AccountTotals, error) {
 	// The evaluator uses totals only for recomputing the rewards pool balance. Indexer
 	// does not currently compute this balance, and we can return an empty struct
 	// here.
 	return ledgercore.AccountTotals{}, nil
-}
-
-// CompactCertVoters is part of go-algorand's ledgerForEvaluator interface.
-func (l LedgerForEvaluator) CompactCertVoters(basics.Round) (*ledger.VotersForRound, error) {
-	// This function is not used by evaluator.
-	return nil, errors.New("CompactCertVoters() not implemented")
 }

--- a/idb/postgres/internal/ledger_for_evaluator/ledger_for_evaluator_test.go
+++ b/idb/postgres/internal/ledger_for_evaluator/ledger_for_evaluator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/ledger"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stretchr/testify/assert"
@@ -51,7 +52,7 @@ func TestLedgerForEvaluatorBlockHdr(t *testing.T) {
 	defer tx.Rollback(context.Background())
 
 	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-		tx, header.GenesisHash, transactions.SpecialAddresses{})
+		tx, transactions.SpecialAddresses{})
 	require.NoError(t, err)
 	defer l.Close()
 
@@ -104,25 +105,19 @@ func TestLedgerForEvaluatorAccountTableBasic(t *testing.T) {
 	require.NoError(t, err)
 	defer tx.Rollback(context.Background())
 
-	checkFunc := func(preload bool) {
-		l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-			tx, crypto.Digest{}, transactions.SpecialAddresses{})
-		require.NoError(t, err)
+	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
+		tx, transactions.SpecialAddresses{})
+	require.NoError(t, err)
 
-		if preload {
-			err := l.PreloadAccounts(map[basics.Address]struct{}{test.AccountB: {}})
-			require.NoError(t, err)
-		}
+	ret, err :=
+		l.LookupWithoutRewards(map[basics.Address]struct{}{test.AccountB: {}})
+	require.NoError(t, err)
+	l.Close()
 
-		accountDataRet, round, err := l.LookupWithoutRewards(7, test.AccountB)
-		require.NoError(t, err)
-		l.Close()
+	accountDataRet := ret[test.AccountB]
 
-		assert.Equal(t, basics.Round(7), round)
-		assert.Equal(t, accountDataFull, accountDataRet)
-	}
-	checkFunc(false)
-	checkFunc(true)
+	require.NotNil(t, accountDataRet)
+	assert.Equal(t, accountDataFull, *accountDataRet)
 }
 
 func TestLedgerForEvaluatorAccountTableDeleted(t *testing.T) {
@@ -146,25 +141,17 @@ func TestLedgerForEvaluatorAccountTableDeleted(t *testing.T) {
 	require.NoError(t, err)
 	defer tx.Rollback(context.Background())
 
-	checkFunc := func(preload bool) {
-		l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-			tx, crypto.Digest{}, transactions.SpecialAddresses{})
-		require.NoError(t, err)
+	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
+		tx, transactions.SpecialAddresses{})
+	require.NoError(t, err)
 
-		if preload {
-			err := l.PreloadAccounts(map[basics.Address]struct{}{test.AccountB: {}})
-			require.NoError(t, err)
-		}
+	ret, err :=
+		l.LookupWithoutRewards(map[basics.Address]struct{}{test.AccountB: {}})
+	require.NoError(t, err)
+	l.Close()
 
-		accountDataRet, round, err := l.LookupWithoutRewards(7, test.AccountB)
-		require.NoError(t, err)
-		l.Close()
-
-		assert.Equal(t, basics.Round(7), round)
-		assert.Equal(t, basics.AccountData{}, accountDataRet)
-	}
-	checkFunc(false)
-	checkFunc(true)
+	accountDataRet := ret[test.AccountB]
+	assert.Nil(t, accountDataRet)
 }
 
 func TestLedgerForEvaluatorAccountTableMissingAccount(t *testing.T) {
@@ -175,25 +162,17 @@ func TestLedgerForEvaluatorAccountTableMissingAccount(t *testing.T) {
 	require.NoError(t, err)
 	defer tx.Rollback(context.Background())
 
-	checkFunc := func(preload bool) {
-		l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-			tx, crypto.Digest{}, transactions.SpecialAddresses{})
-		require.NoError(t, err)
+	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
+		tx, transactions.SpecialAddresses{})
+	require.NoError(t, err)
 
-		if preload {
-			err := l.PreloadAccounts(map[basics.Address]struct{}{test.AccountB: {}})
-			require.NoError(t, err)
-		}
+	ret, err :=
+		l.LookupWithoutRewards(map[basics.Address]struct{}{test.AccountB: {}})
+	require.NoError(t, err)
+	l.Close()
 
-		accountDataRet, round, err := l.LookupWithoutRewards(7, test.AccountB)
-		require.NoError(t, err)
-		l.Close()
-
-		assert.Equal(t, basics.Round(7), round)
-		assert.Equal(t, basics.AccountData{}, accountDataRet)
-	}
-	checkFunc(false)
-	checkFunc(true)
+	accountDataRet := ret[test.AccountB]
+	assert.Nil(t, accountDataRet)
 }
 
 func TestLedgerForEvaluatorAccountTableNullAccountData(t *testing.T) {
@@ -221,14 +200,17 @@ func TestLedgerForEvaluatorAccountTableNullAccountData(t *testing.T) {
 	defer tx.Rollback(context.Background())
 
 	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-		tx, crypto.Digest{}, transactions.SpecialAddresses{})
+		tx, transactions.SpecialAddresses{})
 	require.NoError(t, err)
 	defer l.Close()
 
-	accountDataRet, _, err := l.LookupWithoutRewards(0, test.AccountA)
+	ret, err :=
+		l.LookupWithoutRewards(map[basics.Address]struct{}{test.AccountA: {}})
 	require.NoError(t, err)
 
-	assert.Equal(t, accountDataFull, accountDataRet)
+	accountDataRet := ret[test.AccountA]
+	require.NotNil(t, accountDataRet)
+	assert.Equal(t, accountDataFull, *accountDataRet)
 }
 
 func TestLedgerForEvaluatorAccountAssetTable(t *testing.T) {
@@ -259,12 +241,16 @@ func TestLedgerForEvaluatorAccountAssetTable(t *testing.T) {
 	defer tx.Rollback(context.Background())
 
 	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-		tx, crypto.Digest{}, transactions.SpecialAddresses{})
+		tx, transactions.SpecialAddresses{})
 	require.NoError(t, err)
 	defer l.Close()
 
-	accountDataRet, _, err := l.LookupWithoutRewards(0, test.AccountA)
+	ret, err :=
+		l.LookupWithoutRewards(map[basics.Address]struct{}{test.AccountA: {}})
 	require.NoError(t, err)
+
+	accountDataRet := ret[test.AccountA]
+	require.NotNil(t, accountDataRet)
 
 	accountDataExpected := basics.AccountData{
 		AssetParams: make(map[basics.AssetIndex]basics.AssetParams),
@@ -281,7 +267,7 @@ func TestLedgerForEvaluatorAccountAssetTable(t *testing.T) {
 		AppLocalStates: make(map[basics.AppIndex]basics.AppLocalState),
 		AppParams:      make(map[basics.AppIndex]basics.AppParams),
 	}
-	assert.Equal(t, accountDataExpected, accountDataRet)
+	assert.Equal(t, accountDataExpected, *accountDataRet)
 }
 
 func TestLedgerForEvaluatorAssetTable(t *testing.T) {
@@ -322,12 +308,16 @@ func TestLedgerForEvaluatorAssetTable(t *testing.T) {
 	defer tx.Rollback(context.Background())
 
 	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-		tx, crypto.Digest{}, transactions.SpecialAddresses{})
+		tx, transactions.SpecialAddresses{})
 	require.NoError(t, err)
 	defer l.Close()
 
-	accountDataRet, _, err := l.LookupWithoutRewards(0, test.AccountA)
+	ret, err :=
+		l.LookupWithoutRewards(map[basics.Address]struct{}{test.AccountA: {}})
 	require.NoError(t, err)
+
+	accountDataRet := ret[test.AccountA]
+	require.NotNil(t, accountDataRet)
 
 	accountDataExpected := basics.AccountData{
 		AssetParams: map[basics.AssetIndex]basics.AssetParams{
@@ -342,7 +332,7 @@ func TestLedgerForEvaluatorAssetTable(t *testing.T) {
 		AppLocalStates: make(map[basics.AppIndex]basics.AppLocalState),
 		AppParams:      make(map[basics.AppIndex]basics.AppParams),
 	}
-	assert.Equal(t, accountDataExpected, accountDataRet)
+	assert.Equal(t, accountDataExpected, *accountDataRet)
 }
 
 func TestLedgerForEvaluatorAppTable(t *testing.T) {
@@ -391,12 +381,16 @@ func TestLedgerForEvaluatorAppTable(t *testing.T) {
 	defer tx.Rollback(context.Background())
 
 	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-		tx, crypto.Digest{}, transactions.SpecialAddresses{})
+		tx, transactions.SpecialAddresses{})
 	require.NoError(t, err)
 	defer l.Close()
 
-	accountDataRet, _, err := l.LookupWithoutRewards(0, test.AccountA)
+	ret, err :=
+		l.LookupWithoutRewards(map[basics.Address]struct{}{test.AccountA: {}})
 	require.NoError(t, err)
+
+	accountDataRet := ret[test.AccountA]
+	require.NotNil(t, accountDataRet)
 
 	accountDataExpected := basics.AccountData{
 		AssetParams:    make(map[basics.AssetIndex]basics.AssetParams),
@@ -407,7 +401,7 @@ func TestLedgerForEvaluatorAppTable(t *testing.T) {
 			2: params2,
 		},
 	}
-	assert.Equal(t, accountDataExpected, accountDataRet)
+	assert.Equal(t, accountDataExpected, *accountDataRet)
 }
 
 func TestLedgerForEvaluatorAccountAppTable(t *testing.T) {
@@ -458,12 +452,16 @@ func TestLedgerForEvaluatorAccountAppTable(t *testing.T) {
 	defer tx.Rollback(context.Background())
 
 	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-		tx, crypto.Digest{}, transactions.SpecialAddresses{})
+		tx, transactions.SpecialAddresses{})
 	require.NoError(t, err)
 	defer l.Close()
 
-	accountDataRet, _, err := l.LookupWithoutRewards(0, test.AccountA)
+	ret, err :=
+		l.LookupWithoutRewards(map[basics.Address]struct{}{test.AccountA: {}})
 	require.NoError(t, err)
+
+	accountDataRet := ret[test.AccountA]
+	require.NotNil(t, accountDataRet)
 
 	accountDataExpected := basics.AccountData{
 		AssetParams: make(map[basics.AssetIndex]basics.AssetParams),
@@ -474,7 +472,7 @@ func TestLedgerForEvaluatorAccountAppTable(t *testing.T) {
 		},
 		AppParams: make(map[basics.AppIndex]basics.AppParams),
 	}
-	assert.Equal(t, accountDataExpected, accountDataRet)
+	assert.Equal(t, accountDataExpected, *accountDataRet)
 }
 
 // Tests that queuing and reading from a batch when using PreloadAccounts()
@@ -533,23 +531,20 @@ func TestLedgerForEvaluatorLookupMultipleAccounts(t *testing.T) {
 	defer tx.Rollback(context.Background())
 
 	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-		tx, crypto.Digest{}, transactions.SpecialAddresses{})
+		tx, transactions.SpecialAddresses{})
 	require.NoError(t, err)
 	defer l.Close()
 
-	// Preload accounts so that batching is actually used.
-	{
-		addressesMap := make(map[basics.Address]struct{})
-		for _, address := range addresses {
-			addressesMap[address] = struct{}{}
-		}
-		err := l.PreloadAccounts(addressesMap)
-		require.NoError(t, err)
+	addressesMap := make(map[basics.Address]struct{})
+	for _, address := range addresses {
+		addressesMap[address] = struct{}{}
 	}
+	ret, err := l.LookupWithoutRewards(addressesMap)
+	require.NoError(t, err)
 
 	for i, address := range addresses {
-		accountData, _, err := l.LookupWithoutRewards(0, address)
-		require.NoError(t, err)
+		accountData, _ := ret[address]
+		require.NotNil(t, accountData)
 
 		assert.Equal(t, len(seq), len(accountData.Assets))
 		assert.Equal(t, len(seq), len(accountData.AssetParams))
@@ -587,16 +582,22 @@ func TestLedgerForEvaluatorAssetCreatorBasic(t *testing.T) {
 	defer tx.Rollback(context.Background())
 
 	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-		tx, crypto.Digest{}, transactions.SpecialAddresses{})
+		tx, transactions.SpecialAddresses{})
 	require.NoError(t, err)
 	defer l.Close()
 
-	address, ok, err := l.GetCreatorForRound(
-		basics.Round(0), basics.CreatableIndex(2), basics.AssetCreatable)
+	ret, err := l.GetAssetCreator(
+		map[basics.AssetIndex]struct{}{basics.AssetIndex(2): {}})
 	require.NoError(t, err)
 
-	assert.True(t, ok)
-	assert.Equal(t, test.AccountA, address)
+	foundAddress, ok := ret[basics.AssetIndex(2)]
+	require.True(t, ok)
+
+	expected := ledger.FoundAddress{
+		Address: test.AccountA,
+		Exists: true,
+	}
+	assert.Equal(t, expected, foundAddress)
 }
 
 func TestLedgerForEvaluatorAssetCreatorDeleted(t *testing.T) {
@@ -614,15 +615,75 @@ func TestLedgerForEvaluatorAssetCreatorDeleted(t *testing.T) {
 	defer tx.Rollback(context.Background())
 
 	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-		tx, crypto.Digest{}, transactions.SpecialAddresses{})
+		tx, transactions.SpecialAddresses{})
 	require.NoError(t, err)
 	defer l.Close()
 
-	_, ok, err := l.GetCreatorForRound(
-		basics.Round(0), basics.CreatableIndex(2), basics.AssetCreatable)
+	ret, err := l.GetAssetCreator(
+		map[basics.AssetIndex]struct{}{basics.AssetIndex(2): {}})
 	require.NoError(t, err)
 
-	assert.False(t, ok)
+	foundAddress, ok := ret[basics.AssetIndex(2)]
+	require.True(t, ok)
+
+	assert.False(t, foundAddress.Exists)
+}
+
+func TestLedgerForEvaluatorAssetCreatorMultiple(t *testing.T) {
+	db, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+
+	creatorsMap := map[basics.AssetIndex]basics.Address{
+		1: test.AccountA,
+		2: test.AccountB,
+		3: test.AccountC,
+		4: test.AccountD,
+		5: test.AccountE,
+	}
+
+	query :=
+		"INSERT INTO asset (index, creator_addr, params, deleted, created_at) " +
+			"VALUES ($1, $2, '{}', false, 0)"
+	for index, address := range creatorsMap {
+		_, err := db.Exec(context.Background(), query, index, address[:])
+		require.NoError(t, err)
+	}
+
+	tx, err := db.BeginTx(context.Background(), readonlyRepeatableRead)
+	require.NoError(t, err)
+	defer tx.Rollback(context.Background())
+
+	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
+		tx, transactions.SpecialAddresses{})
+	require.NoError(t, err)
+	defer l.Close()
+
+	indices := map[basics.AssetIndex]struct{}{
+		1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}, 8: {}}
+	ret, err := l.GetAssetCreator(indices)
+	require.NoError(t, err)
+
+	assert.Equal(t, len(indices), len(ret))
+	for i := 1; i <= 5; i++ {
+		index := basics.AssetIndex(i)
+
+		foundAddress, ok := ret[index]
+		require.True(t, ok)
+
+		expected := ledger.FoundAddress{
+			Address: creatorsMap[index],
+			Exists: true,
+		}
+		assert.Equal(t, expected, foundAddress)
+	}
+	for i := 6; i <= 8; i++ {
+		index := basics.AssetIndex(i)
+
+		foundAddress, ok := ret[index]
+		require.True(t, ok)
+
+		assert.False(t, foundAddress.Exists)
+	}
 }
 
 func TestLedgerForEvaluatorAppCreatorBasic(t *testing.T) {
@@ -640,16 +701,22 @@ func TestLedgerForEvaluatorAppCreatorBasic(t *testing.T) {
 	defer tx.Rollback(context.Background())
 
 	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-		tx, crypto.Digest{}, transactions.SpecialAddresses{})
+		tx, transactions.SpecialAddresses{})
 	require.NoError(t, err)
 	defer l.Close()
 
-	address, ok, err := l.GetCreatorForRound(
-		basics.Round(0), basics.CreatableIndex(2), basics.AppCreatable)
+	ret, err := l.GetAppCreator(
+		map[basics.AppIndex]struct{}{basics.AppIndex(2): {}})
 	require.NoError(t, err)
 
-	assert.True(t, ok)
-	assert.Equal(t, test.AccountA, address)
+	foundAddress, ok := ret[basics.AppIndex(2)]
+	require.True(t, ok)
+
+	expected := ledger.FoundAddress{
+		Address: test.AccountA,
+		Exists: true,
+	}
+	assert.Equal(t, expected, foundAddress)
 }
 
 func TestLedgerForEvaluatorAppCreatorDeleted(t *testing.T) {
@@ -667,15 +734,75 @@ func TestLedgerForEvaluatorAppCreatorDeleted(t *testing.T) {
 	defer tx.Rollback(context.Background())
 
 	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-		tx, crypto.Digest{}, transactions.SpecialAddresses{})
+		tx, transactions.SpecialAddresses{})
 	require.NoError(t, err)
 	defer l.Close()
 
-	_, ok, err := l.GetCreatorForRound(
-		basics.Round(0), basics.CreatableIndex(2), basics.AppCreatable)
+	ret, err := l.GetAppCreator(
+		map[basics.AppIndex]struct{}{basics.AppIndex(2): {}})
 	require.NoError(t, err)
 
-	assert.False(t, ok)
+	foundAddress, ok := ret[basics.AppIndex(2)]
+	require.True(t, ok)
+
+	assert.False(t, foundAddress.Exists)
+}
+
+func TestLedgerForEvaluatorAppCreatorMultiple(t *testing.T) {
+	db, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+
+	creatorsMap := map[basics.AppIndex]basics.Address{
+		1: test.AccountA,
+		2: test.AccountB,
+		3: test.AccountC,
+		4: test.AccountD,
+		5: test.AccountE,
+	}
+
+	query :=
+		"INSERT INTO app (index, creator, params, deleted, created_at) " +
+			"VALUES ($1, $2, '{}', false, 0)"
+	for index, address := range creatorsMap {
+		_, err := db.Exec(context.Background(), query, index, address[:])
+		require.NoError(t, err)
+	}
+
+	tx, err := db.BeginTx(context.Background(), readonlyRepeatableRead)
+	require.NoError(t, err)
+	defer tx.Rollback(context.Background())
+
+	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
+		tx, transactions.SpecialAddresses{})
+	require.NoError(t, err)
+	defer l.Close()
+
+	indices := map[basics.AppIndex]struct{}{
+		1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}, 8: {}}
+	ret, err := l.GetAppCreator(indices)
+	require.NoError(t, err)
+
+	assert.Equal(t, len(indices), len(ret))
+	for i := 1; i <= 5; i++ {
+		index := basics.AppIndex(i)
+
+		foundAddress, ok := ret[index]
+		require.True(t, ok)
+
+		expected := ledger.FoundAddress{
+			Address: creatorsMap[index],
+			Exists: true,
+		}
+		assert.Equal(t, expected, foundAddress)
+	}
+	for i := 6; i <= 8; i++ {
+		index := basics.AppIndex(i)
+
+		foundAddress, ok := ret[index]
+		require.True(t, ok)
+
+		assert.False(t, foundAddress.Exists)
+	}
 }
 
 func TestLedgerForEvaluatorSpecialAddresses(t *testing.T) {
@@ -690,37 +817,19 @@ func TestLedgerForEvaluatorSpecialAddresses(t *testing.T) {
 		FeeSink:     test.FeeAddr,
 		RewardsPool: test.RewardAddr,
 	}
-	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-		tx, test.GenesisHash, specialAddresses)
+	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(tx, specialAddresses)
 	require.NoError(t, err)
 	defer l.Close()
 
 	amount := basics.MicroAlgos{Raw: 1000 * 1000 * 1000 * 1000 * 1000}
 
-	accountData, round, err := l.LookupWithoutRewards(basics.Round(5), test.FeeAddr)
+	addressesMap := map[basics.Address]struct{}{test.FeeAddr: {}, test.RewardAddr: {}}
+	ret, err := l.LookupWithoutRewards(addressesMap)
 	require.NoError(t, err)
-	assert.Equal(t, amount, accountData.MicroAlgos)
-	assert.Equal(t, basics.Round(5), round)
 
-	accountData, round, err = l.LookupWithoutRewards(basics.Round(5), test.RewardAddr)
-	require.NoError(t, err)
-	assert.Equal(t, amount, accountData.MicroAlgos)
-	assert.Equal(t, basics.Round(5), round)
-}
-
-func TestLedgerForEvaluatorGenesisHash(t *testing.T) {
-	db, shutdownFunc := setupPostgres(t)
-	defer shutdownFunc()
-
-	tx, err := db.BeginTx(context.Background(), readonlyRepeatableRead)
-	require.NoError(t, err)
-	defer tx.Rollback(context.Background())
-
-	l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-		tx, test.GenesisHash, transactions.SpecialAddresses{})
-	require.NoError(t, err)
-	defer l.Close()
-
-	genesisHash := l.GenesisHash()
-	assert.Equal(t, test.GenesisHash, genesisHash)
+	for address := range addressesMap {
+		accountDataRet := ret[address]
+		require.NotNil(t, accountDataRet)
+		assert.Equal(t, amount, accountDataRet.MicroAlgos)
+	}
 }

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -211,12 +211,7 @@ func (db *IndexerDb) AddBlock(block *bookkeeping.Block) error {
 				RewardsPool: block.RewardsPool,
 			}
 			ledgerForEval, err := ledger_for_evaluator.MakeLedgerForEvaluator(
-				tx, block.GenesisHash(), specialAddresses)
-			if err != nil {
-				return fmt.Errorf("AddBlock() err: %w", err)
-			}
-
-			err = ledgerForEval.PreloadAccounts(ledger.GetBlockAddresses(block))
+				tx, specialAddresses)
 			if err != nil {
 				return fmt.Errorf("AddBlock() err: %w", err)
 			}


### PR DESCRIPTION
## Summary

This significantly simplifies the code in Indexer, and paves a way to querying asset/app creators in a batch.

## Test Plan

New tests for batch querying of asset/app creators.