### PR TITLE
Disable TimeoutMiddleware.

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -54,12 +54,6 @@ func Serve(ctx context.Context, serveAddr string, db idb.IndexerDb, fetcherError
 	e := echo.New()
 	e.HideBanner = true
 
-	// To ensure everything uses the correct context this must be specified first.
-	e.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{
-		ErrorMessage: `{"message":"Request Timeout"}`,
-		Timeout:      options.handlerTimeout(),
-	}))
-
 	if options.MetricsEndpoint {
 		p := echo_contrib.NewPrometheus("indexer", nil, nil)
 		if options.MetricsEndpointVerbose {


### PR DESCRIPTION
## Summary

The TimeoutMiddleware, as implemented, has a rare race condition. Disable it for now.