### PR TITLE
Increase balance of genesis accounts to 1 billion algos

### DIFF
--- a/cmd/block-generator/scenarios/config.payment.full.yml
+++ b/cmd/block-generator/scenarios/config.payment.full.yml
@@ -1,6 +1,6 @@
 name: "Pay (full)"
 genesis_accounts: 10
-genesis_account_balance: 1000000000000
+genesis_account_balance: 1000000000000000
 tx_per_block: 5000
 
 # transaction distribution

--- a/cmd/block-generator/scenarios/config.payment.jumbo.yml
+++ b/cmd/block-generator/scenarios/config.payment.jumbo.yml
@@ -1,6 +1,6 @@
 name: "Pay (jumbo)"
 genesis_accounts: 10
-genesis_account_balance: 1000000000000
+genesis_account_balance: 1000000000000000
 tx_per_block: 19999
 
 # transaction distribution

--- a/cmd/block-generator/scenarios/config.payment.small.yml
+++ b/cmd/block-generator/scenarios/config.payment.small.yml
@@ -1,6 +1,6 @@
 name: "Pay (small)"
 genesis_accounts: 10
-genesis_account_balance: 1000000000000
+genesis_account_balance: 1000000000000000
 tx_per_block: 100
 
 # transaction distribution


### PR DESCRIPTION
## Summary

To prevent running out of funds, increase balance of genesis accounts to 1 billion algos for payment scenarios.