### PR TITLE
Runtime configurable server read/write timeouts

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -44,9 +44,9 @@ func (e ExtraOptions) handlerTimeout() time.Duration {
 	// If less, subtract 10% as a safety valve.
 	if e.WriteTimeout >= 2*time.Second {
 		return e.WriteTimeout - time.Second
-	} else {
-		return e.WriteTimeout - time.Duration(0.1*float64(e.WriteTimeout))
 	}
+
+	return e.WriteTimeout - time.Duration(0.1*float64(e.WriteTimeout))
 }
 
 // Serve starts an http server for the indexer API. This call blocks.

--- a/api/server.go
+++ b/api/server.go
@@ -17,15 +17,6 @@ import (
 	"github.com/algorand/indexer/idb"
 )
 
-const (
-	// ReadTimeout covers the time from when the connection is accepted to when the request body is fully read
-	ReadTimeout = 5 * time.Second
-	//WriteTimeout normally covers the time from the end of the request header read to the end of the response write
-	WriteTimeout = 59 * time.Second
-	// HandlerTimeout defines how long the handlers are given before the context times out.
-	HandlerTimeout = WriteTimeout - time.Second
-)
-
 // ExtraOptions are options which change the behavior or the HTTP server.
 type ExtraOptions struct {
 	// Tokens are the access tokens which can access the API.
@@ -39,6 +30,23 @@ type ExtraOptions struct {
 
 	// MetricsEndpointVerbose generates separate histograms based on query parameters on the /metrics endpoint.
 	MetricsEndpointVerbose bool
+
+	// Maximum amount of time to wait before timing out writes to a response. Note that handler timeout is computed
+	//off of this.
+	WriteTimeout time.Duration
+
+	// ReadTimeout is the maximum duration for reading the entire request, including the body.
+	ReadTimeout time.Duration
+}
+
+func (e ExtraOptions) handlerTimeout() time.Duration {
+	// Basically, if write timeout is 2 seconds or greater, subtract a second.
+	// If less, subtract 10% as a safety valve.
+	if e.WriteTimeout >= 2 * time.Second {
+		return e.WriteTimeout - time.Second
+	} else {
+		return e.WriteTimeout - time.Duration(0.1 * float64(e.WriteTimeout))
+	}
 }
 
 // Serve starts an http server for the indexer API. This call blocks.
@@ -49,7 +57,7 @@ func Serve(ctx context.Context, serveAddr string, db idb.IndexerDb, fetcherError
 	// To ensure everything uses the correct context this must be specified first.
 	e.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{
 		ErrorMessage: `{"message":"Request Timeout"}`,
-		Timeout:      HandlerTimeout,
+		Timeout:      options.handlerTimeout(),
 	}))
 
 	if options.MetricsEndpoint {
@@ -92,8 +100,8 @@ func Serve(ctx context.Context, serveAddr string, db idb.IndexerDb, fetcherError
 	}
 	s := &http.Server{
 		Addr:           serveAddr,
-		ReadTimeout:    ReadTimeout,
-		WriteTimeout:   WriteTimeout,
+		ReadTimeout:    options.ReadTimeout,
+		WriteTimeout:   options.WriteTimeout,
 		MaxHeaderBytes: 1 << 20,
 		BaseContext:    getctx,
 	}

--- a/api/server.go
+++ b/api/server.go
@@ -42,10 +42,10 @@ type ExtraOptions struct {
 func (e ExtraOptions) handlerTimeout() time.Duration {
 	// Basically, if write timeout is 2 seconds or greater, subtract a second.
 	// If less, subtract 10% as a safety valve.
-	if e.WriteTimeout >= 2 * time.Second {
+	if e.WriteTimeout >= 2*time.Second {
 		return e.WriteTimeout - time.Second
 	} else {
-		return e.WriteTimeout - time.Duration(0.1 * float64(e.WriteTimeout))
+		return e.WriteTimeout - time.Duration(0.1*float64(e.WriteTimeout))
 	}
 }
 

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -31,6 +31,8 @@ var (
 	allowMigration   bool
 	metricsMode      string
 	tokenString      string
+	writeTimeout 	 time.Duration
+	readTimeout 	 time.Duration
 )
 
 var daemonCmd = &cobra.Command{
@@ -124,6 +126,8 @@ func init() {
 	daemonCmd.Flags().BoolVarP(&developerMode, "dev-mode", "", false, "allow performance intensive operations like searching for accounts at a particular round")
 	daemonCmd.Flags().BoolVarP(&allowMigration, "allow-migration", "", false, "allow migrations to happen even when no algod connected")
 	daemonCmd.Flags().StringVarP(&metricsMode, "metrics-mode", "", "OFF", "configure the /metrics endpoint to [ON, OFF, VERBOSE]")
+	daemonCmd.Flags().DurationVarP(&writeTimeout, "write-timeout", "", 30 * time.Second, "set the maximum duration to wait before timing out writes to a http response, breaking connection")
+	daemonCmd.Flags().DurationVarP(&readTimeout, "read-timeout", "", 5 * time.Second, "set the maximum duration for reading the entire request")
 
 	viper.RegisterAlias("algod", "algod-data-dir")
 	viper.RegisterAlias("algod-net", "algod-address")
@@ -149,6 +153,9 @@ func makeOptions() (options api.ExtraOptions) {
 		options.MetricsEndpointVerbose = true
 
 	}
+	options.WriteTimeout = writeTimeout
+	options.ReadTimeout = readTimeout
+
 	return
 }
 

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -31,8 +31,8 @@ var (
 	allowMigration   bool
 	metricsMode      string
 	tokenString      string
-	writeTimeout 	 time.Duration
-	readTimeout 	 time.Duration
+	writeTimeout     time.Duration
+	readTimeout      time.Duration
 )
 
 var daemonCmd = &cobra.Command{
@@ -126,8 +126,8 @@ func init() {
 	daemonCmd.Flags().BoolVarP(&developerMode, "dev-mode", "", false, "allow performance intensive operations like searching for accounts at a particular round")
 	daemonCmd.Flags().BoolVarP(&allowMigration, "allow-migration", "", false, "allow migrations to happen even when no algod connected")
 	daemonCmd.Flags().StringVarP(&metricsMode, "metrics-mode", "", "OFF", "configure the /metrics endpoint to [ON, OFF, VERBOSE]")
-	daemonCmd.Flags().DurationVarP(&writeTimeout, "write-timeout", "", 30 * time.Second, "set the maximum duration to wait before timing out writes to a http response, breaking connection")
-	daemonCmd.Flags().DurationVarP(&readTimeout, "read-timeout", "", 5 * time.Second, "set the maximum duration for reading the entire request")
+	daemonCmd.Flags().DurationVarP(&writeTimeout, "write-timeout", "", 30*time.Second, "set the maximum duration to wait before timing out writes to a http response, breaking connection")
+	daemonCmd.Flags().DurationVarP(&readTimeout, "read-timeout", "", 5*time.Second, "set the maximum duration for reading the entire request")
 
 	viper.RegisterAlias("algod", "algod-data-dir")
 	viper.RegisterAlias("algod-net", "algod-address")


### PR DESCRIPTION


<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Made configurations for read/write timeouts configurable at runtime, with sensible defaults and a basic generation formula for handler timeout.

## Test Plan

Started up server locally, exercised both using default values and passing in command line overrides for each. 
