### PR TITLE
Add missing dependencies: autoconf automake g++ boost-dev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine
 
 # Dependencies
-RUN apk add --update make bash libtool git python3
+RUN apk add --update make bash libtool git python3 autoconf automake g++ boost-dev
 
 # Install test data
 COPY docker/testdata.tar.bz2 /tmp/testdata.tar.bz2


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->
Fixes #646 

## Summary
- Adds additional dependencies in order to make `docker-compose up` work again.

## Test Plan

I ran `docker-compose up` on macOS.


