### PR TITLE
Return error in `GetTypeEnum()`

### DIFF
--- a/api/converter_utils.go
+++ b/api/converter_utils.go
@@ -130,7 +130,7 @@ func decodeSigType(str *string, errorArr []string) (idb.SigType, []string) {
 func decodeType(str *string, errorArr []string) (t idb.TxnTypeEnum, err []string) {
 	if str != nil {
 		typeLc := protocol.TxType(strings.ToLower(*str))
-		if val, err := idb.GetTypeEnum(typeLc); err != nil {
+		if val, err := idb.GetTypeEnum(typeLc); err == nil {
 			return val, errorArr
 		}
 		return 0, append(errorArr, fmt.Sprintf("%s: '%s'", errUnknownTxType, typeLc))

--- a/api/converter_utils.go
+++ b/api/converter_utils.go
@@ -130,7 +130,7 @@ func decodeSigType(str *string, errorArr []string) (idb.SigType, []string) {
 func decodeType(str *string, errorArr []string) (t idb.TxnTypeEnum, err []string) {
 	if str != nil {
 		typeLc := protocol.TxType(strings.ToLower(*str))
-		if val, ok := idb.GetTypeEnum(typeLc); ok {
+		if val, err := idb.GetTypeEnum(typeLc); err != nil {
 			return val, errorArr
 		}
 		return 0, append(errorArr, fmt.Sprintf("%s: '%s'", errUnknownTxType, typeLc))

--- a/idb/postgres/internal/writer/writer.go
+++ b/idb/postgres/internal/writer/writer.go
@@ -187,9 +187,9 @@ func transactionAssetID(stxnad *transactions.SignedTxnWithAD, intra uint, block 
 func (w *Writer) addInnerTransactions(stxnad *transactions.SignedTxnWithAD, block *bookkeeping.Block, intra, rootIntra uint, rootTxid string, rows [][]interface{}) (uint, [][]interface{}, error) {
 	for _, itxn := range stxnad.ApplyData.EvalDelta.InnerTxns {
 		txn := &itxn.Txn
-		typeenum, ok := idb.GetTypeEnum(txn.Type)
-		if !ok {
-			return 0, nil, fmt.Errorf("addInnerTransactions() get type enum")
+		typeenum, err := idb.GetTypeEnum(txn.Type)
+		if err != nil {
+			return 0, nil, fmt.Errorf("addInnerTransactions() err: %w", err)
 		}
 		// block shouldn't be used for inner transactions.
 		assetid, err := transactionAssetID(&itxn, 0, nil)
@@ -241,9 +241,9 @@ func (w *Writer) addTransactions(block *bookkeeping.Block, modifiedTxns []transa
 		}
 
 		txn := &stxnad.Txn
-		typeenum, ok := idb.GetTypeEnum(txn.Type)
-		if !ok {
-			return fmt.Errorf("addTransactions() get type enum")
+		typeenum, err := idb.GetTypeEnum(txn.Type)
+		if err != nil {
+			return fmt.Errorf("addTransactions() err: %w", err)
 		}
 		assetid, err := transactionAssetID(&stxnad, intra, block)
 		if err != nil {

--- a/idb/txn_type_enum.go
+++ b/idb/txn_type_enum.go
@@ -1,6 +1,7 @@
 package idb
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/algorand/go-algorand/protocol"
@@ -42,7 +43,10 @@ func makeTypeEnumString() string {
 var TxnTypeEnumString = makeTypeEnumString()
 
 // GetTypeEnum returns the enum for the given transaction type string.
-func GetTypeEnum(t protocol.TxType) (TxnTypeEnum, bool /*ok*/) {
+func GetTypeEnum(t protocol.TxType) (TxnTypeEnum, error) {
 	e, ok := typeEnumMap[string(t)]
-	return e, ok
+	if !ok {
+		return 0, fmt.Errorf("GetTypeEnum() unknown type t: %s (0x%x)", t, t)
+	}
+	return e, nil
 }


### PR DESCRIPTION
## Summary

Right now if transaction type is not recognized, the import error is not very meaningful.
`AddBlock() err: TxWithRetry() err: attemptTx() err: AddBlock() err: AddBlock() err: addTransactions() get type enum`

This PR adds a return error value in `GetTypeEnum()` that includes the unrecognized type string.