### PR TITLE
Resolve staticcheck lint warnings

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -258,14 +258,15 @@ func (si *ServerImplementation) LookupApplicationByID(ctx echo.Context, applicat
 	out := generated.ApplicationResponse{
 		CurrentRound: round,
 	}
-	for result := range results {
-		if result.Error != nil {
-			return indexerError(ctx, result.Error.Error())
-		}
-		out.Application = &result.Application
-		return ctx.JSON(http.StatusOK, out)
+	result, ok := <-results
+	if !ok {
+		return ctx.JSON(http.StatusNotFound, out)
 	}
-	return ctx.JSON(http.StatusNotFound, out)
+	if result.Error != nil {
+		return indexerError(ctx, result.Error.Error())
+	}
+	out.Application = &result.Application
+	return ctx.JSON(http.StatusOK, out)
 }
 
 // LookupAssetByID looks up a particular asset

--- a/api/pointer_utils.go
+++ b/api/pointer_utils.go
@@ -96,7 +96,7 @@ func boolPtr(x bool) *bool {
 }
 
 func strArrayPtr(x []string) *[]string {
-	if x == nil || len(x) == 0 {
+	if len(x) == 0 {
 		return nil
 	}
 	return &x

--- a/cmd/block-generator/generator/generate.go
+++ b/cmd/block-generator/generator/generate.go
@@ -20,8 +20,6 @@ import (
 	"github.com/algorand/go-algorand/rpcs"
 )
 
-var errOutOfRange = fmt.Errorf("selection is out of weighted range")
-
 // TxTypeID is the transaction type.
 type TxTypeID string
 
@@ -229,8 +227,8 @@ type Report map[TxTypeID]TxData
 
 // TxData is the generator report data.
 type TxData struct {
-	GenerationTimeMilli time.Duration `json:"generation_time_milli"`
-	GenerationCount     uint64        `json:"num_generated"`
+	GenerationTime  time.Duration `json:"generation_time_milli"`
+	GenerationCount uint64        `json:"num_generated"`
 }
 
 func track(id TxTypeID) (TxTypeID, time.Time) {
@@ -239,7 +237,7 @@ func track(id TxTypeID) (TxTypeID, time.Time) {
 func (g *generator) recordData(id TxTypeID, start time.Time) {
 	data := g.reportData[id]
 	data.GenerationCount++
-	data.GenerationTimeMilli += time.Since(start)
+	data.GenerationTime += time.Since(start)
 	g.reportData[id] = data
 }
 
@@ -460,7 +458,7 @@ func (g *generator) generatePaymentTxnInternal(selection TxTypeID, round uint64,
 	fee := uint64(1000)
 	total := amount + fee
 	if g.balances[sendIndex] < total {
-		fmt.Printf(fmt.Sprintf("\n\nthe sender account does not have enough algos for the transfer. idx %d, payment number %d\n\n", sendIndex, g.numPayments))
+		fmt.Printf("\n\nthe sender account does not have enough algos for the transfer. idx %d, payment number %d\n\n", sendIndex, g.numPayments)
 		os.Exit(1)
 	}
 
@@ -581,11 +579,11 @@ func (g *generator) generateAssetTxnInternalHint(txType TxTypeID, round uint64, 
 			txn = g.makeAssetTransferTxn(g.makeTxnHeader(sender, round, intra), receiver, amount, basics.Address{}, asset.assetID)
 
 			if asset.holdings[0].balance < amount {
-				fmt.Printf(fmt.Sprintf("\n\ncreator doesn't have enough funds for asset %d\n\n", asset.assetID))
+				fmt.Printf("\n\ncreator doesn't have enough funds for asset %d\n\n", asset.assetID)
 				os.Exit(1)
 			}
 			if g.balances[asset.holdings[0].acctIndex] < fee {
-				fmt.Printf(fmt.Sprintf("\n\ncreator doesn't have enough funds for transaction %d\n\n", asset.assetID))
+				fmt.Printf("\n\ncreator doesn't have enough funds for transaction %d\n\n", asset.assetID)
 				os.Exit(1)
 			}
 
@@ -626,7 +624,7 @@ func (g *generator) generateAssetTxnInternalHint(txType TxTypeID, round uint64, 
 	}
 
 	if g.balances[senderIndex] < txn.Fee.ToUint64() {
-		fmt.Printf(fmt.Sprintf("\n\nthe sender account does not have enough algos for the transfer. idx %d, asset transaction type %v, num %d\n\n", senderIndex, actual, g.reportData[actual].GenerationCount))
+		fmt.Printf("\n\nthe sender account does not have enough algos for the transfer. idx %d, asset transaction type %v, num %d\n\n", senderIndex, actual, g.reportData[actual].GenerationCount)
 		os.Exit(1)
 	}
 	g.balances[senderIndex] -= txn.Fee.ToUint64()

--- a/cmd/block-generator/generator/server_test.go
+++ b/cmd/block-generator/generator/server_test.go
@@ -47,7 +47,7 @@ func TestParseRound(t *testing.T) {
 		},
 		{
 			name:          "invalid prefix",
-			url:           fmt.Sprintf("/v2/wrong/prefix/1"),
+			url:           "/v2/wrong/prefix/1",
 			expectedRound: 0,
 			err:           "not a blocks query",
 		},

--- a/cmd/e2equeries/main.go
+++ b/cmd/e2equeries/main.go
@@ -71,7 +71,7 @@ func main() {
 		printAccountQuery(db, idb.AccountQueryOptions{HasAssetID: bestid, Limit: bestcount})
 	}
 
-	dt := time.Now().Sub(start)
+	dt := time.Since(start)
 	exitValue := testutil.ExitValue()
 	if exitValue == 0 {
 		fmt.Printf("wat OK %s\n", dt.String())

--- a/cmd/idbtest/idbtest.go
+++ b/cmd/idbtest/idbtest.go
@@ -190,7 +190,7 @@ func main() {
 		testTxnPaging(db, idb.TransactionFilter{AlgosGT: uint64Ptr(1)})
 	}
 
-	dt := time.Now().Sub(start)
+	dt := time.Since(start)
 	exitValue += testutil.ExitValue()
 	if exitValue == 0 {
 		fmt.Printf("wat OK %s\n", dt.String())

--- a/cmd/validator/core/dynamic_processor.go
+++ b/cmd/validator/core/dynamic_processor.go
@@ -59,9 +59,9 @@ func (gp DynamicProcessor) ProcessAddress(algodData, indexerData []byte) (Result
 
 // isDeleted is a simple helper to check for boolean values
 func isDeleted(val interface{}) (bool, error) {
-	switch val.(type) {
+	switch val := val.(type) {
 	case bool:
-		return val.(bool), nil
+		return val, nil
 	default:
 		return false, fmt.Errorf("unable to parse value as boolean (%v)", val)
 	}
@@ -143,10 +143,10 @@ func normalizeRecurse(key string, data interface{}) (interface{}, error) {
 	result := data
 
 	// If the data is a complex type, recursively normalize result
-	switch data.(type) {
+	switch data := data.(type) {
 	case map[string]interface{}:
 		// Handle objects.
-		object := data.(map[string]interface{})
+		object := data
 
 		if deletedVal, ok := object["deleted"]; ok {
 			deleted, err := isDeleted(deletedVal)
@@ -209,7 +209,7 @@ func normalizeRecurse(key string, data interface{}) (interface{}, error) {
 	case []interface{}:
 		// Normalize each element of array
 		resultArray := make([]interface{}, 0)
-		for _, arrVal := range data.([]interface{}) {
+		for _, arrVal := range data {
 			normalized, err := normalizeRecurse("", arrVal)
 			if err != nil {
 				return nil, err

--- a/cmd/validator/core/struct_processor.go
+++ b/cmd/validator/core/struct_processor.go
@@ -242,10 +242,10 @@ func equals(indexer, algod generated.Account) (differences []string) {
 			if !stringPtrEqual(algodCreatedApp.Params.Creator, indexerCreatedApp.Params.Creator) {
 				differences = append(differences, fmt.Sprintf("created-app creator %d", algodCreatedApp.Id))
 			}
-			if bytes.Compare(algodCreatedApp.Params.ApprovalProgram, indexerCreatedApp.Params.ApprovalProgram) != 0 {
+			if !bytes.Equal(algodCreatedApp.Params.ApprovalProgram, indexerCreatedApp.Params.ApprovalProgram) {
 				differences = append(differences, fmt.Sprintf("created-app approval-program %d", algodCreatedApp.Id))
 			}
-			if bytes.Compare(algodCreatedApp.Params.ClearStateProgram, indexerCreatedApp.Params.ClearStateProgram) != 0 {
+			if !bytes.Equal(algodCreatedApp.Params.ClearStateProgram, indexerCreatedApp.Params.ClearStateProgram) {
 				differences = append(differences, fmt.Sprintf("created-app clear-state-program %d", algodCreatedApp.Id))
 			}
 			if !tealKeyValueStoreEqual(algodCreatedApp.Params.GlobalState, indexerCreatedApp.Params.GlobalState) {
@@ -321,7 +321,7 @@ func bytesPtrEqual(val1, val2 *[]uint8) bool {
 		return false
 	}
 
-	return bytes.Compare(*val1, *val2) == 0
+	return bytes.Equal(*val1, *val2)
 }
 
 func boolPtrEqual(val1, val2 *bool) bool {

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -99,7 +99,7 @@ func (bot *fetcherImpl) catchupLoop() {
 	var err error
 	var blockbytes []byte
 	aclient := bot.Algod()
-	for true {
+	for {
 		if bot.isDone() {
 			return
 		}
@@ -127,7 +127,7 @@ func (bot *fetcherImpl) followLoop() {
 	var err error
 	var blockbytes []byte
 	aclient := bot.Algod()
-	for true {
+	for {
 		for retries := 0; retries < 3; retries++ {
 			if bot.isDone() {
 				return
@@ -162,7 +162,7 @@ func (bot *fetcherImpl) followLoop() {
 
 // Run is part of the Fetcher interface
 func (bot *fetcherImpl) Run() {
-	for true {
+	for {
 		if bot.isDone() {
 			return
 		}

--- a/idb/migration/migration.go
+++ b/idb/migration/migration.go
@@ -216,7 +216,6 @@ func (m *Migration) runMigrations(ch chan struct{}) {
 		close(ch)
 	}
 	m.log.Println("Migration finished successfully.")
-	return
 }
 
 // RunMigrations runs all tasks which have been loaded into the migration.

--- a/idb/migration/migration_test.go
+++ b/idb/migration/migration_test.go
@@ -20,28 +20,12 @@ var fastSuccessTask2 = makeTask(0*time.Second, nil, 2, false, "fast success")
 var fastSuccessTask3 = makeTask(0*time.Second, nil, 3, false, "fast success")
 
 var fastErrorTask1 = makeTask(0*time.Second, errMigration, 1, false, "fast error")
-var fastErrorTask2 = makeTask(0*time.Second, errMigration, 2, false, "fast error")
-var fastErrorTask3 = makeTask(0*time.Second, errMigration, 3, false, "fast error")
 
-var slowErrorTask1 = makeTask(1*time.Second, errMigration, 1, false, "slow error")
-var slowErrorTask2 = makeTask(1*time.Second, errMigration, 2, false, "slow error")
 var slowErrorTask3 = makeTask(1*time.Second, errMigration, 3, false, "slow error")
 
 var slowSuccessBlockingTask1 = makeTask(1*time.Second, nil, 1, true, "blocking slow success")
 var slowSuccessBlockingTask2 = makeTask(1*time.Second, nil, 2, true, "blocking slow success")
 var slowSuccessBlockingTask3 = makeTask(1*time.Second, nil, 3, true, "blocking slow success")
-
-var fastSuccessBlockingTask1 = makeTask(0*time.Second, nil, 1, true, "blocking fast success")
-var fastSuccessBlockingTask2 = makeTask(0*time.Second, nil, 2, true, "blocking fast success")
-var fastSuccessBlockingTask3 = makeTask(0*time.Second, nil, 3, true, "blocking fast success")
-
-var fastErrorBlockingTask1 = makeTask(0*time.Second, errMigration, 1, true, "blocking fast error")
-var fastErrorBlockingTask2 = makeTask(0*time.Second, errMigration, 2, true, "blocking fast error")
-var fastErrorBlockingTask3 = makeTask(0*time.Second, errMigration, 3, true, "blocking fast error")
-
-var slowErrorBlockingTask1 = makeTask(1*time.Second, errMigration, 1, true, "blocking slow error")
-var slowErrorBlockingTask2 = makeTask(1*time.Second, errMigration, 2, true, "blocking slow error")
-var slowErrorBlockingTask3 = makeTask(1*time.Second, errMigration, 3, true, "blocking slow error")
 
 type testTask struct {
 	id          int

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -598,7 +598,7 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 		partNumber++
 	}
 	if tf.RekeyTo != nil && (*tf.RekeyTo) {
-		whereParts = append(whereParts, fmt.Sprintf("(t.txn -> 'txn' -> 'rekey') IS NOT NULL"))
+		whereParts = append(whereParts, "(t.txn -> 'txn' -> 'rekey') IS NOT NULL")
 	}
 	query = "SELECT t.round, t.intra, t.txnbytes, t.extra, t.asset, h.realtime FROM txn t JOIN block_header h ON t.round = h.round"
 	if joinParticipation {
@@ -1375,7 +1375,7 @@ func stringPtr(x string) *string {
 }
 
 func baPtr(x []byte) *[]byte {
-	if x == nil || len(x) == 0 {
+	if len(x) == 0 {
 		return nil
 	}
 	allzero := true

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -782,6 +782,7 @@ func TestAppExtraPages(t *testing.T) {
 
 	var ap basics.AppParams
 	err = encoding.DecodeJSON(paramsStr, &ap)
+	require.NoError(t, err)
 	require.Equal(t, uint32(1), ap.ExtraProgramPages)
 
 	var filter generated.SearchForApplicationsParams
@@ -864,6 +865,7 @@ func TestLargeAssetAmount(t *testing.T) {
 	txn := test.MakeConfigAssetTxn(
 		0, math.MaxUint64, 0, false, "mc", "mycoin", "", test.AccountA)
 	block, err := test.MakeBlockForTxns(test.MakeGenesisBlock().BlockHeader, &txn)
+	require.NoError(t, err)
 
 	err = db.AddBlock(&block)
 	require.NoError(t, err)

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -100,6 +100,7 @@ func needsMigration(state MigrationState) bool {
 // upsertMigrationState updates the migration state, and optionally increments
 // the next counter with an existing transaction.
 // If `tx` is nil, use a normal query.
+//lint:ignore U1000 this function might be used in a future migration
 func upsertMigrationState(db *IndexerDb, tx pgx.Tx, state *MigrationState) error {
 	migrationStateJSON := encoding.EncodeJSON(state)
 	return db.setMetastate(tx, schema.MigrationMetastateKey, string(migrationStateJSON))
@@ -176,6 +177,7 @@ func (db *IndexerDb) getMigrationState() (MigrationState, error) {
 }
 
 // sqlMigration executes a sql statements as the entire migration.
+//lint:ignore U1000 this function might be used in a future migration
 func sqlMigration(db *IndexerDb, state *MigrationState, sqlLines []string) error {
 	db.accountingLock.Lock()
 	defer db.accountingLock.Unlock()

--- a/version/strings.go
+++ b/version/strings.go
@@ -41,7 +41,7 @@ func Version() string {
 	if err != nil {
 		return fmt.Sprintf("compiled with bad GitDecorateBase64, %s", err.Error())
 	}
-	tre := regexp.MustCompile("tag:\\s+([^,]+)")
+	tre := regexp.MustCompile(`tag:\s+([^,]+)`)
 	m := tre.FindAllStringSubmatch(string(b), -1)
 	if m == nil {
 		return UnknownVersion


### PR DESCRIPTION
## Summary

This PR fixes the staticcheck lint warnings.
```
accounting/rewind.go:220:4: the surrounding loop is unconditionally terminated (SA4004)
api/handlers.go:266:3: the surrounding loop is unconditionally terminated (SA4004)
api/pointer_utils.go:99:5: should omit nil check; len() for nil slices is defined as zero (S1009)
cmd/block-generator/generator/generate.go:21:5: var errOutOfRange is unused (U1000)
cmd/block-generator/generator/generate.go:227:2: var GenerationTimeMilli is of type time.Duration; don't use unit-specific suffix "Milli" (ST1011)
cmd/block-generator/generator/generate.go:379:9: unnecessary use of fmt.Sprintf (S1039)
cmd/block-generator/generator/generate.go:456:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
cmd/block-generator/generator/generate.go:571:5: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
cmd/block-generator/generator/generate.go:575:5: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
cmd/block-generator/generator/generate.go:616:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
cmd/block-generator/generator/server.go:74:4: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
cmd/block-generator/generator/server_test.go:50:19: unnecessary use of fmt.Sprintf (S1039)
cmd/e2equeries/main.go:74:8: should use time.Since instead of time.Now().Sub (S1012)
cmd/idbtest/idbtest.go:193:8: should use time.Since instead of time.Now().Sub (S1012)
cmd/validator/dynamic_processor.go:62:9: assigning the result of this type assertion to a variable (switch val := val.(type)) could eliminate type assertions in switch cases (S1034)
	cmd/validator/dynamic_processor.go:64:10: could eliminate this type assertion
cmd/validator/dynamic_processor.go:146:9: assigning the result of this type assertion to a variable (switch data := data.(type)) could eliminate type assertions in switch cases (S1034)
	cmd/validator/dynamic_processor.go:149:13: could eliminate this type assertion
	cmd/validator/dynamic_processor.go:212:26: could eliminate this type assertion
cmd/validator/struct_processor.go:245:7: should use !bytes.Equal(algodCreatedApp.Params.ApprovalProgram, indexerCreatedApp.Params.ApprovalProgram) instead (S1004)
cmd/validator/struct_processor.go:248:7: should use !bytes.Equal(algodCreatedApp.Params.ClearStateProgram, indexerCreatedApp.Params.ClearStateProgram) instead (S1004)
cmd/validator/struct_processor.go:324:9: should use bytes.Equal(*val1, *val2) instead (S1004)
fetcher/fetcher.go:102:2: should use for {} instead of for true {} (S1006)
fetcher/fetcher.go:130:2: should use for {} instead of for true {} (S1006)
fetcher/fetcher.go:165:2: should use for {} instead of for true {} (S1006)
idb/migration/migration.go:219:2: redundant return statement (S1023)
idb/migration/migration_test.go:23:5: var fastErrorTask2 is unused (U1000)
idb/migration/migration_test.go:24:5: var fastErrorTask3 is unused (U1000)
idb/migration/migration_test.go:26:5: var slowErrorTask1 is unused (U1000)
idb/migration/migration_test.go:27:5: var slowErrorTask2 is unused (U1000)
idb/migration/migration_test.go:34:5: var fastSuccessBlockingTask1 is unused (U1000)
idb/migration/migration_test.go:35:5: var fastSuccessBlockingTask2 is unused (U1000)
idb/migration/migration_test.go:36:5: var fastSuccessBlockingTask3 is unused (U1000)
idb/migration/migration_test.go:38:5: var fastErrorBlockingTask1 is unused (U1000)
idb/migration/migration_test.go:39:5: var fastErrorBlockingTask2 is unused (U1000)
idb/migration/migration_test.go:40:5: var fastErrorBlockingTask3 is unused (U1000)
idb/migration/migration_test.go:42:5: var slowErrorBlockingTask1 is unused (U1000)
idb/migration/migration_test.go:43:5: var slowErrorBlockingTask2 is unused (U1000)
idb/migration/migration_test.go:44:5: var slowErrorBlockingTask3 is unused (U1000)
idb/postgres/postgres.go:601:35: unnecessary use of fmt.Sprintf (S1039)
idb/postgres/postgres.go:1378:5: should omit nil check; len() for nil slices is defined as zero (S1009)
idb/postgres/postgres_integration_test.go:784:2: this value of err is never used (SA4006)
idb/postgres/postgres_integration_test.go:866:2: this value of err is never used (SA4006)
idb/postgres/postgres_migrations.go:103:6: func upsertMigrationState is unused (U1000)
idb/postgres/postgres_migrations.go:179:6: func sqlMigration is unused (U1000)
version/strings.go:44:9: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
```