### PR TITLE
Better error when validator fails to parse data.

### DIFF
--- a/cmd/validator/core/dynamic_processor.go
+++ b/cmd/validator/core/dynamic_processor.go
@@ -24,13 +24,13 @@ func (gp DynamicProcessor) ProcessAddress(algodData, indexerData []byte) (Result
 	var indexerAcct map[string]interface{}
 	err := json.Unmarshal(indexerData, &indexerAcct)
 	if err != nil {
-		return Result{}, fmt.Errorf("unable to parse indexer data: %v", err)
+		return Result{}, fmt.Errorf("unable to parse indexer data ('%s'): %v", string(indexerData), err)
 	}
 
 	var algodAcct map[string]interface{}
 	err = json.Unmarshal(algodData, &algodAcct)
 	if err != nil {
-		return Result{}, fmt.Errorf("unable to parse algod data: %v", err)
+		return Result{}, fmt.Errorf("unable to parse algod data ('%s'): %v", string(algodData), err)
 	}
 
 	indexerNorm, err := normalize(indexerAcct)

--- a/cmd/validator/core/struct_processor.go
+++ b/cmd/validator/core/struct_processor.go
@@ -19,14 +19,14 @@ func (gp StructProcessor) ProcessAddress(algodData, indexerData []byte) (Result,
 	var indexerResponse generated.AccountResponse
 	err := json.Unmarshal(indexerData, &indexerResponse)
 	if err != nil {
-		return Result{}, fmt.Errorf("unable to parse indexer data: %v", err)
+		return Result{}, fmt.Errorf("unable to parse indexer data ('%s'): %v", string(indexerData), err)
 	}
 
 	indexerAcct := indexerResponse.Account
 	var algodAcct generated.Account
 	err = json.Unmarshal(algodData, &algodAcct)
 	if err != nil {
-		return Result{}, fmt.Errorf("unable to parse algod data: %v", err)
+		return Result{}, fmt.Errorf("unable to parse algod data ('%s'): %v", string(algodData), err)
 	}
 
 	differences := equals(indexerAcct, algodAcct)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Improve error message when failing to parse account data. This is the message but doesn't include enough information to understand why parsing failed:
```
Processor error: error processing account V2XS7RPZG7KFDBPF23K6MDFQMTSEWNP2JTZ5GNA4Y65CTSCTCCOMAJ6D34: unable to parse indexer data: invalid character '<' looking for beginning of value
```
