### PR TITLE
Always close resources

### DIFF
--- a/idb/postgres/internal/ledger_for_evaluator/ledger_for_evaluator.go
+++ b/idb/postgres/internal/ledger_for_evaluator/ledger_for_evaluator.go
@@ -144,6 +144,7 @@ func (l *LedgerForEvaluator) parseAccountTable(row pgx.Row) (basics.AccountData,
 }
 
 func (l *LedgerForEvaluator) parseAccountAssetTable(rows pgx.Rows) (map[basics.AssetIndex]basics.AssetHolding, error) {
+	defer rows.Close()
 	res := make(map[basics.AssetIndex]basics.AssetHolding)
 
 	var assetid uint64
@@ -171,6 +172,7 @@ func (l *LedgerForEvaluator) parseAccountAssetTable(rows pgx.Rows) (map[basics.A
 }
 
 func (l *LedgerForEvaluator) parseAssetTable(rows pgx.Rows) (map[basics.AssetIndex]basics.AssetParams, error) {
+	defer rows.Close()
 	res := make(map[basics.AssetIndex]basics.AssetParams)
 
 	var index uint64
@@ -197,6 +199,7 @@ func (l *LedgerForEvaluator) parseAssetTable(rows pgx.Rows) (map[basics.AssetInd
 }
 
 func (l *LedgerForEvaluator) parseAppTable(rows pgx.Rows) (map[basics.AppIndex]basics.AppParams, error) {
+	defer rows.Close()
 	res := make(map[basics.AppIndex]basics.AppParams)
 
 	var index uint64
@@ -223,6 +226,7 @@ func (l *LedgerForEvaluator) parseAppTable(rows pgx.Rows) (map[basics.AppIndex]b
 }
 
 func (l *LedgerForEvaluator) parseAccountAppTable(rows pgx.Rows) (map[basics.AppIndex]basics.AppLocalState, error) {
+	defer rows.Close()
 	res := make(map[basics.AppIndex]basics.AppLocalState)
 
 	var app uint64
@@ -264,6 +268,8 @@ func (l *LedgerForEvaluator) loadAccountTable(addresses map[basics.Address]struc
 	}
 
 	results := l.tx.SendBatch(context.Background(), &batch)
+	defer results.Close()
+
 	res := make(map[basics.Address]*basics.AccountData, len(addresses))
 	for _, address := range addressesArr {
 		row := results.QueryRow()
@@ -318,6 +324,7 @@ func (l *LedgerForEvaluator) loadCreatables(accountDataMap *map[basics.Address]*
 	}
 
 	results := l.tx.SendBatch(context.Background(), &batch)
+	defer results.Close()
 
 	for _, address := range existingAddresses {
 		rows, err := results.Query()

--- a/idb/postgres/internal/ledger_for_evaluator/ledger_for_evaluator_test.go
+++ b/idb/postgres/internal/ledger_for_evaluator/ledger_for_evaluator_test.go
@@ -110,6 +110,7 @@ func TestLedgerForEvaluatorAccountTableBasic(t *testing.T) {
 		l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
 			tx, crypto.Digest{}, transactions.SpecialAddresses{})
 		require.NoError(t, err)
+		defer l.Close()
 
 		if preload {
 			err := l.PreloadAccounts(map[basics.Address]struct{}{test.AccountB: {}})
@@ -118,7 +119,6 @@ func TestLedgerForEvaluatorAccountTableBasic(t *testing.T) {
 
 		accountDataRet, round, err := l.LookupWithoutRewards(7, test.AccountB)
 		require.NoError(t, err)
-		l.Close()
 
 		assert.Equal(t, basics.Round(7), round)
 		assert.Equal(t, accountDataFull, accountDataRet)
@@ -229,6 +229,7 @@ func TestLedgerForEvaluatorAccountTableSingleAccount(t *testing.T) {
 					return
 				}
 				require.NoError(t, err)
+				defer l.Close()
 
 				if preload {
 					err := l.PreloadAccounts(map[basics.Address]struct{}{addr: {}})
@@ -243,7 +244,6 @@ func TestLedgerForEvaluatorAccountTableSingleAccount(t *testing.T) {
 					return
 				}
 				require.NoError(t, err)
-				l.Close()
 
 				assert.Equal(t, basics.Round(7), round)
 				// should be no result if deleted
@@ -284,6 +284,7 @@ func TestLedgerForEvaluatorAccountTableDeleted(t *testing.T) {
 		l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
 			tx, crypto.Digest{}, transactions.SpecialAddresses{})
 		require.NoError(t, err)
+		defer l.Close()
 
 		if preload {
 			err := l.PreloadAccounts(map[basics.Address]struct{}{test.AccountB: {}})
@@ -292,7 +293,6 @@ func TestLedgerForEvaluatorAccountTableDeleted(t *testing.T) {
 
 		accountDataRet, round, err := l.LookupWithoutRewards(7, test.AccountB)
 		require.NoError(t, err)
-		l.Close()
 
 		assert.Equal(t, basics.Round(7), round)
 		assert.Equal(t, basics.AccountData{}, accountDataRet)
@@ -313,6 +313,7 @@ func TestLedgerForEvaluatorAccountTableMissingAccount(t *testing.T) {
 		l, err := ledger_for_evaluator.MakeLedgerForEvaluator(
 			tx, crypto.Digest{}, transactions.SpecialAddresses{})
 		require.NoError(t, err)
+		defer l.Close()
 
 		if preload {
 			err := l.PreloadAccounts(map[basics.Address]struct{}{test.AccountB: {}})
@@ -321,7 +322,6 @@ func TestLedgerForEvaluatorAccountTableMissingAccount(t *testing.T) {
 
 		accountDataRet, round, err := l.LookupWithoutRewards(7, test.AccountB)
 		require.NoError(t, err)
-		l.Close()
 
 		assert.Equal(t, basics.Round(7), round)
 		assert.Equal(t, basics.AccountData{}, accountDataRet)

--- a/idb/postgres/internal/writer/writer.go
+++ b/idb/postgres/internal/writer/writer.go
@@ -438,9 +438,11 @@ func (w *Writer) AddBlock(block *bookkeeping.Block, modifiedTxns []transactions.
 	}
 
 	results := w.tx.SendBatch(context.Background(), &batch)
+	// Clean the results off the connection's queue. Without this, weird things happen.
 	for i := 0; i < batch.Len(); i++ {
 		_, err := results.Exec()
 		if err != nil {
+			results.Close()
 			return fmt.Errorf("AddBlock() exec err: %w", err)
 		}
 	}

--- a/idb/postgres/internal/writer/writer_test.go
+++ b/idb/postgres/internal/writer/writer_test.go
@@ -60,6 +60,7 @@ func txnQuery(db *pgxpool.Pool, query string) ([]txnRow, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var result txnRow
 		var txid []byte
@@ -198,6 +199,7 @@ func TestWriterTxnTableBasic(t *testing.T) {
 
 	rows, err := db.Query(context.Background(), "SELECT * FROM txn ORDER BY intra")
 	require.NoError(t, err)
+	defer rows.Close()
 
 	var round uint64
 	var intra uint64
@@ -284,6 +286,7 @@ func TestWriterTxnTableAssetCloseAmount(t *testing.T) {
 	rows, err := db.Query(
 		context.Background(), "SELECT txn, extra FROM txn ORDER BY intra")
 	require.NoError(t, err)
+	defer rows.Close()
 
 	var txn []byte
 	var extra []byte
@@ -354,6 +357,7 @@ func TestWriterTxnParticipationTableBasic(t *testing.T) {
 	rows, err := db.Query(
 		context.Background(), "SELECT * FROM txn_participation ORDER BY round, intra, addr")
 	require.NoError(t, err)
+	defer rows.Close()
 
 	var addr []byte
 	var round uint64
@@ -430,6 +434,7 @@ func TestWriterAccountTableBasic(t *testing.T) {
 
 	rows, err := db.Query(context.Background(), "SELECT * FROM account")
 	require.NoError(t, err)
+	defer rows.Close()
 
 	var addr []byte
 	var microalgos uint64
@@ -484,6 +489,7 @@ func TestWriterAccountTableBasic(t *testing.T) {
 
 	rows, err = db.Query(context.Background(), "SELECT * FROM account")
 	require.NoError(t, err)
+	defer rows.Close()
 
 	require.True(t, rows.Next())
 	err = rows.Scan(
@@ -532,6 +538,7 @@ func TestWriterAccountTableCreateDeleteSameRound(t *testing.T) {
 
 	rows, err := db.Query(context.Background(), "SELECT * FROM account")
 	require.NoError(t, err)
+	defer rows.Close()
 
 	var addr []byte
 	var microalgos uint64
@@ -670,6 +677,7 @@ func TestWriterAccountAssetTableBasic(t *testing.T) {
 
 	rows, err := db.Query(context.Background(), "SELECT * FROM account_asset")
 	require.NoError(t, err)
+	defer rows.Close()
 
 	require.True(t, rows.Next())
 	err = rows.Scan(&addr, &assetid, &amount, &frozen, &deleted, &createdAt, &closedAt)
@@ -701,6 +709,7 @@ func TestWriterAccountAssetTableBasic(t *testing.T) {
 
 	rows, err = db.Query(context.Background(), "SELECT * FROM account_asset")
 	require.NoError(t, err)
+	defer rows.Close()
 
 	require.True(t, rows.Next())
 	err = rows.Scan(&addr, &assetid, &amount, &frozen, &deleted, &createdAt, &closedAt)
@@ -802,11 +811,8 @@ func TestWriterAccountAssetTableLargeAmount(t *testing.T) {
 
 	var amount uint64
 
-	rows, err := db.Query(context.Background(), "SELECT amount FROM account_asset")
-	require.NoError(t, err)
-
-	require.True(t, rows.Next())
-	err = rows.Scan(&amount)
+	row := db.QueryRow(context.Background(), "SELECT amount FROM account_asset")
+	err = row.Scan(&amount)
 	require.NoError(t, err)
 	assert.Equal(t, assetHolding.Amount, amount)
 }
@@ -854,6 +860,7 @@ func TestWriterAssetTableBasic(t *testing.T) {
 
 	rows, err := db.Query(context.Background(), "SELECT * FROM asset")
 	require.NoError(t, err)
+	defer rows.Close()
 
 	require.True(t, rows.Next())
 	err = rows.Scan(&index, &creatorAddr, &params, &deleted, &createdAt, &closedAt)
@@ -892,6 +899,7 @@ func TestWriterAssetTableBasic(t *testing.T) {
 
 	rows, err = db.Query(context.Background(), "SELECT * FROM asset")
 	require.NoError(t, err)
+	defer rows.Close()
 
 	require.True(t, rows.Next())
 	err = rows.Scan(&index, &creatorAddr, &params, &deleted, &createdAt, &closedAt)
@@ -1015,6 +1023,7 @@ func TestWriterAppTableBasic(t *testing.T) {
 
 	rows, err := db.Query(context.Background(), "SELECT * FROM app")
 	require.NoError(t, err)
+	defer rows.Close()
 
 	require.True(t, rows.Next())
 	err = rows.Scan(&index, &creator, &params, &deleted, &createdAt, &closedAt)
@@ -1053,6 +1062,7 @@ func TestWriterAppTableBasic(t *testing.T) {
 
 	rows, err = db.Query(context.Background(), "SELECT * FROM app")
 	require.NoError(t, err)
+	defer rows.Close()
 
 	require.True(t, rows.Next())
 	err = rows.Scan(&index, &creator, &params, &deleted, &createdAt, &closedAt)
@@ -1176,6 +1186,7 @@ func TestWriterAccountAppTableBasic(t *testing.T) {
 
 	rows, err := db.Query(context.Background(), "SELECT * FROM account_app")
 	require.NoError(t, err)
+	defer rows.Close()
 
 	require.True(t, rows.Next())
 	err = rows.Scan(&addr, &app, &localstate, &deleted, &createdAt, &closedAt)
@@ -1210,6 +1221,7 @@ func TestWriterAccountAppTableBasic(t *testing.T) {
 
 	rows, err = db.Query(context.Background(), "SELECT * FROM account_app")
 	require.NoError(t, err)
+	defer rows.Close()
 
 	require.True(t, rows.Next())
 	err = rows.Scan(&addr, &app, &localstate, &deleted, &createdAt, &closedAt)

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -215,6 +215,7 @@ func (db *IndexerDb) AddBlock(block *bookkeeping.Block) error {
 			if err != nil {
 				return fmt.Errorf("AddBlock() err: %w", err)
 			}
+			defer ledgerForEval.Close()
 
 			err = ledgerForEval.PreloadAccounts(ledger.GetBlockAddresses(block))
 			if err != nil {
@@ -234,7 +235,6 @@ func (db *IndexerDb) AddBlock(block *bookkeeping.Block) error {
 				return fmt.Errorf("AddBlock() eval err: %w", err)
 			}
 			metrics.PostgresEvalTimeSeconds.Observe(time.Since(start).Seconds())
-			ledgerForEval.Close()
 
 			err = writer.AddBlock(block, modifiedTxns, delta)
 			if err != nil {
@@ -425,7 +425,6 @@ func (db *IndexerDb) GetBlock(ctx context.Context, round uint64, options idb.Get
 		results := make([]idb.TxnRow, 0)
 		for txrow := range out {
 			results = append(results, txrow)
-			txrow.Next()
 		}
 		transactions = results
 	}


### PR DESCRIPTION
## Summary

As part of hunting down the "conn busy" issue, I decided to make sure we close all resources even if there is some error. For example, before if there was e.g. a decoding error, we would exit the function without closing database rows. Without going into what errors should or should not happen, let's just make sure we close resources unconditionally.