### PR TITLE
Add libboost-math-dev to mule's Dockerfile

### DIFF
--- a/docker/Dockerfile.mule
+++ b/docker/Dockerfile.mule
@@ -1,14 +1,14 @@
 # This Dockerfile is used by Jenkins.
 FROM ubuntu:latest
 
-ARG GO_VERSION=1.15
+ARG GO_VERSION=1.16
 ENV DEBIAN_FRONTEND noninteractive
 ENV USER root
 ENV GOROOT=/usr/local/go
 ENV GOPATH=$HOME/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
-RUN apt-get update && apt-get install -y apt-transport-https awscli ca-certificates build-essential curl git software-properties-common gnupg2 make bash libtool && \
+RUN apt-get update && apt-get install -y apt-transport-https awscli ca-certificates build-essential curl git software-properties-common gnupg2 make bash libtool libboost-math-dev && \
     curl https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz | tar xzf - && \
     mv go /usr/local && \
     export PATH=/usr/local/go/bin:$PATH && \


### PR DESCRIPTION
## Summary

The new submodule setup for go-algorand has added this dependency.

## Test Plan

Verified I could build a docker container and run a `make package`.