### PR TITLE
Use short version for health endpoint.

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -76,7 +76,7 @@ func (si *ServerImplementation) MakeHealthCheck(ctx echo.Context) error {
 	}
 
 	return ctx.JSON(http.StatusOK, common.HealthCheckResponse{
-		Version:     version.LongVersion(),
+		Version:     version.Version(),
 		Data:        health.Data,
 		Round:       health.Round,
 		IsMigrating: health.IsMigrating,

--- a/api/handlers_e2e_test.go
+++ b/api/handlers_e2e_test.go
@@ -329,5 +329,5 @@ func TestVersion(t *testing.T) {
 	require.Equal(t, uint64(0), response.Round)
 	require.False(t, response.IsMigrating)
 	// This is weird looking because the version is set with -ldflags
-	require.Equal(t, response.Version, "-dev.unknown compiled at  from git hash ")
+	require.Equal(t, response.Version, "(unknown version)")
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

The short version is probably easier for API users, the long version can be left for `-v`.

## Test Plan

Updated the unit test.