### PR TITLE
Remove non UTF-8 characters from Inner transaction Asset fields

### DIFF
--- a/idb/postgres/internal/encoding/encode.go
+++ b/idb/postgres/internal/encoding/encode.go
@@ -2,8 +2,6 @@ package encoding
 
 import (
 	"encoding/base64"
-	"unicode"
-	"unicode/utf8"
 
 	sdk_types "github.com/algorand/go-algorand-sdk/types"
 	"github.com/algorand/go-codec/codec"
@@ -83,20 +81,6 @@ func convertLocalDeltas(deltas map[uint64]types.StateDelta) map[uint64]types.Sta
 	return res
 }
 
-// printableUTF8OrEmpty checks to see if the entire string is a UTF8 printable string.
-// If this is the case, the string is returned as is. Otherwise, the empty string is returned.
-func printableUTF8OrEmpty(in string) string {
-	// iterate throughout all the characters in the string to see if they are all printable.
-	// when range iterating on go strings, go decode each element as a utf8 rune.
-	for _, c := range in {
-		// is this a printable character, or invalid rune ?
-		if c == utf8.RuneError || !unicode.IsPrint(c) {
-			return ""
-		}
-	}
-	return in
-}
-
 func convertItxnSignedTxnWithAD(stxn types.SignedTxnWithAD) types.SignedTxnWithAD {
 	stxn.EvalDelta = convertEvalDelta(stxn.EvalDelta)
 	// Remove non UTF8 characters from Asset params in Inner Transactions
@@ -124,7 +108,7 @@ func removeNonUTF8Chars(logs []string) []string {
 	}
 	res := make([]string, len(logs))
 	for i, log := range logs {
-		res[i] = printableUTF8OrEmpty(log)
+		res[i] = util.PrintableUTF8OrEmpty(log)
 	}
 	return res
 }

--- a/idb/postgres/internal/encoding/encode.go
+++ b/idb/postgres/internal/encoding/encode.go
@@ -97,6 +97,27 @@ func printableUTF8OrEmpty(in string) string {
 	return in
 }
 
+func convertItxnSignedTxnWithAD(stxn types.SignedTxnWithAD) types.SignedTxnWithAD {
+	stxn.EvalDelta = convertEvalDelta(stxn.EvalDelta)
+	// Remove non UTF8 characters from Asset params in Inner Transactions
+	stxn.Txn.AssetParams.AssetName = util.PrintableUTF8OrEmpty(stxn.Txn.AssetParams.AssetName)
+	stxn.Txn.AssetParams.UnitName = util.PrintableUTF8OrEmpty(stxn.Txn.AssetParams.UnitName)
+	stxn.Txn.AssetParams.URL = util.PrintableUTF8OrEmpty(stxn.Txn.AssetParams.URL)
+	return stxn
+}
+
+func convertInnerTxns(innerTxns []types.SignedTxnWithAD) []types.SignedTxnWithAD {
+	if innerTxns == nil {
+		return nil
+	}
+
+	res := make([]types.SignedTxnWithAD, len(innerTxns))
+	for i, innerTxn := range innerTxns {
+		res[i] = convertItxnSignedTxnWithAD(innerTxn)
+	}
+	return res
+}
+
 func removeNonUTF8Chars(logs []string) []string {
 	if logs == nil {
 		return nil
@@ -112,6 +133,7 @@ func convertEvalDelta(evalDelta types.EvalDelta) types.EvalDelta {
 	evalDelta.Logs = removeNonUTF8Chars(evalDelta.Logs)
 	evalDelta.GlobalDelta = convertStateDelta(evalDelta.GlobalDelta)
 	evalDelta.LocalDeltas = convertLocalDeltas(evalDelta.LocalDeltas)
+	evalDelta.InnerTxns = convertInnerTxns(evalDelta.InnerTxns)
 	return evalDelta
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Removes non UTF-8 characters for Inner transaction asset fields. 

A "proper" fix will be introduced in the `2.8.0` release.

## Test Plan

TODO
