### PR TITLE
Make `EncodeJSON()` private

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,5 +22,4 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
-	github.com/vektra/mockery v1.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -438,8 +438,6 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/karalabe/hid v0.0.0-20181128192157-d815e0c1a2e2/go.mod h1:YvbcH+3Wo6XPs9nkgTY3u19KXLauXW+J5nB7hEHuX0A=
-github.com/karalabe/hid v1.0.0 h1:+/CIMNXhSU/zIJgnIvBD2nKHxS/bnRHhhs9xBryLpPo=
 github.com/karalabe/hid v1.0.0/go.mod h1:Vr51f8rUOLYrfrWDFlV12GGQgM5AT8sVh+2fY4MPeu8=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
@@ -706,8 +704,6 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/valyala/fasttemplate v1.1.0/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1 h1:TVEnxayobAdVkhQfrfes2IzOB6o+z4roRkPF52WA1u4=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
-github.com/vektra/mockery v1.1.2 h1:uc0Yn67rJpjt8U/mAZimdCKn9AeA97BOkjpmtBSlfP4=
-github.com/vektra/mockery v1.1.2/go.mod h1:VcfZjKaFOPO+MpN4ZvwPjs4c48lkq1o3Ym8yHZJu0jU=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
@@ -988,7 +984,6 @@ golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
-golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200423205358-59e73619c742/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200426102838-f3a5411a4c3b/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/idb/postgres/internal/encoding/decode.go
+++ b/idb/postgres/internal/encoding/decode.go
@@ -8,6 +8,9 @@ import (
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/protocol"
+
+	"github.com/algorand/indexer/idb"
+	"github.com/algorand/indexer/idb/postgres/internal/types"
 )
 
 // DecodeJSON is a function that decodes json.
@@ -303,4 +306,37 @@ func DecodeSpecialAddresses(data []byte) (transactions.SpecialAddresses, error) 
 	}
 
 	return unconvertSpecialAddresses(special), nil
+}
+
+// DecodeTxnExtra decodes transaction extra info from json.
+func DecodeTxnExtra(data []byte) (idb.TxnExtra, error) {
+	var extra idb.TxnExtra
+	err := DecodeJSON(data, &extra)
+	if err != nil {
+		return idb.TxnExtra{}, err
+	}
+
+	return extra, nil
+}
+
+// DecodeImportState decodes import state from json.
+func DecodeImportState(data []byte) (types.ImportState, error) {
+	var state types.ImportState
+	err := DecodeJSON(data, &state)
+	if err != nil {
+		return types.ImportState{}, err
+	}
+
+	return state, nil
+}
+
+// DecodeMigrationState decodes migration state from json.
+func DecodeMigrationState(data []byte) (types.MigrationState, error) {
+	var state types.MigrationState
+	err := DecodeJSON(data, &state)
+	if err != nil {
+		return types.MigrationState{}, err
+	}
+
+	return state, nil
 }

--- a/idb/postgres/internal/encoding/encode.go
+++ b/idb/postgres/internal/encoding/encode.go
@@ -9,13 +9,15 @@ import (
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-codec/codec"
 
+	"github.com/algorand/indexer/idb"
+	"github.com/algorand/indexer/idb/postgres/internal/types"
 	"github.com/algorand/indexer/util"
 )
 
 var jsonCodecHandle *codec.JsonHandle
 
-// EncodeJSON converts an object into JSON
-func EncodeJSON(obj interface{}) []byte {
+// encodeJSON converts an object into JSON
+func encodeJSON(obj interface{}) []byte {
 	var buf []byte
 	enc := codec.NewEncoderBytes(&buf, jsonCodecHandle)
 	enc.MustEncode(obj)
@@ -38,7 +40,7 @@ func convertBlockHeader(header bookkeeping.BlockHeader) blockHeader {
 
 // EncodeBlockHeader encodes block header into json.
 func EncodeBlockHeader(header bookkeeping.BlockHeader) []byte {
-	return EncodeJSON(convertBlockHeader(header))
+	return encodeJSON(convertBlockHeader(header))
 }
 
 func convertAssetParams(params basics.AssetParams) assetParams {
@@ -74,7 +76,7 @@ func convertAssetParams(params basics.AssetParams) assetParams {
 
 // EncodeAssetParams encodes asset params into json.
 func EncodeAssetParams(params basics.AssetParams) []byte {
-	return EncodeJSON(convertAssetParams(params))
+	return encodeJSON(convertAssetParams(params))
 }
 
 func convertAccounts(accounts []basics.Address) []crypto.Digest {
@@ -155,7 +157,7 @@ func convertSignedTxnWithAD(stxn transactions.SignedTxnWithAD) signedTxnWithAD {
 
 // EncodeSignedTxnWithAD encodes signed transaction with apply data into json.
 func EncodeSignedTxnWithAD(stxn transactions.SignedTxnWithAD) []byte {
-	return EncodeJSON(convertSignedTxnWithAD(stxn))
+	return encodeJSON(convertSignedTxnWithAD(stxn))
 }
 
 // TrimAccountData deletes various information from account data that we do not write to
@@ -183,7 +185,7 @@ func convertTrimmedAccountData(ad basics.AccountData) trimmedAccountData {
 
 // EncodeTrimmedAccountData encodes account data into json.
 func EncodeTrimmedAccountData(ad basics.AccountData) []byte {
-	return EncodeJSON(convertTrimmedAccountData(ad))
+	return encodeJSON(convertTrimmedAccountData(ad))
 }
 
 func convertTealValue(tv basics.TealValue) tealValue {
@@ -218,7 +220,7 @@ func convertAppLocalState(state basics.AppLocalState) appLocalState {
 
 // EncodeAppLocalState encodes local application state into json.
 func EncodeAppLocalState(state basics.AppLocalState) []byte {
-	return EncodeJSON(convertAppLocalState(state))
+	return encodeJSON(convertAppLocalState(state))
 }
 
 func convertAppParams(params basics.AppParams) appParams {
@@ -230,7 +232,7 @@ func convertAppParams(params basics.AppParams) appParams {
 
 // EncodeAppParams encodes application params into json.
 func EncodeAppParams(params basics.AppParams) []byte {
-	return EncodeJSON(convertAppParams(params))
+	return encodeJSON(convertAppParams(params))
 }
 
 func convertSpecialAddresses(special transactions.SpecialAddresses) specialAddresses {
@@ -243,7 +245,22 @@ func convertSpecialAddresses(special transactions.SpecialAddresses) specialAddre
 
 // EncodeSpecialAddresses encodes special addresses (sink and rewards pool) into json.
 func EncodeSpecialAddresses(special transactions.SpecialAddresses) []byte {
-	return EncodeJSON(convertSpecialAddresses(special))
+	return encodeJSON(convertSpecialAddresses(special))
+}
+
+// EncodeTxnExtra encodes transaction extra info into json.
+func EncodeTxnExtra(extra *idb.TxnExtra) []byte {
+	return encodeJSON(extra)
+}
+
+// EncodeImportState encodes import state into json.
+func EncodeImportState(state *types.ImportState) []byte {
+	return encodeJSON(state)
+}
+
+// EncodeMigrationState encodes migration state into json.
+func EncodeMigrationState(state *types.MigrationState) []byte {
+	return encodeJSON(state)
 }
 
 func init() {

--- a/idb/postgres/internal/encoding/encoding_test.go
+++ b/idb/postgres/internal/encoding/encoding_test.go
@@ -77,7 +77,7 @@ func TestJSONEncoding(t *testing.T) {
 		Bytes:  []byte{4, 5, 6},
 		Object: Y{Num: 7},
 	}
-	buf := EncodeJSON(x)
+	buf := encodeJSON(x)
 
 	var xx T
 	err := DecodeJSON(buf, &xx)
@@ -243,7 +243,7 @@ func TestByteArrayEncoding(t *testing.T) {
 			{string([]byte{0xff})}: 3,
 		},
 	}
-	buf := EncodeJSON(x)
+	buf := encodeJSON(x)
 
 	expectedString := `{"ByteArray":"/w==","Map":{"/w==":3}}`
 	assert.Equal(t, expectedString, string(buf))

--- a/idb/postgres/internal/types/types.go
+++ b/idb/postgres/internal/types/types.go
@@ -1,0 +1,22 @@
+package types
+
+// ImportState encodes an import round counter.
+type ImportState struct {
+	// Next round to account.
+	NextRoundToAccount *uint64 `codec:"next_account_round"`
+}
+
+// MigrationState is metadata used by the postgres migrations.
+type MigrationState struct {
+	NextMigration int `json:"next"`
+
+	// The following are deprecated.
+	NextRound    int64  `json:"round,omitempty"`
+	NextAssetID  int64  `json:"assetid,omitempty"`
+	PointerRound *int64 `json:"pointerRound,omitempty"`
+	PointerIntra *int64 `json:"pointerIntra,omitempty"`
+
+	// Note: a generic "data" field here could be a good way to deal with this growing over time.
+	//       It would require a mechanism to clear the data field between migrations to avoid using migration data
+	//       from the previous migration.
+}

--- a/idb/postgres/internal/writer/writer.go
+++ b/idb/postgres/internal/writer/writer.go
@@ -209,7 +209,7 @@ func addTransactions(block *bookkeeping.Block, modifiedTxns []transactions.Signe
 			uint64(block.Round()), intra, int(typeenum), assetid, id,
 			protocol.Encode(&stxnad),
 			encoding.EncodeSignedTxnWithAD(stxnad),
-			encoding.EncodeJSON(extra))
+			encoding.EncodeTxnExtra(&extra))
 
 		intra += countTxns(modifiedTxns[idx].SignedTxnWithAD)
 	}

--- a/idb/postgres/internal/writer/writer_test.go
+++ b/idb/postgres/internal/writer/writer_test.go
@@ -302,8 +302,7 @@ func TestWriterTxnTableAssetCloseAmount(t *testing.T) {
 	{
 		expected := idb.TxnExtra{AssetCloseAmount: 3}
 
-		var actual idb.TxnExtra
-		err := encoding.DecodeJSON(extra, &actual)
+		actual, err := encoding.DecodeTxnExtra(extra)
 		require.NoError(t, err)
 
 		assert.Equal(t, expected, actual)

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -851,8 +851,7 @@ func TestAppExtraPages(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, index)
 
-	var ap basics.AppParams
-	err = encoding.DecodeJSON(paramsStr, &ap)
+	ap, err := encoding.DecodeAppParams(paramsStr)
 	require.NoError(t, err)
 	require.Equal(t, uint32(1), ap.ExtraProgramPages)
 


### PR DESCRIPTION
## Summary

To prevent use of `EncodeJSON()` for types that need special handling, replace use of `EncodeJSON()` with specialized functions and make `EncodeJSON()` private.