### PR TITLE
Always give nil maps to evaluator when empty

### DIFF
--- a/idb/postgres/internal/ledger_for_evaluator/ledger_for_evaluator.go
+++ b/idb/postgres/internal/ledger_for_evaluator/ledger_for_evaluator.go
@@ -145,7 +145,7 @@ func (l *LedgerForEvaluator) parseAccountTable(row pgx.Row) (basics.AccountData,
 
 func (l *LedgerForEvaluator) parseAccountAssetTable(rows pgx.Rows) (map[basics.AssetIndex]basics.AssetHolding, error) {
 	defer rows.Close()
-	res := make(map[basics.AssetIndex]basics.AssetHolding)
+	var res map[basics.AssetIndex]basics.AssetHolding
 
 	var assetid uint64
 	var amount uint64
@@ -157,6 +157,9 @@ func (l *LedgerForEvaluator) parseAccountAssetTable(rows pgx.Rows) (map[basics.A
 			return nil, fmt.Errorf("parseAccountAssetTable() scan row err: %w", err)
 		}
 
+		if res == nil {
+			res = make(map[basics.AssetIndex]basics.AssetHolding)
+		}
 		res[basics.AssetIndex(assetid)] = basics.AssetHolding{
 			Amount: amount,
 			Frozen: frozen,
@@ -173,7 +176,7 @@ func (l *LedgerForEvaluator) parseAccountAssetTable(rows pgx.Rows) (map[basics.A
 
 func (l *LedgerForEvaluator) parseAssetTable(rows pgx.Rows) (map[basics.AssetIndex]basics.AssetParams, error) {
 	defer rows.Close()
-	res := make(map[basics.AssetIndex]basics.AssetParams)
+	var res map[basics.AssetIndex]basics.AssetParams
 
 	var index uint64
 	var params []byte
@@ -184,6 +187,9 @@ func (l *LedgerForEvaluator) parseAssetTable(rows pgx.Rows) (map[basics.AssetInd
 			return nil, fmt.Errorf("parseAssetTable() scan row err: %w", err)
 		}
 
+		if res == nil {
+			res = make(map[basics.AssetIndex]basics.AssetParams)
+		}
 		res[basics.AssetIndex(index)], err = encoding.DecodeAssetParams(params)
 		if err != nil {
 			return nil, fmt.Errorf("parseAssetTable() decode params err: %w", err)
@@ -200,7 +206,7 @@ func (l *LedgerForEvaluator) parseAssetTable(rows pgx.Rows) (map[basics.AssetInd
 
 func (l *LedgerForEvaluator) parseAppTable(rows pgx.Rows) (map[basics.AppIndex]basics.AppParams, error) {
 	defer rows.Close()
-	res := make(map[basics.AppIndex]basics.AppParams)
+	var res map[basics.AppIndex]basics.AppParams
 
 	var index uint64
 	var params []byte
@@ -211,6 +217,9 @@ func (l *LedgerForEvaluator) parseAppTable(rows pgx.Rows) (map[basics.AppIndex]b
 			return nil, fmt.Errorf("parseAppTable() scan row err: %w", err)
 		}
 
+		if res == nil {
+			res = make(map[basics.AppIndex]basics.AppParams)
+		}
 		res[basics.AppIndex(index)], err = encoding.DecodeAppParams(params)
 		if err != nil {
 			return nil, fmt.Errorf("parseAppTable() decode params err: %w", err)
@@ -227,7 +236,7 @@ func (l *LedgerForEvaluator) parseAppTable(rows pgx.Rows) (map[basics.AppIndex]b
 
 func (l *LedgerForEvaluator) parseAccountAppTable(rows pgx.Rows) (map[basics.AppIndex]basics.AppLocalState, error) {
 	defer rows.Close()
-	res := make(map[basics.AppIndex]basics.AppLocalState)
+	var res map[basics.AppIndex]basics.AppLocalState
 
 	var app uint64
 	var localstate []byte
@@ -238,6 +247,9 @@ func (l *LedgerForEvaluator) parseAccountAppTable(rows pgx.Rows) (map[basics.App
 			return nil, fmt.Errorf("parseAccountAppTable() scan row err: %w", err)
 		}
 
+		if res == nil {
+			res = make(map[basics.AppIndex]basics.AppLocalState)
+		}
 		res[basics.AppIndex(app)], err = encoding.DecodeAppLocalState(localstate)
 		if err != nil {
 			return nil, fmt.Errorf("parseAccountAppTable() decode local state err: %w", err)

--- a/idb/postgres/internal/ledger_for_evaluator/ledger_for_evaluator_test.go
+++ b/idb/postgres/internal/ledger_for_evaluator/ledger_for_evaluator_test.go
@@ -90,10 +90,6 @@ func TestLedgerForEvaluatorAccountTableBasic(t *testing.T) {
 	accountDataFull.MicroAlgos = basics.MicroAlgos{Raw: 2}
 	accountDataFull.RewardsBase = 3
 	accountDataFull.RewardedMicroAlgos = basics.MicroAlgos{Raw: 4}
-	accountDataFull.AssetParams = make(map[basics.AssetIndex]basics.AssetParams)
-	accountDataFull.Assets = make(map[basics.AssetIndex]basics.AssetHolding)
-	accountDataFull.AppLocalStates = make(map[basics.AppIndex]basics.AppLocalState)
-	accountDataFull.AppParams = make(map[basics.AppIndex]basics.AppParams)
 
 	_, err := db.Exec(
 		context.Background(),
@@ -193,19 +189,6 @@ func TestLedgerForEvaluatorAccountTableSingleAccount(t *testing.T) {
 				}
 				require.NoError(t, err)
 				return false
-			}
-			// Add empty maps
-			if tc.data.AssetParams == nil {
-				tc.data.AssetParams = make(map[basics.AssetIndex]basics.AssetParams)
-			}
-			if tc.data.Assets == nil {
-				tc.data.Assets = make(map[basics.AssetIndex]basics.AssetHolding)
-			}
-			if tc.data.AppLocalStates == nil {
-				tc.data.AppLocalStates = make(map[basics.AppIndex]basics.AppLocalState)
-			}
-			if tc.data.AppParams == nil {
-				tc.data.AppParams = make(map[basics.AppIndex]basics.AppParams)
 			}
 
 			err := insertAccountData(db, addr, tc.createdAt, tc.deleted, tc.data)
@@ -340,11 +323,7 @@ func TestLedgerForEvaluatorAccountTableNullAccountData(t *testing.T) {
 			"VALUES ($1, $2, 0, 0, false, 0)"
 
 	accountDataFull := basics.AccountData{
-		MicroAlgos:     basics.MicroAlgos{Raw: 2},
-		AssetParams:    make(map[basics.AssetIndex]basics.AssetParams),
-		Assets:         make(map[basics.AssetIndex]basics.AssetHolding),
-		AppLocalStates: make(map[basics.AppIndex]basics.AppLocalState),
-		AppParams:      make(map[basics.AppIndex]basics.AppParams),
+		MicroAlgos: basics.MicroAlgos{Raw: 2},
 	}
 	_, err := db.Exec(
 		context.Background(), query, test.AccountA[:], accountDataFull.MicroAlgos.Raw)
@@ -401,7 +380,6 @@ func TestLedgerForEvaluatorAccountAssetTable(t *testing.T) {
 	require.NoError(t, err)
 
 	accountDataExpected := basics.AccountData{
-		AssetParams: make(map[basics.AssetIndex]basics.AssetParams),
 		Assets: map[basics.AssetIndex]basics.AssetHolding{
 			1: {
 				Amount: 2,
@@ -412,8 +390,6 @@ func TestLedgerForEvaluatorAccountAssetTable(t *testing.T) {
 				Frozen: true,
 			},
 		},
-		AppLocalStates: make(map[basics.AppIndex]basics.AppLocalState),
-		AppParams:      make(map[basics.AppIndex]basics.AppParams),
 	}
 	assert.Equal(t, accountDataExpected, accountDataRet)
 }
@@ -472,9 +448,6 @@ func TestLedgerForEvaluatorAssetTable(t *testing.T) {
 				Manager: test.AccountC,
 			},
 		},
-		Assets:         make(map[basics.AssetIndex]basics.AssetHolding),
-		AppLocalStates: make(map[basics.AppIndex]basics.AppLocalState),
-		AppParams:      make(map[basics.AppIndex]basics.AppParams),
 	}
 	assert.Equal(t, accountDataExpected, accountDataRet)
 }
@@ -533,9 +506,6 @@ func TestLedgerForEvaluatorAppTable(t *testing.T) {
 	require.NoError(t, err)
 
 	accountDataExpected := basics.AccountData{
-		AssetParams:    make(map[basics.AssetIndex]basics.AssetParams),
-		Assets:         make(map[basics.AssetIndex]basics.AssetHolding),
-		AppLocalStates: make(map[basics.AppIndex]basics.AppLocalState),
 		AppParams: map[basics.AppIndex]basics.AppParams{
 			1: params1,
 			2: params2,
@@ -600,13 +570,10 @@ func TestLedgerForEvaluatorAccountAppTable(t *testing.T) {
 	require.NoError(t, err)
 
 	accountDataExpected := basics.AccountData{
-		AssetParams: make(map[basics.AssetIndex]basics.AssetParams),
-		Assets:      make(map[basics.AssetIndex]basics.AssetHolding),
 		AppLocalStates: map[basics.AppIndex]basics.AppLocalState{
 			1: params1,
 			2: params2,
 		},
-		AppParams: make(map[basics.AppIndex]basics.AppParams),
 	}
 	assert.Equal(t, accountDataExpected, accountDataRet)
 }


### PR DESCRIPTION
## Summary

Decoding an empty creatable map from msgpack always results in `nil` maps because of the `omitempty` directive. So, the evaluator gets `nil` maps in algod. We should be consistent, and also return empty maps in Indexer's `LedgerForEvaluator`.