### PR TITLE
Revert "Statically link glib libraries (#730)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,31 +4,12 @@ OS_TYPE		?= $(shell $(SRCPATH)/mule/scripts/ostype.sh)
 ARCH			?= $(shell $(SRCPATH)/mule/scripts/archtype.sh)
 PKG_DIR		= $(SRCPATH)/tmp/node_pkgs/$(OS_TYPE)/$(ARCH)/$(VERSION)
 
-ifeq ($(OS_TYPE), linux)
-EXTLDFLAGS := -static-libstdc++ -static-libgcc
-ifeq ($(ARCH), amd64)
-ifeq (,$(wildcard /etc/centos-release))
-EXTLDFLAGS  += -static
-endif
-endif
-ifeq ($(ARCH), arm)
-ifneq ("$(wildcard /etc/alpine-release)","")
-EXTLDFLAGS  += -static
-endif
-endif
-endif
-ifneq (, $(findstring MINGW,$(OS_TYPE)))
-EXTLDFLAGS := -static -static-libstdc++ -static-libgcc
-endif
-
-
 # TODO: ensure any additions here are mirrored in misc/release.py
 GOLDFLAGS += -X github.com/algorand/indexer/version.Hash=$(shell git log -n 1 --pretty="%H")
 GOLDFLAGS += -X github.com/algorand/indexer/version.Dirty=$(if $(filter $(strip $(shell git status --porcelain|wc -c)), "0"),,true)
 GOLDFLAGS += -X github.com/algorand/indexer/version.CompileTime=$(shell date -u +%Y-%m-%dT%H:%M:%S%z)
 GOLDFLAGS += -X github.com/algorand/indexer/version.GitDecorateBase64=$(shell git log -n 1 --pretty="%D"|base64|tr -d ' \n')
 GOLDFLAGS += -X github.com/algorand/indexer/version.ReleaseVersion=$(shell cat .version)
-GOLDFLAGS += -extldflags \"$(EXTLDFLAGS)\"
 
 # Used for e2e test
 export GO_IMAGE = golang:$(shell go version | cut -d ' ' -f 3 | tail -c +3 )

--- a/misc/release.py
+++ b/misc/release.py
@@ -101,7 +101,7 @@ def link(sourcepath, destpath):
 
 _tagpat = re.compile(r'tag:\s+([^,\n]+)')
 
-def compile_version_opts(hostos, release_version=None, allow_mismatch=False):
+def compile_version_opts(release_version=None, allow_mismatch=False):
     result = subprocess.run(['git', 'log', '-n', '1', '--pretty=%H %D'], stdout=subprocess.PIPE)
     result.check_returncode()
     so = result.stdout.decode()
@@ -132,8 +132,6 @@ def compile_version_opts(hostos, release_version=None, allow_mismatch=False):
     ldflags += ' -X github.com/algorand/indexer/version.GitDecorateBase64={}'.format(base64.b64encode(desc.encode()).decode())
     if release_version:
         ldflags += ' -X github.com/algorand/indexer/version.ReleaseVersion={}'.format(release_version)
-    if hostos == 'linux':
-        ldflags += ' -extldflags "-static -static-libstdc++ -static-libgcc"'
     logger.debug('Hash=%r Dirty=%r CompileTime=%r decorate=%r ReleaseVersion=%r', githash, dirty, now, desc, release_version)
     logger.debug('%s', ldflags)
     return ldflags
@@ -247,7 +245,7 @@ def main():
         logger.info('will only run %s %s', hostos, hostarch)
     with open('.version') as fin:
         version = fin.read().strip()
-    ldflags = compile_version_opts(hostos, version, allow_mismatch=args.fake_release)
+    ldflags = compile_version_opts(version, allow_mismatch=args.fake_release)
     for goos, goarch, debarch in osArchArch:
         if args.host_only and (goos != hostos or goarch != hostarch):
             logger.debug('skip %s %s', goos, goarch)


### PR DESCRIPTION
## Summary

Indexer crashes on ubuntu. I noticed it when I tried using the block generator. Reverting the commit that links glib statically solves the issue.

```
./block-generator runner -i ../algorand-indexer/algorand-indexer -c "user=indexer password=indexer host=localhost port=5432 database=p0 sslmode=disable" -r r -s scenarios/config.mixed.yml -l info --validate -d 1m --reset
Running test for configuration 'scenarios/config.mixed.yml'
stdout:
serving on localhost:4010

stderr:
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x63 pc=0x7fcc5975f5ca]

runtime stack:
runtime.throw(0x17fb57f, 0x2a)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/runtime/panic.go:1116 +0x72
runtime.sigpanic()
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/runtime/signal_unix.go:679 +0x46a

goroutine 155 [syscall]:
runtime.cgocall(0x122f460, 0xc00005b5c0, 0xc000126600)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/runtime/cgocall.go:133 +0x5b fp=0xc00005b590 sp=0xc00005b558 pc=0x408bbb
net._C2func_getaddrinfo(0xc000626ec0, 0x0, 0xc00062dc80, 0xc000126600, 0x0, 0x0, 0x0)
	_cgo_gotypes.go:92 +0x55 fp=0xc00005b5c0 sp=0xc00005b590 pc=0x5d9065
net.cgoLookupIPCNAME.func1(0xc000626ec0, 0xa, 0xa, 0xc00062dc80, 0xc000126600, 0x0, 0xc00005b6a0, 0x5dc442)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/cgo_unix.go:161 +0xd2 fp=0xc00005b608 sp=0xc00005b5c0 pc=0x5deac2
net.cgoLookupIPCNAME(0x17c6c30, 0x3, 0x7fff32866611, 0x9, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/cgo_unix.go:161 +0x183 fp=0xc00005b718 sp=0xc00005b608 pc=0x5da4f3
net.cgoIPLookup(0xc00060bc80, 0x17c6c30, 0x3, 0x7fff32866611, 0x9)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/cgo_unix.go:218 +0x67 fp=0xc00005b7b8 sp=0xc00005b718 pc=0x5dac27
runtime.goexit()
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc00005b7c0 sp=0xc00005b7b8 pc=0x46a721
created by net.cgoLookupIP
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/cgo_unix.go:228 +0xc7

goroutine 1 [chan receive]:
github.com/algorand/indexer/api.Serve(0x1b5b120, 0xc0005f9300, 0x7fff32866611, 0xe, 0x1b719c0, 0xc00062cba0, 0x7fcc60096630, 0xc00059c6e0, 0xc0006167e0, 0x0, ...)
	/home/ubuntu/indexer/api/server.go:113 +0x79e
main.glob..func1(0x252bc60, 0xc000171100, 0x0, 0x10)
	/home/ubuntu/indexer/cmd/algorand-indexer/daemon.go:114 +0x53c
github.com/spf13/cobra.(*Command).execute(0x252bc60, 0xc000170d00, 0x10, 0x10, 0x252bc60, 0xc000170d00)
	/home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x29d
github.com/spf13/cobra.(*Command).ExecuteC(0x252b9e0, 0xc000092058, 0x0, 0x0)
	/home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
	/home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
	/home/ubuntu/indexer/cmd/algorand-indexer/main.go:173 +0x31

goroutine 141 [syscall]:
os/signal.signal_recv(0x46a726)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/runtime/sigqueue.go:147 +0x9c
os/signal.loop()
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/os/signal/signal_unix.go:23 +0x22
created by os/signal.Notify.func1
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/os/signal/signal.go:127 +0x44

goroutine 143 [chan receive]:
main.glob..func1.1(0xc00060aa20, 0xc00060ed00)
	/home/ubuntu/indexer/cmd/algorand-indexer/daemon.go:62 +0x38
created by main.glob..func1
	/home/ubuntu/indexer/cmd/algorand-indexer/daemon.go:61 +0x20e

goroutine 144 [select]:
github.com/jackc/pgx/v4/pgxpool.(*Pool).backgroundHealthCheck(0xc0006168c0)
	/home/ubuntu/go/pkg/mod/github.com/jackc/pgx/v4@v4.13.0/pgxpool/pool.go:342 +0xe7
created by github.com/jackc/pgx/v4/pgxpool.ConnectConfig
	/home/ubuntu/go/pkg/mod/github.com/jackc/pgx/v4@v4.13.0/pgxpool/pool.go:223 +0x25e

goroutine 145 [select]:
net/http.(*Transport).getConn(0x252a4e0, 0xc0002105d0, 0x0, 0xc000228020, 0x4, 0xc000224050, 0xf, 0x0, 0x0, 0x0, ...)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/http/transport.go:1291 +0x57b
net/http.(*Transport).roundTrip(0x252a4e0, 0xc00022a200, 0xc0002120f0, 0xc0000eb738, 0x412858)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/http/transport.go:552 +0x726
net/http.(*Transport).RoundTrip(0x252a4e0, 0xc00022a200, 0x252a4e0, 0x0, 0x0)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/http/roundtrip.go:17 +0x35
net/http.send(0xc00022a200, 0x1b336c0, 0x252a4e0, 0x0, 0x0, 0x0, 0xc000214030, 0x400, 0x1, 0x0)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/http/client.go:252 +0x43e
net/http.(*Client).send(0xc0002104b0, 0xc00022a200, 0x0, 0x0, 0x0, 0xc000214030, 0x0, 0x1, 0x411fe6)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/http/client.go:176 +0xfa
net/http.(*Client).do(0xc0002104b0, 0xc00022a200, 0x0, 0x0, 0x0)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/http/client.go:699 +0x44a
net/http.(*Client).Do(...)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/http/client.go:567
github.com/algorand/go-algorand-sdk/client/v2/common.(*Client).submitFormRaw(0xc00014e240, 0x1b5b160, 0xc000036070, 0x17cb669, 0x8, 0x0, 0x0, 0x17c6897, 0x3, 0x411f00, ...)
	/home/ubuntu/go/pkg/mod/github.com/algorand/go-algorand-sdk@v1.9.1/client/v2/common/common.go:150 +0x6e2
github.com/algorand/go-algorand-sdk/client/v2/common.(*Client).submitForm(0xc00014e240, 0x1b5b160, 0xc000036070, 0x157c180, 0xc0002120d0, 0x17cb669, 0x8, 0x0, 0x0, 0x17c6897, ...)
	/home/ubuntu/go/pkg/mod/github.com/algorand/go-algorand-sdk@v1.9.1/client/v2/common/common.go:164 +0xf9
github.com/algorand/go-algorand-sdk/client/v2/common.(*Client).Get(...)
	/home/ubuntu/go/pkg/mod/github.com/algorand/go-algorand-sdk@v1.9.1/client/v2/common/common.go:195
github.com/algorand/go-algorand-sdk/client/v2/algod.(*Client).get(...)
	/home/ubuntu/go/pkg/mod/github.com/algorand/go-algorand-sdk@v1.9.1/client/v2/algod/algod.go:16
github.com/algorand/go-algorand-sdk/client/v2/algod.(*GetGenesis).Do(0xc0000ebeb8, 0x1b5b160, 0xc000036070, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/ubuntu/go/pkg/mod/github.com/algorand/go-algorand-sdk@v1.9.1/client/v2/algod/getGenesis.go:16 +0xea
github.com/algorand/indexer/importer.InitialImport(0x1b719c0, 0xc00062cba0, 0x0, 0x0, 0xc00014e240, 0xc0006167e0, 0x0)
	/home/ubuntu/indexer/importer/helper.go:212 +0x1d5
main.glob..func1.2(0xc000654120, 0x1b719c0, 0xc00062cba0, 0x1b68fe0, 0xc00059c6e0, 0x1b5b120, 0xc0005f9300, 0xc00060ed00)
	/home/ubuntu/indexer/cmd/algorand-indexer/daemon.go:92 +0xa1
created by main.glob..func1
	/home/ubuntu/indexer/cmd/algorand-indexer/daemon.go:87 +0x31e

goroutine 153 [select]:
net.(*Resolver).lookupIPAddr(0x25b1aa0, 0x1b5b160, 0xc000036070, 0x17c6c30, 0x3, 0x7fff32866611, 0x9, 0xfaa, 0x0, 0x0, ...)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/lookup.go:274 +0x664
net.(*Resolver).internetAddrList(0x25b1aa0, 0x1b5b160, 0xc000036070, 0x17c6c30, 0x3, 0x7fff32866611, 0xe, 0x0, 0x0, 0x0, ...)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/ipsock.go:280 +0x4da
net.(*Resolver).resolveAddrList(0x25b1aa0, 0x1b5b160, 0xc000036070, 0x17c961c, 0x6, 0x17c6c30, 0x3, 0x7fff32866611, 0xe, 0x0, ...)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/dial.go:222 +0x49e
net.(*ListenConfig).Listen(0xc00006add0, 0x1b5b160, 0xc000036070, 0x17c6c30, 0x3, 0x7fff32866611, 0xe, 0xef12f0, 0x1, 0x5401, ...)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/dial.go:624 +0xaa
net.Listen(0x17c6c30, 0x3, 0x7fff32866611, 0xe, 0xc00005b640, 0xef14b0, 0x1, 0x0)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/dial.go:707 +0x80
github.com/labstack/echo/v4.newListener(0x7fff32866611, 0xe, 0x17c6c30, 0x3, 0xc00005b678, 0x4670d0, 0xc000000180)
	/home/ubuntu/go/pkg/mod/github.com/labstack/echo/v4@v4.3.0/echo.go:970 +0x9f
github.com/labstack/echo/v4.(*Echo).configureServer(0xc000128400, 0xc00016a700, 0xc00060b2c0, 0xc00005b798)
	/home/ubuntu/go/pkg/mod/github.com/labstack/echo/v4@v4.3.0/echo.go:766 +0x473
github.com/labstack/echo/v4.(*Echo).StartServer(0xc000128400, 0xc00016a700, 0xc00005b7b8, 0x106c989)
	/home/ubuntu/go/pkg/mod/github.com/labstack/echo/v4@v4.3.0/echo.go:739 +0x49
github.com/algorand/indexer/api.Serve.func2(0xc0006167e0, 0xc000128400, 0xc00016a700)
	/home/ubuntu/indexer/api/server.go:110 +0x35
created by github.com/algorand/indexer/api.Serve
	/home/ubuntu/indexer/api/server.go:109 +0x76e

goroutine 154 [select]:
net.cgoLookupIP(0x1b5b120, 0xc0005f9fc0, 0x17c6c30, 0x3, 0x7fff32866611, 0x9, 0xc000036070, 0x17c961c, 0x6, 0x17c6c30, ...)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/cgo_unix.go:229 +0x195
net.(*Resolver).lookupIP(0x25b1aa0, 0x1b5b120, 0xc0005f9fc0, 0x17c6c30, 0x3, 0x7fff32866611, 0x9, 0xc00005b640, 0xef14b0, 0x1, ...)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/lookup_unix.go:96 +0x187
net.glob..func1(0x1b5b120, 0xc0005f9fc0, 0xc00060f710, 0x17c6c30, 0x3, 0x7fff32866611, 0x9, 0xc00005b730, 0x3, 0x0, ...)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/hook.go:23 +0x72
net.(*Resolver).lookupIPAddr.func1(0x0, 0x0, 0x0, 0x0)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/lookup.go:268 +0xb9
internal/singleflight.(*Group).doCall(0x25b1ab0, 0xc00063c960, 0xc000626eb0, 0xd, 0xc00065c000)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/internal/singleflight/singleflight.go:95 +0x2e
created by internal/singleflight.(*Group).DoChan
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/internal/singleflight/singleflight.go:88 +0x2bc

goroutine 70 [runnable]:
net/http.(*Transport).dialConnFor(0x252a4e0, 0xc000242000)
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/http/transport.go:1362
created by net/http.(*Transport).queueForDial
	/home/ubuntu/.gimme/versions/go1.14.7.linux.amd64/src/net/http/transport.go:1334 +0x3fe

Done running tests!
failed to start indexer: the process failed to start properly, health endpoint query failed
```