### PR TITLE
Add `IndexerDb.Close()`

### DIFF
--- a/api/handlers_e2e_test.go
+++ b/api/handlers_e2e_test.go
@@ -28,6 +28,7 @@ func setupIdb(t *testing.T, genesis bookkeeping.Genesis, genesisBlock bookkeepin
 
 	db, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	require.NoError(t, err)
+	defer db.Close()
 
 	err = db.LoadGenesis(genesis)
 	require.NoError(t, err)

--- a/api/handlers_e2e_test.go
+++ b/api/handlers_e2e_test.go
@@ -28,7 +28,11 @@ func setupIdb(t *testing.T, genesis bookkeeping.Genesis, genesisBlock bookkeepin
 
 	db, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	require.NoError(t, err)
-	defer db.Close()
+
+	newShutdownFunc := func() {
+		db.Close()
+		shutdownFunc()
+	}
 
 	err = db.LoadGenesis(genesis)
 	require.NoError(t, err)
@@ -36,7 +40,7 @@ func setupIdb(t *testing.T, genesis bookkeeping.Genesis, genesisBlock bookkeepin
 	err = db.AddBlock(&genesisBlock)
 	require.NoError(t, err)
 
-	return db, shutdownFunc
+	return db, newShutdownFunc
 }
 
 func TestApplicationHander(t *testing.T) {

--- a/cmd/algorand-indexer/import.go
+++ b/cmd/algorand-indexer/import.go
@@ -24,6 +24,7 @@ var importCmd = &cobra.Command{
 		}
 
 		db, availableCh := indexerDbFromFlags(idb.IndexerDbOptions{})
+		defer db.Close()
 		<-availableCh
 
 		helper := importer.NewImportHelper(

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -209,12 +209,12 @@ func (bot *fetcherImpl) Run(ctx context.Context) error {
 	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 
-	ch0 := make(chan error)
+	ch0 := make(chan error, 1)
 	go func() {
 		ch0 <- bot.processQueue(ctx)
 	}()
 
-	ch1 := make(chan error)
+	ch1 := make(chan error, 1)
 	go func() {
 		ch1 <- bot.mainLoop(ctx)
 	}()

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -21,19 +21,13 @@ type Fetcher interface {
 	Algod() *algod.Client
 
 	// go bot.Run()
-	Run()
+	Run(ctx context.Context) error
 
-	AddBlockHandler(handler BlockHandler)
-	SetContext(ctx context.Context)
+	SetBlockHandler(f func(context.Context, *rpcs.EncodedBlockCert) error)
 	SetNextRound(nextRound uint64)
 
 	// Error returns any error fetcher is currently experiencing.
 	Error() string
-}
-
-// BlockHandler is the handler fetcher uses to process a block.
-type BlockHandler interface {
-	HandleBlock(block *rpcs.EncodedBlockCert)
 }
 
 type fetcherImpl struct {
@@ -41,12 +35,9 @@ type fetcherImpl struct {
 	aclient      *algod.Client
 	algodLastmod time.Time // newest mod time of algod.net algod.token
 
-	blockHandlers []BlockHandler
+	handler func(context.Context, *rpcs.EncodedBlockCert) error
 
 	nextRound uint64
-
-	ctx  context.Context
-	done bool
 
 	failingSince time.Time
 
@@ -76,35 +67,26 @@ func (bot *fetcherImpl) Algod() *algod.Client {
 	return bot.aclient
 }
 
-func (bot *fetcherImpl) isDone() bool {
-	if bot.done {
-		return true
-	}
-	if bot.ctx == nil {
-		return false
-	}
-	select {
-	case <-bot.ctx.Done():
-		bot.done = true
-		return true
-	default:
-		return false
-	}
-}
-
 func (bot *fetcherImpl) setError(err error) {
 	bot.errmu.Lock()
 	bot.err = err
 	bot.errmu.Unlock()
 }
 
-func (bot *fetcherImpl) processQueue() {
+func (bot *fetcherImpl) processQueue(ctx context.Context) error {
 	for {
-		block, ok := <-bot.blockQueue
-		if !ok {
-			return
+		select {
+		case block, ok := <-bot.blockQueue:
+			if !ok {
+				return nil
+			}
+			err := bot.handler(ctx, block)
+			if err != nil {
+				return fmt.Errorf("processQueue() handler err: %w", err)
+			}
+		case <-ctx.Done():
+			return fmt.Errorf("processQueue: ctx.Err(): %w", ctx.Err())
 		}
-		bot.handleBlock(block)
 	}
 }
 
@@ -112,7 +94,7 @@ func (bot *fetcherImpl) enqueueBlock(blockbytes []byte) error {
 	block := new(rpcs.EncodedBlockCert)
 	err := protocol.Decode(blockbytes, block)
 	if err != nil {
-		return nil
+		return fmt.Errorf("enqueueBlock() decode err: %w", err)
 	}
 
 	bot.blockQueue <- block
@@ -120,27 +102,25 @@ func (bot *fetcherImpl) enqueueBlock(blockbytes []byte) error {
 }
 
 // fetch the next block by round number until we find one missing (because it doesn't exist yet)
-func (bot *fetcherImpl) catchupLoop() {
+func (bot *fetcherImpl) catchupLoop(ctx context.Context) error {
 	var err error
 	var blockbytes []byte
 	aclient := bot.Algod()
 	for {
-		if bot.isDone() {
-			return
-		}
-
-		blockbytes, err = aclient.BlockRaw(bot.nextRound).Do(context.Background())
+		blockbytes, err = aclient.BlockRaw(bot.nextRound).Do(ctx)
 		if err != nil {
+			// If context has expired.
+			if ctx.Err() != nil {
+				return fmt.Errorf("catchupLoop() fetch err: %w", err)
+			}
 			bot.setError(err)
 			bot.log.WithError(err).Errorf("catchup block %d", bot.nextRound)
-			return
+			return nil
 		}
 
 		err = bot.enqueueBlock(blockbytes)
 		if err != nil {
-			bot.setError(err)
-			bot.log.WithError(err).Errorf("error enqueuing catchup block %d", bot.nextRound)
-			return
+			return fmt.Errorf("catchupLoop() err: %w", err)
 		}
 		// If we successfully handle the block, clear out any transient error which may have occurred.
 		bot.setError(nil)
@@ -150,35 +130,37 @@ func (bot *fetcherImpl) catchupLoop() {
 }
 
 // wait for algod to notify of a new round, then fetch that block
-func (bot *fetcherImpl) followLoop() {
+func (bot *fetcherImpl) followLoop(ctx context.Context) error {
 	var err error
 	var blockbytes []byte
 	aclient := bot.Algod()
 	for {
 		for retries := 0; retries < 3; retries++ {
-			if bot.isDone() {
-				return
-			}
-			_, err = aclient.StatusAfterBlock(bot.nextRound).Do(context.Background())
+			_, err = aclient.StatusAfterBlock(bot.nextRound).Do(ctx)
 			if err != nil {
-				bot.log.WithError(err).Errorf("r=%d error getting status %d", retries, bot.nextRound)
+				// If context has expired.
+				if ctx.Err() != nil {
+					return fmt.Errorf("followLoop() status err: %w", err)
+				}
+				bot.log.WithError(err).Errorf(
+					"r=%d error getting status %d", retries, bot.nextRound)
 				continue
 			}
-			blockbytes, err = aclient.BlockRaw(bot.nextRound).Do(context.Background())
+			blockbytes, err = aclient.BlockRaw(bot.nextRound).Do(ctx)
 			if err == nil {
 				break
+			} else if ctx.Err() != nil { // if context has expired
+				return fmt.Errorf("followLoop() fetch block err: %w", err)
 			}
 			bot.log.WithError(err).Errorf("r=%d err getting block %d", retries, bot.nextRound)
 		}
 		if err != nil {
 			bot.setError(err)
-			return
+			return nil
 		}
 		err = bot.enqueueBlock(blockbytes)
 		if err != nil {
-			bot.setError(err)
-			bot.log.WithError(err).Errorf("error enqueuing follow block %d", bot.nextRound)
-			break
+			return fmt.Errorf("followLoop() err: %w", err)
 		}
 		// Clear out any transient error which may have occurred.
 		bot.setError(nil)
@@ -187,21 +169,15 @@ func (bot *fetcherImpl) followLoop() {
 	}
 }
 
-// Run is part of the Fetcher interface
-func (bot *fetcherImpl) Run() {
-	// In theory a buffer of size one should be enough, but let's make it bigger.
-	bot.blockQueue = make(chan *rpcs.EncodedBlockCert, 5)
-	defer close(bot.blockQueue)
-	go bot.processQueue()
-
+func (bot *fetcherImpl) mainLoop(ctx context.Context) error {
 	for {
-		if bot.isDone() {
-			return
+		err := bot.catchupLoop(ctx)
+		if err != nil {
+			return fmt.Errorf("mainLoop() err: %w", err)
 		}
-		bot.catchupLoop()
-		bot.followLoop()
-		if bot.isDone() {
-			return
+		err = bot.followLoop(ctx)
+		if err != nil {
+			return fmt.Errorf("mainLoop() err: %w", err)
 		}
 
 		if bot.failingSince.IsZero() {
@@ -212,7 +188,7 @@ func (bot *fetcherImpl) Run() {
 			bot.log.Warnf("failing to fetch from algod for %s, (since %s, now %s)", dt.String(), bot.failingSince.String(), now.String())
 		}
 		time.Sleep(5 * time.Second)
-		err := bot.reclient()
+		err = bot.reclient()
 		if err != nil {
 			bot.setError(err)
 			bot.log.WithError(err).Errorln("err trying to re-client")
@@ -222,9 +198,34 @@ func (bot *fetcherImpl) Run() {
 	}
 }
 
-// SetContext is part of the Fetcher interface
-func (bot *fetcherImpl) SetContext(ctx context.Context) {
-	bot.ctx = ctx
+// Run is part of the Fetcher interface
+func (bot *fetcherImpl) Run(ctx context.Context) error {
+	// In theory a buffer of size one should be enough, but let's make it bigger.
+	bot.blockQueue = make(chan *rpcs.EncodedBlockCert, 5)
+
+	ctx, cancelFunc := context.WithCancel(ctx)
+	defer cancelFunc()
+
+	ch0 := make(chan error)
+	go func() {
+		ch0 <- bot.processQueue(ctx)
+	}()
+
+	ch1 := make(chan error)
+	go func() {
+		ch1 <- bot.mainLoop(ctx)
+	}()
+
+	select {
+	case err := <-ch0:
+		cancelFunc()
+		<-ch1
+		return fmt.Errorf("Run() err: %w", err)
+	case err := <-ch1:
+		cancelFunc()
+		<-ch0
+		return fmt.Errorf("Run() err: %w", err)
+	}
 }
 
 // SetNextRound is part of the Fetcher interface
@@ -232,26 +233,9 @@ func (bot *fetcherImpl) SetNextRound(nextRound uint64) {
 	bot.nextRound = nextRound
 }
 
-func (bot *fetcherImpl) handleBlock(block *rpcs.EncodedBlockCert) {
-	for _, handler := range bot.blockHandlers {
-		handler.HandleBlock(block)
-	}
-}
-
 // AddBlockHandler is part of the Fetcher interface
-func (bot *fetcherImpl) AddBlockHandler(handler BlockHandler) {
-	if bot.blockHandlers == nil {
-		x := make([]BlockHandler, 1, 10)
-		x[0] = handler
-		bot.blockHandlers = x
-		return
-	}
-	for _, oh := range bot.blockHandlers {
-		if oh == handler {
-			return
-		}
-	}
-	bot.blockHandlers = append(bot.blockHandlers, handler)
+func (bot *fetcherImpl) SetBlockHandler(handler func(context.Context, *rpcs.EncodedBlockCert) error) {
+	bot.handler = handler
 }
 
 // ForDataDir initializes Fetcher to read data from the data directory.

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -223,7 +223,6 @@ func (bot *fetcherImpl) Run(ctx context.Context) error {
 	select {
 	case err := <-ch0:
 		cancelFunc()
-		<-ch1
 		return fmt.Errorf("Run() err: %w", err)
 	case err := <-ch1:
 		cancelFunc()

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -204,8 +204,7 @@ func (bot *fetcherImpl) mainLoop(ctx context.Context) error {
 
 // Run is part of the Fetcher interface
 func (bot *fetcherImpl) Run(ctx context.Context) error {
-	// In theory a buffer of size one should be enough, but let's make it bigger.
-	bot.blockQueue = make(chan *rpcs.EncodedBlockCert, 5)
+	bot.blockQueue = make(chan *rpcs.EncodedBlockCert)
 
 	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()

--- a/idb/dummy/dummy.go
+++ b/idb/dummy/dummy.go
@@ -20,6 +20,9 @@ func IndexerDb() idb.IndexerDb {
 	return &dummyIndexerDb{}
 }
 
+func (db *dummyIndexerDb) Close() {
+}
+
 func (db *dummyIndexerDb) AddBlock(block *bookkeeping.Block) error {
 	db.log.Printf("AddBlock")
 	return nil

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -155,6 +155,10 @@ var ErrorBlockNotFound = errors.New("block not found")
 // TODO: sqlite3 impl
 // TODO: cockroachdb impl
 type IndexerDb interface {
+	// Close all connections to the database. Should be called when IndexerDb is
+	// no longer needed.
+	Close()
+
 	// Import a block and do the accounting.
 	AddBlock(block *bookkeeping.Block) error
 

--- a/idb/mocks/IndexerDb.go
+++ b/idb/mocks/IndexerDb.go
@@ -104,6 +104,11 @@ func (_m *IndexerDb) Assets(ctx context.Context, filter idb.AssetsQuery) (<-chan
 	return r0, r1
 }
 
+// Close provides a mock function with given fields:
+func (_m *IndexerDb) Close() {
+	_m.Called()
+}
+
 // GetAccounts provides a mock function with given fields: ctx, opts
 func (_m *IndexerDb) GetAccounts(ctx context.Context, opts idb.AccountQueryOptions) (<-chan idb.AccountRow, uint64) {
 	ret := _m.Called(ctx, opts)

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -107,6 +107,11 @@ type IndexerDb struct {
 	accountingLock sync.Mutex
 }
 
+// Close is part of idb.IndexerDb.
+func (db *IndexerDb) Close() {
+	db.db.Close()
+}
+
 // txWithRetry is a helper function that retries the function `f` in case the database
 // transaction in it fails due to a serialization error. `f` is provided
 // a transaction created using `opts`. If `f` experiences a database error, this error

--- a/idb/postgres/postgres_integration_common_test.go
+++ b/idb/postgres/postgres_integration_common_test.go
@@ -27,7 +27,14 @@ func setupIdbWithConnectionString(t *testing.T, connStr string, genesis bookkeep
 
 func setupIdb(t *testing.T, genesis bookkeeping.Genesis, genesisBlock bookkeeping.Block) (*IndexerDb /*db*/, func() /*shutdownFunc*/) {
 	_, connStr, shutdownFunc := pgtest.SetupPostgres(t)
-	return setupIdbWithConnectionString(t, connStr, genesis, genesisBlock), shutdownFunc
+
+	db := setupIdbWithConnectionString(t, connStr, genesis, genesisBlock)
+	newShutdownFunc := func() {
+		db.Close()
+		shutdownFunc()
+	}
+
+	return db, newShutdownFunc
 }
 
 // Helper to execute a query returning an integer, for example COUNT(*). Returns -1 on an error.


### PR DESCRIPTION
## Summary

When running test with the `--test-pg` flag, we open many database connections without closing them. This leads to the database refusing new connections.

This PR adds `IndexerDb.Close()` function that closes all active connections to the database.