### PR TITLE
Backport AVM 1.0 DB support to 2.6.2

### DIFF
--- a/idb/postgres/postgres_integration_common_test.go
+++ b/idb/postgres/postgres_integration_common_test.go
@@ -87,6 +87,7 @@ func queryInt(db *sql.DB, queryString string, args ...interface{}) int {
 	var count int
 	err := row.Scan(&count)
 	if err != nil {
+		fmt.Println(err.Error())
 		return -1
 	}
 	return count


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Update accounting to process inner transactions.
Update transaction participation table to find the root transaction by inner transaction participants.

Some of these changes are backported from these issues:
#656 
#661 
#675 

## Test Plan

Unit tests.