### PR TITLE
Search for serialization error in function's return error

### DIFF
--- a/idb/postgres/internal/util/util_test.go
+++ b/idb/postgres/internal/util/util_test.go
@@ -1,0 +1,38 @@
+package util_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pgtest "github.com/algorand/indexer/idb/postgres/internal/testing"
+	"github.com/algorand/indexer/idb/postgres/internal/util"
+)
+
+func TestTxWithRetry(t *testing.T) {
+	count := 3
+	f := func(pgx.Tx) error {
+		if count == 0 {
+			return nil
+		}
+
+		count--
+
+		pgerr := pgconn.PgError{
+			Code: pgerrcode.SerializationFailure,
+		}
+		return fmt.Errorf("database error: %w", &pgerr)
+	}
+
+	db, _, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
+
+	err := util.TxWithRetry(db, pgx.TxOptions{}, f, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -107,9 +107,9 @@ type IndexerDb struct {
 
 // txWithRetry is a helper function that retries the function `f` in case the database
 // transaction in it fails due to a serialization error. `f` is provided
-// a transaction created using `opts`. `f` should either return an error in which case
-// the transaction is rolled back and `TxWithRetry` terminates, or nil in which case
-// the transaction attempts to be committed.
+// a transaction created using `opts`. If `f` experiences a database error, this error
+// must be included in `f`'s return error's chain, so that a serialization error can be
+// detected.
 func (db *IndexerDb) txWithRetry(opts pgx.TxOptions, f func(pgx.Tx) error) error {
 	return pgutil.TxWithRetry(db.db, opts, f, db.log)
 }


### PR DESCRIPTION
## Summary

We used to assume that false positive serialization errors with postgres are only returned from `Commit()`. Turns out, any database operation such as reading rows can return this error.

## Test Plan

Haven't been able to reproduce this behavior.