### PR TITLE
Fix "conn busy" issue.

### DIFF
--- a/idb/postgres/internal/util/util.go
+++ b/idb/postgres/internal/util/util.go
@@ -16,10 +16,10 @@ import (
 
 // TxWithRetry is a helper function that retries the function `f` in case the database
 // transaction in it fails due to a serialization error. `f` is provided
-// a transaction created using `opts`. `f` must either return an error or
-// call sql.Tx.Commit(). In the second case, `f` must return an error which contains the
+// a transaction created using `opts`. `f` should either return an error or
+// call sql.Tx.Commit(). In the second case, `f` should return an error that contains the
 // error returned by sql.Tx.Commit(). The easiest way is to just return the result of
-// sql.Tx.Commit().
+// sql.Tx.Commit(). If sql.Tx.Commit() is not called, results are rolled back.
 func TxWithRetry(db *pgxpool.Pool, opts pgx.TxOptions, f func(pgx.Tx) error, log *log.Logger) error {
 	count := 0
 	for {

--- a/idb/postgres/internal/util/util.go
+++ b/idb/postgres/internal/util/util.go
@@ -16,10 +16,10 @@ import (
 
 // TxWithRetry is a helper function that retries the function `f` in case the database
 // transaction in it fails due to a serialization error. `f` is provided
-// a transaction created using `opts`. `f` takes ownership of the
-// transaction and must either call sql.Tx.Rollback() or sql.Tx.Commit(). In the second
-// case, `f` must return an error which contains the error returned by sql.Tx.Commit().
-// The easiest way is to just return the result of sql.Tx.Commit().
+// a transaction created using `opts`. `f` must either return an error or
+// call sql.Tx.Commit(). In the second case, `f` must return an error which contains the
+// error returned by sql.Tx.Commit(). The easiest way is to just return the result of
+// sql.Tx.Commit().
 func TxWithRetry(db *pgxpool.Pool, opts pgx.TxOptions, f func(pgx.Tx) error, log *log.Logger) error {
 	count := 0
 	for {
@@ -29,6 +29,7 @@ func TxWithRetry(db *pgxpool.Pool, opts pgx.TxOptions, f func(pgx.Tx) error, log
 		}
 
 		err = f(tx)
+		tx.Rollback(context.Background())
 
 		// If not serialization error.
 		var pgerr *pgconn.PgError

--- a/idb/postgres/internal/writer/writer_test.go
+++ b/idb/postgres/internal/writer/writer_test.go
@@ -88,11 +88,11 @@ func TestWriterBlockHeaderTableBasic(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, ledgercore.StateDelta{})
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err := pgutil.TxWithRetry(db, serializable, f, nil)
@@ -126,11 +126,11 @@ func TestWriterSpecialAccounts(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, ledgercore.StateDelta{})
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err := pgutil.TxWithRetry(db, serializable, f, nil)
@@ -187,11 +187,11 @@ func TestWriterTxnTableBasic(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, ledgercore.StateDelta{})
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err = pgutil.TxWithRetry(db, serializable, f, nil)
@@ -273,11 +273,11 @@ func TestWriterTxnTableAssetCloseAmount(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, payset, ledgercore.StateDelta{})
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err = pgutil.TxWithRetry(db, serializable, f, nil)
@@ -344,11 +344,11 @@ func TestWriterTxnParticipationTableBasic(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, ledgercore.StateDelta{})
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err = pgutil.TxWithRetry(db, serializable, f, nil)
@@ -422,11 +422,11 @@ func TestWriterAccountTableBasic(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, delta)
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err := pgutil.TxWithRetry(db, serializable, f, nil)
@@ -526,11 +526,11 @@ func TestWriterAccountTableCreateDeleteSameRound(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, delta)
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err := pgutil.TxWithRetry(db, serializable, f, nil)
@@ -602,11 +602,11 @@ func TestWriterDeleteAccountDoesNotDeleteKeytype(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, delta)
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err = pgutil.TxWithRetry(db, serializable, f, nil)
@@ -657,11 +657,11 @@ func TestWriterAccountAssetTableBasic(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, delta)
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err := pgutil.TxWithRetry(db, serializable, f, nil)
@@ -746,11 +746,11 @@ func TestWriterAccountAssetTableCreateDeleteSameRound(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, delta)
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err := pgutil.TxWithRetry(db, serializable, f, nil)
@@ -799,11 +799,11 @@ func TestWriterAccountAssetTableLargeAmount(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, delta)
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err := pgutil.TxWithRetry(db, serializable, f, nil)
@@ -841,11 +841,11 @@ func TestWriterAssetTableBasic(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, delta)
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err := pgutil.TxWithRetry(db, serializable, f, nil)
@@ -943,11 +943,11 @@ func TestWriterAssetTableCreateDeleteSameRound(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, delta)
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err := pgutil.TxWithRetry(db, serializable, f, nil)
@@ -1004,11 +1004,11 @@ func TestWriterAppTableBasic(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, delta)
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err := pgutil.TxWithRetry(db, serializable, f, nil)
@@ -1106,11 +1106,11 @@ func TestWriterAppTableCreateDeleteSameRound(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, delta)
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err := pgutil.TxWithRetry(db, serializable, f, nil)
@@ -1167,11 +1167,11 @@ func TestWriterAccountAppTableBasic(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, delta)
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err := pgutil.TxWithRetry(db, serializable, f, nil)
@@ -1261,11 +1261,11 @@ func TestWriterAccountAppTableCreateDeleteSameRound(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, delta)
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err := pgutil.TxWithRetry(db, serializable, f, nil)
@@ -1330,11 +1330,11 @@ func TestWriterAddBlockTwice(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, ledgercore.StateDelta{})
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 
@@ -1362,11 +1362,11 @@ func TestWriterAddBlockInnerTxnsAssetCreate(t *testing.T) {
 	err = makeTx(db, func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&block, block.Payset, ledgercore.StateDelta{})
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	})
 	require.NoError(t, err)

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -111,10 +111,10 @@ type IndexerDb struct {
 
 // txWithRetry is a helper function that retries the function `f` in case the database
 // transaction in it fails due to a serialization error. `f` is provided
-// a transaction created using `opts`. `f` must either return an error or
-// call sql.Tx.Commit(). In the second case, `f` must return an error which contains the
+// a transaction created using `opts`. `f` should either return an error or
+// call sql.Tx.Commit(). In the second case, `f` should return an error that contains the
 // error returned by sql.Tx.Commit(). The easiest way is to just return the result of
-// sql.Tx.Commit().
+// sql.Tx.Commit(). If sql.Tx.Commit() is not called, results are rolled back.
 func (db *IndexerDb) txWithRetry(opts pgx.TxOptions, f func(pgx.Tx) error) error {
 	return pgutil.TxWithRetry(db.db, opts, f, db.log)
 }

--- a/idb/postgres/postgres_migrations.go
+++ b/idb/postgres/postgres_migrations.go
@@ -186,8 +186,6 @@ func sqlMigration(db *IndexerDb, state *MigrationState, sqlLines []string) error
 	nextState.NextMigration++
 
 	f := func(tx pgx.Tx) error {
-		defer tx.Rollback(context.Background())
-
 		for _, cmd := range sqlLines {
 			_, err := tx.Exec(context.Background(), cmd)
 			if err != nil {

--- a/idb/postgres/postgres_rand_test.go
+++ b/idb/postgres/postgres_rand_test.go
@@ -118,11 +118,11 @@ func TestWriteReadAccountData(t *testing.T) {
 	f := func(tx pgx.Tx) error {
 		w, err := writer.MakeWriter(tx)
 		require.NoError(t, err)
-		defer w.Close()
 
 		err = w.AddBlock(&bookkeeping.Block{}, transactions.Payset{}, delta)
 		require.NoError(t, err)
 
+		w.Close()
 		return tx.Commit(context.Background())
 	}
 	err := db.txWithRetry(serializable, f)
@@ -135,6 +135,7 @@ func TestWriteReadAccountData(t *testing.T) {
 	l, err := ledgerforevaluator.MakeLedgerForEvaluator(
 		tx, crypto.Digest{}, transactions.SpecialAddresses{})
 	require.NoError(t, err)
+	defer l.Close()
 
 	// Load all accounts in a batch.
 	err = l.PreloadAccounts(addresses)


### PR DESCRIPTION
## Summary

Querying any REST endpoint during catchup sometimes returned an error like this:
```
curl "http://localhost:10001/v2/accounts/FT6OTSGGH5AHWUB537CGH2YWUS6DK7TZ26K2D42JVC3CPH3PLLRF6PWPQY?round=10000000"
{"message":"Indexer health error: getNextRoundToAccount() err: unable to get import state err: getMetastate() err: conn busy"}
```

The problem was that we closed prepared statements after committing the database transaction. This PR fixes the problem.

## Test Plan

Ran indexer and used `watch -n 0.2 curl -s "http://localhost:10000/health"` to watch for any errors.