### PR TITLE
Add error msg in rewind about inner txns

### DIFF
--- a/accounting/rewind.go
+++ b/accounting/rewind.go
@@ -111,6 +111,10 @@ func AccountAtRound(account models.Account, round uint64, db idb.IndexerDb) (acc
 			return
 		}
 		txcount++
+		if txnrow.TxnBytes == nil {
+			return models.Account{},
+				fmt.Errorf("rewinding past inner transactions is not supported")
+		}
 		var stxn transactions.SignedTxnWithAD
 		err = protocol.Decode(txnrow.TxnBytes, &stxn)
 		if err != nil {


### PR DESCRIPTION
## Summary

Without this, the error message would be obscure "cannot decode transaction".