### PR TITLE
Make inner transaction creatable ID lookup more resilient.

### DIFF
--- a/idb/postgres/internal/writer/writer.go
+++ b/idb/postgres/internal/writer/writer.go
@@ -142,40 +142,40 @@ func setSpecialAccounts(addresses transactions.SpecialAddresses, batch *pgx.Batc
 //       other things too, so it is not clear we should use it. The only
 //       real benefit is that it would slightly simplify this function by
 //       allowing us to leave out the intra / block parameters.
-func transactionAssetID(txn transactions.SignedTxnWithAD, intra uint, block *bookkeeping.Block) (uint64, error) {
+func transactionAssetID(stxnad *transactions.SignedTxnWithAD, intra uint, block *bookkeeping.Block) (uint64, error) {
 	assetid := uint64(0)
 
-	switch txn.Txn.Type {
+	switch stxnad.Txn.Type {
 	case protocol.ApplicationCallTx:
-		assetid = uint64(txn.Txn.ApplicationID)
+		assetid = uint64(stxnad.Txn.ApplicationID)
 		if assetid == 0 {
-			assetid = uint64(txn.ApplyData.ApplicationID)
+			assetid = uint64(stxnad.ApplyData.ApplicationID)
 		}
 		if assetid == 0 {
 			if block == nil {
-				return 0, fmt.Errorf("transactionAssetID(): Missing ApplicationID for transaction: %s", txn.ID())
+				return 0, fmt.Errorf("transactionAssetID(): Missing ApplicationID for transaction: %s", stxnad.ID())
 			}
 			// pre v30 transactions do not have ApplyData.ConfigAsset or InnerTxns
 			// so txn counter + payset pos calculation is OK
 			assetid = block.TxnCounter - uint64(len(block.Payset)) + uint64(intra) + 1
 		}
 	case protocol.AssetConfigTx:
-		assetid = uint64(txn.Txn.ConfigAsset)
+		assetid = uint64(stxnad.Txn.ConfigAsset)
 		if assetid == 0 {
-			assetid = uint64(txn.ApplyData.ConfigAsset)
+			assetid = uint64(stxnad.ApplyData.ConfigAsset)
 		}
 		if assetid == 0 {
 			if block == nil {
-				return 0, fmt.Errorf("transactionAssetID(): Missing ConfigAsset for transaction: %s", txn.ID())
+				return 0, fmt.Errorf("transactionAssetID(): Missing ConfigAsset for transaction: %s", stxnad.ID())
 			}
 			// pre v30 transactions do not have ApplyData.ApplicationID or InnerTxns
 			// so txn counter + payset pos calculation is OK
 			assetid = block.TxnCounter - uint64(len(block.Payset)) + uint64(intra) + 1
 		}
 	case protocol.AssetTransferTx:
-		assetid = uint64(txn.Txn.XferAsset)
+		assetid = uint64(stxnad.Txn.XferAsset)
 	case protocol.AssetFreezeTx:
-		assetid = uint64(txn.Txn.FreezeAsset)
+		assetid = uint64(stxnad.Txn.FreezeAsset)
 	}
 
 	return assetid, nil
@@ -191,8 +191,8 @@ func (w *Writer) addInnerTransactions(stxnad *transactions.SignedTxnWithAD, bloc
 		if !ok {
 			return 0, nil, fmt.Errorf("addInnerTransactions() get type enum")
 		}
-		// block should be used for inner transactions.
-		assetid, err := transactionAssetID(itxn, 0, nil)
+		// block shouldn't be used for inner transactions.
+		assetid, err := transactionAssetID(&itxn, 0, nil)
 		if err != nil {
 			return 0, nil, err
 		}
@@ -245,7 +245,7 @@ func (w *Writer) addTransactions(block *bookkeeping.Block, modifiedTxns []transa
 		if !ok {
 			return fmt.Errorf("addTransactions() get type enum")
 		}
-		assetid, err := transactionAssetID(stxnad, intra, block)
+		assetid, err := transactionAssetID(&stxnad, intra, block)
 		if err != nil {
 			return err
 		}

--- a/idb/postgres/internal/writer/writer.go
+++ b/idb/postgres/internal/writer/writer.go
@@ -186,7 +186,10 @@ func (w *Writer) addInnerTransactions(stxnad *transactions.SignedTxnWithAD, bloc
 		if !ok {
 			return 0, nil, fmt.Errorf("addInnerTransactions() get type enum")
 		}
-		assetid := transactionAssetID(itxn, 0, nil)
+		// Note: the block should be unused when we have inner transactions,
+		// but it is possible to create non-standard environments in sandbox
+		// where that might not be true.
+		assetid := transactionAssetID(itxn, 0, block)
 		extra := idb.TxnExtra{
 			AssetCloseAmount: itxn.ApplyData.AssetClosingAmount,
 			RootIntra:        idb.OptionalUint{Present: true, Value: rootIntra},

--- a/idb/postgres/internal/writer/writer_test.go
+++ b/idb/postgres/internal/writer/writer_test.go
@@ -1416,8 +1416,8 @@ func TestAddBlockInvalidInnerAsset(t *testing.T) {
 
 		// Add block detects an error
 		err = w.AddBlock(&block, block.Payset, ledgercore.StateDelta{})
-		expectedError := "AddBlock() err: addTransactions() adding inner: transactionAssetID(): Missing ConfigAsset for transaction: BDFOJVJRY4GPOMW7F3ZQMNAA2ESQMCP5BIZOWCGHGJFFCN3CZTRQ"
-		require.Error(t, err, expectedError)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Missing ConfigAsset for transaction: ")
 
 		return nil
 	})

--- a/idb/postgres/internal/writer/writer_test.go
+++ b/idb/postgres/internal/writer/writer_test.go
@@ -1381,6 +1381,48 @@ func TestWriterAccountAppTableCreateDeleteSameRound(t *testing.T) {
 	assert.Equal(t, block.Round(), basics.Round(closedAt))
 }
 
+func TestAddBlockInvalidInnerAsset(t *testing.T) {
+	db, shutdownFunc := setupPostgres(t)
+	defer shutdownFunc()
+
+	callWithBadInner := test.MakeCreateAppTxn(test.AccountA)
+	callWithBadInner.ApplyData.EvalDelta.InnerTxns = []transactions.SignedTxnWithAD{
+		{
+			ApplyData: transactions.ApplyData{
+				// This should not be zero
+				ConfigAsset: 0,
+			},
+			SignedTxn: transactions.SignedTxn{
+				Txn: transactions.Transaction{
+					Type: protocol.AssetConfigTx,
+					Header: transactions.Header{
+						Sender: test.AccountB,
+					},
+					AssetConfigTxnFields: transactions.AssetConfigTxnFields{
+						ConfigAsset: 0,
+					},
+				},
+			},
+		},
+	}
+
+	block, err := test.MakeBlockForTxns(test.MakeGenesisBlock().BlockHeader, &callWithBadInner)
+	require.NoError(t, err)
+
+	err = makeTx(db, func(tx pgx.Tx) error {
+		w, err := writer.MakeWriter(tx)
+		require.NoError(t, err)
+		defer w.Close()
+
+		// Add block detects an error
+		err = w.AddBlock(&block, block.Payset, ledgercore.StateDelta{})
+		expectedError := "AddBlock() err: addTransactions() adding inner: transactionAssetID(): Missing ConfigAsset for transaction: BDFOJVJRY4GPOMW7F3ZQMNAA2ESQMCP5BIZOWCGHGJFFCN3CZTRQ"
+		require.Error(t, err, expectedError)
+
+		return nil
+	})
+}
+
 func TestWriterAddBlockInnerTxnsAssetCreate(t *testing.T) {
 	db, shutdownFunc := setupPostgres(t)
 	defer shutdownFunc()

--- a/idb/postgres/internal/writer/writer_test.go
+++ b/idb/postgres/internal/writer/writer_test.go
@@ -1389,7 +1389,7 @@ func TestAddBlockInvalidInnerAsset(t *testing.T) {
 	callWithBadInner.ApplyData.EvalDelta.InnerTxns = []transactions.SignedTxnWithAD{
 		{
 			ApplyData: transactions.ApplyData{
-				// This should not be zero
+				// This is the invalid inner asset. It should not be zero.
 				ConfigAsset: 0,
 			},
 			SignedTxn: transactions.SignedTxn{


### PR DESCRIPTION
## Summary

Make the inner transaction ID lookup more resilient by passing in a block pointer even though it shouldn't be required.

A crash was reported when using sandbox with `stable` algod (3.0.1) and `develop` indexer (Nov 8):
```
Starting indexer against algod.
Connecting to algod:4001 (172.18.0.2:4001)
saving to 'genesis.json'
genesis.json         100% |********************************|  1822  0:00:00 ETA
'genesis.json' saved
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x158 pc=0x1284f16]

goroutine 22 [running]:
github.com/algorand/indexer/idb/postgres/internal/writer.transactionAssetID(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/opt/indexer/idb/postgres/internal/writer/writer.go:167 +0x56
github.com/algorand/indexer/idb/postgres/internal/writer.(*Writer).addInnerTransactions(0xc00048e728, 0xc00048d418, 0xc0000ba780, 0x1, 0x0, 0xc0004b0280, 0x34, 0xc00013c8c0, 0x1, 0x1, ...)
	/opt/indexer/idb/postgres/internal/writer/writer.go:189 +0x183
github.com/algorand/indexer/idb/postgres/internal/writer.(*Writer).addTransactions(0xc00048e728, 0xc0000ba780, 0xc000294000, 0x2, 0x2, 0xc65f57e557c98cf5, 0x8cc1f3760e6e675a)
	/opt/indexer/idb/postgres/internal/writer/writer.go:251 +0x956
github.com/algorand/indexer/idb/postgres/internal/writer.(*Writer).AddBlock(0xc00048e728, 0xc0000ba780, 0xc000294000, 0x2, 0x2, 0xc0002a8000, 0x5, 0x8, 0xc000319770, 0xc0003197a0, ...)
	/opt/indexer/idb/postgres/internal/writer/writer.go:507 +0x77
github.com/algorand/indexer/idb/postgres.(*IndexerDb).AddBlock.func1(0x1a8bfc0, 0xc00000e120, 0x0, 0x0)
	/opt/indexer/idb/postgres/postgres.go:255 +0xace
github.com/algorand/indexer/idb/postgres/internal/util.attemptTx(0x1a8bfc0, 0xc00000e120, 0xc0000135d0, 0x0, 0x0)
	/opt/indexer/idb/postgres/internal/util/util.go:25 +0xb6
github.com/algorand/indexer/idb/postgres/internal/util.TxWithRetry(0xc0004485b0, 0x16e1632, 0xc, 0x0, 0x0, 0x0, 0x0, 0xc00048f5d0, 0xc0004484d0, 0x0, ...)
	/opt/indexer/idb/postgres/internal/util/util.go:52 +0xbe
github.com/algorand/indexer/idb/postgres.(*IndexerDb).txWithRetry(...)
	/opt/indexer/idb/postgres/postgres.go:115
github.com/algorand/indexer/idb/postgres.(*IndexerDb).AddBlock(0xc0002cfd40, 0xc0000ba780, 0x0, 0x0)
	/opt/indexer/idb/postgres/postgres.go:263 +0x204
github.com/algorand/indexer/importer.(*Importer).ImportBlock(0xc00011a120, 0xc0000ba780, 0x2480de0, 0x0)
	/opt/indexer/importer/importer.go:25 +0x77
main.(*blockImporterHandler).HandleBlock(0xc00011a120, 0xc0000ba780)
	/opt/indexer/cmd/algorand-indexer/daemon.go:168 +0x77
github.com/algorand/indexer/fetcher.(*fetcherImpl).handleBlock(0xc00036ba20, 0xc0000ba780)
	/opt/indexer/fetcher/fetcher.go:237 +0x6c
github.com/algorand/indexer/fetcher.(*fetcherImpl).processQueue(0xc00036ba20)
	/opt/indexer/fetcher/fetcher.go:107 +0x32
created by github.com/algorand/indexer/fetcher.(*fetcherImpl).Run
	/opt/indexer/fetcher/fetcher.go:195 +0xc8
```