### PR TITLE
Write transactions earlier if possible

### DIFF
--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -308,7 +308,8 @@ func (db *IndexerDb) AddBlock(block *bookkeeping.Block) error {
 			defer wg.Wait()
 
 			// Write transaction participation and possibly transactions in a parallel db
-			// transaction.
+			// transaction. If `proto.EnableAssetCloseAmount` is already true, we can start
+			// writing transactions contained in the block early.
 			var err0 error
 			wg.Add(1)
 			go func() {

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -348,6 +348,7 @@ func (db *IndexerDb) AddBlock(block *bookkeeping.Block) error {
 			metrics.PostgresEvalTimeSeconds.Observe(time.Since(start).Seconds())
 
 			var err1 error
+			// Skip if transaction writing has already started.
 			if protoChanged {
 				// Write transactions in a parallel db transaction.
 				wg.Add(1)


### PR DESCRIPTION
## Summary

If `proto.EnableAssetCloseAmount` is already true, we can start writing transactions before running the evaluator.

9200 -> 9460 TPS

## Test Plan

`TestAddBlockAssetCloseAmountInTxnExtra` already tests that we write transactions when `proto.EnableAssetCloseAmount` is false. There are multiple test checking that transactions are written when `proto.EnableAssetCloseAmount` is true.