### PR TITLE
Clear out error in catchup loop

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -117,6 +117,8 @@ func (bot *fetcherImpl) catchupLoop() {
 			bot.log.WithError(err).Errorf("err handling catchup block %d", bot.nextRound)
 			return
 		}
+		// If we successfully handle the block, clear out any transient error which may have occurred.
+		bot.setError(nil)
 		bot.nextRound++
 		bot.failingSince = time.Time{}
 	}


### PR DESCRIPTION
## Summary

Same as in `followLoop()`.

I observed this bug after pausing algod for awhile and starting again. The error is still there.
```
curl -s "http://localhost:10000/health"
{"data":{"migration-required":false,"migration-status":"Migrations Complete"},"db-available":true,"errors":["fetcher error: Get \"http://127.0.0.1:8080/v2/status/wait-for-block-after/8956439\": dial tcp 127.0.0.1:8080: connect: connection refused"],"is-migrating":false,"message":"8963384","round":8963384}
```