### PR TITLE
Use integer for root intra in `TxnExtra`

### DIFF
--- a/api/converter_utils.go
+++ b/api/converter_utils.go
@@ -241,7 +241,7 @@ func stateDeltaToStateDelta(d basics.StateDelta) *generated.StateDelta {
 type rowData struct {
 	Round            uint64
 	RoundTime        int64
-	Intra            int
+	Intra            uint
 	AssetID          uint64
 	AssetCloseAmount uint64
 }
@@ -270,16 +270,13 @@ func txnRowToTransaction(row idb.TxnRow) (generated.Transaction, error) {
 	extra := rowData{
 		Round:            row.Round,
 		RoundTime:        row.RoundTime.Unix(),
-		Intra:            row.Intra,
+		Intra:            uint(row.Intra),
 		AssetID:          row.AssetID,
 		AssetCloseAmount: row.Extra.AssetCloseAmount,
 	}
 
-	if row.Extra.RootIntra != "" {
-		extra.Intra, err = strconv.Atoi(row.Extra.RootIntra)
-		if err != nil {
-			return generated.Transaction{}, fmt.Errorf("txnRowToTransaction(): failed to parse root-intra (%s): %w", row.Extra.RootIntra, err)
-		}
+	if row.Extra.RootIntra.Present {
+		extra.Intra = row.Extra.RootIntra.Value
 	}
 
 	txn, err := signedTxnWithAdToTransaction(&stxn, extra)

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -44,8 +44,8 @@ type TxnRow struct {
 	Error error
 }
 
-func countInner(stxn *transactions.SignedTxnWithAD) int {
-	num := 0
+func countInner(stxn *transactions.SignedTxnWithAD) uint {
+	num := uint(0)
 	for _, itxn := range stxn.ApplyData.EvalDelta.InnerTxns {
 		num++
 		num += countInner(&itxn)
@@ -59,10 +59,10 @@ func (tr TxnRow) Next(ascending bool) (string, error) {
 	var b [12]byte
 	binary.LittleEndian.PutUint64(b[:8], tr.Round)
 
-	intra := tr.Intra
-	if tr.Extra.RootIntra != "" {
+	intra := uint(tr.Intra)
+	if tr.Extra.RootIntra.Present {
 		// initialize for descending order, the root intra.
-		intra, err = strconv.Atoi(tr.Extra.RootIntra)
+		intra = tr.Extra.RootIntra.Value
 		if err != nil {
 			return "", fmt.Errorf("Next() could not parse root intra: %w", err)
 		}
@@ -106,13 +106,45 @@ func DecodeTxnRowNext(s string) (round uint64, intra uint32, err error) {
 	return
 }
 
+// OptionalUint wraps bool and uint. It has a custom marshaller below.
+type OptionalUint struct {
+	Present bool
+	Value   uint
+}
+
+// MarshalText implements TextMarshaler interface.
+func (ou OptionalUint) MarshalText() ([]byte, error) {
+	if !ou.Present {
+		return nil, nil
+	}
+	return []byte(fmt.Sprintf("%d", ou.Value)), nil
+}
+
+// UnmarshalText implements TextUnmarshaler interface.
+func (ou *OptionalUint) UnmarshalText(text []byte) error {
+	if text == nil {
+		*ou = OptionalUint{}
+	} else {
+		value, err := strconv.ParseUint(string(text), 10, 64)
+		if err != nil {
+			return err
+		}
+		*ou = OptionalUint{
+			Present: true,
+			Value:   uint(value),
+		}
+	}
+
+	return nil
+}
+
 // TxnExtra is some additional metadata needed for a transaction.
 type TxnExtra struct {
 	AssetCloseAmount uint64 `codec:"aca,omitempty"`
 	// RootIntra is set on inner transactions. Combined with the confirmation
 	// round it can be used to lookup the root transaction.
 	// The type is string to allow distinguishing between 0 and empty.
-	RootIntra string `codec:"root-intra,omitempty"`
+	RootIntra OptionalUint `codec:"root-intra,omitempty"`
 	// RootTxid is set on inner transactions. It is a convenience for the
 	// future. If we decide to return inner transactions we'll want to include
 	// the root txid.

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -141,9 +141,8 @@ func (ou *OptionalUint) UnmarshalText(text []byte) error {
 // TxnExtra is some additional metadata needed for a transaction.
 type TxnExtra struct {
 	AssetCloseAmount uint64 `codec:"aca,omitempty"`
-	// RootIntra is set on inner transactions. Combined with the confirmation
+	// RootIntra is set only on inner transactions. Combined with the confirmation
 	// round it can be used to lookup the root transaction.
-	// The type is string to allow distinguishing between 0 and empty.
 	RootIntra OptionalUint `codec:"root-intra,omitempty"`
 	// RootTxid is set on inner transactions. It is a convenience for the
 	// future. If we decide to return inner transactions we'll want to include

--- a/idb/idb_test.go
+++ b/idb/idb_test.go
@@ -42,9 +42,11 @@ func TestTxnRowNext(t *testing.T) {
 			ascending: false,
 			txnRow: idb.TxnRow{
 				RootTxnBytes: protocol.Encode(&stxn),
-				Extra:        idb.TxnExtra{RootIntra: "50"},
-				Intra:        51,
-				Round:        1_234_567_890,
+				Extra: idb.TxnExtra{
+					RootIntra: idb.OptionalUint{Present: true, Value: 50},
+				},
+				Intra: 51,
+				Round: 1_234_567_890,
 			},
 			round: 1_234_567_890,
 			intra: 50,
@@ -54,9 +56,11 @@ func TestTxnRowNext(t *testing.T) {
 			ascending: true,
 			txnRow: idb.TxnRow{
 				RootTxnBytes: protocol.Encode(&stxn),
-				Extra:        idb.TxnExtra{RootIntra: "50"},
-				Intra:        51,
-				Round:        1_234_567_890,
+				Extra: idb.TxnExtra{
+					RootIntra: idb.OptionalUint{Present: true, Value: 50},
+				},
+				Intra: 51,
+				Round: 1_234_567_890,
 			},
 			round: 1_234_567_890,
 			intra: 53, // RootIntra + RootTxnBytes.numInnerTxns()
@@ -66,9 +70,11 @@ func TestTxnRowNext(t *testing.T) {
 			ascending: true,
 			txnRow: idb.TxnRow{
 				RootTxnBytes: []byte{},
-				Extra:        idb.TxnExtra{RootIntra: "50"},
-				Intra:        51,
-				Round:        1_234_567_890,
+				Extra: idb.TxnExtra{
+					RootIntra: idb.OptionalUint{Present: true, Value: 50},
+				},
+				Intra: 51,
+				Round: 1_234_567_890,
 			},
 			errMsg: "could not decode root transaction",
 		},
@@ -77,9 +83,11 @@ func TestTxnRowNext(t *testing.T) {
 			ascending: true,
 			txnRow: idb.TxnRow{
 				RootTxnBytes: nil,
-				Extra:        idb.TxnExtra{RootIntra: "50"},
-				Intra:        51,
-				Round:        1_234_567_890,
+				Extra: idb.TxnExtra{
+					RootIntra: idb.OptionalUint{Present: true, Value: 50},
+				},
+				Intra: 51,
+				Round: 1_234_567_890,
 			},
 			errMsg: "was not given transaction bytes",
 		},
@@ -88,11 +96,10 @@ func TestTxnRowNext(t *testing.T) {
 			ascending: true,
 			txnRow: idb.TxnRow{
 				RootTxnBytes: []byte{},
-				Extra:        idb.TxnExtra{RootIntra: "not a number"},
 				Intra:        51,
 				Round:        1_234_567_890,
 			},
-			errMsg: "could not parse root intra",
+			errMsg: "could not decode root transaction",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Found a way use integer for root intra. This doesn't change the format of json.

## Test Plan

Added usual encoding tests.