### PR TITLE
Update sigtype along with the rest of account data

### DIFF
--- a/idb/postgres/internal/writer/writer.go
+++ b/idb/postgres/internal/writer/writer.go
@@ -377,6 +377,8 @@ func (w *Writer) addTransactionParticipation(block *bookkeeping.Block) error {
 	return nil
 }
 
+// Describes a change to the `account.keytype` column. If `present` is true,
+// `value` is the new value. Otherwise, NULL will be the new value.
 type sigTypeDelta struct {
 	present bool
 	value   idb.SigType

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -851,6 +851,7 @@ func TestAppExtraPages(t *testing.T) {
 func assertKeytype(t *testing.T, db *IndexerDb, address basics.Address, keytype *string) {
 	opts := idb.AccountQueryOptions{
 		EqualToAddress: address[:],
+		IncludeDeleted: true,
 	}
 	rowsCh, _ := db.GetAccounts(context.Background(), opts)
 
@@ -1199,6 +1200,26 @@ func TestKeytypeResetsOnRekey(t *testing.T) {
 	require.NoError(t, err)
 
 	keytype = "msig"
+	assertKeytype(t, db, test.AccountA, &keytype)
+}
+
+// Test that after closing the account, keytype will be correctly set.
+func TestKeytypeDeletedAccount(t *testing.T) {
+	block := test.MakeGenesisBlock()
+	db, shutdownFunc := setupIdb(t, test.MakeGenesis(), block)
+	defer shutdownFunc()
+
+	assertKeytype(t, db, test.AccountA, nil)
+
+	closeTxn := test.MakePaymentTxn(
+		0, 0, 0, 0, 0, 0, test.AccountA, test.AccountA, test.AccountB, basics.Address{})
+
+	block, err := test.MakeBlockForTxns(block.BlockHeader, &closeTxn)
+	require.NoError(t, err)
+	err = db.AddBlock(&block)
+	require.NoError(t, err)
+
+	keytype := "sig"
 	assertKeytype(t, db, test.AccountA, &keytype)
 }
 


### PR DESCRIPTION
## Summary

Before we were updating the `account.keytype` column separately from updating accounts which resulted in one extra account lookup and one extra account rewrite by the database. This PR changes the way sigtype is updated; now it's done with the rest of account changes. The TPS improvement is 1.6X in my tests.

## Test Plan

We already have tests for the keytype, but I added another one that tests that even when an account is deleted after a round, the keytype is updated anyway.

One concern I had is that the evaluator might skip an account delta when the account data doesn't change even when it is a transaction sender (which triggers keytype change), but we already have a test (`TestKeytypeBasic`) that uses zero fee transactions that don't modify the account state.