### PR TITLE
Add CLI option for providing configfile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ The command line arguments always take priority over the config file and environ
 ## Configuration file
 Default values are placed in the configuration file. They can be overridden with environment variables and command line arguments.
 
-The configuration file must named **indexer**, **indexer.yml**, or **indexer.yaml**. It must also be in the correct location. Only one configuration file is loaded, the path is searched in the following order:
+The configuration file must named **indexer**, **indexer.yml**, or **indexer.yaml**. The filepath may be set on the CLI using `--configfile` or `-c`. 
+When the filepath is not provided on the CLI, it must also be in the correct location. Only one configuration file is loaded, the path is searched in the following order:
 * `./` (current working directory)
 * `$HOME`
 * `$HOME/.algorand-indexer`
@@ -170,6 +171,11 @@ algod-data-dir: "/var/lib/algorand"
 If it is in the current working directory along with the indexer command we can start the indexer daemon with:
 ```
 ~$ ./algorand-indexer daemon
+```
+
+If it is not in the current working directory along with the indexer command we can start the indexer daemon with:
+```
+~$ ./algorand-indexer daemon -c <full-file-location>/indexer.yml
 ```
 
 ## Example environment variable

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -61,14 +61,12 @@ var rootCmd = &cobra.Command{
 		if configFile != "" {
 			configs, err := os.Open(configFile)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "%v", err)
-				os.Exit(1)
+				maybeFail(err, "%v", err)
 			}
 			defer configs.Close()
 			err = viper.ReadConfig(configs)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "invalid config file (%s): %v", viper.ConfigFileUsed(), err)
-				os.Exit(1)
+				maybeFail(err, "invalid config file (%s): %v", viper.ConfigFileUsed(), err)
 			}
 			fmt.Printf("Using configuration file: %s\n", configFile)
 		}

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -58,15 +58,15 @@ var rootCmd = &cobra.Command{
 			err = pprof.StartCPUProfile(profFile)
 			maybeFail(err, "%s: start pprof, %v", cpuProfile, err)
 		}
-		if configFile!=""{
-			configs,err:=os.Open(configFile)
+		if configFile != "" {
+			configs, err := os.Open(configFile)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v", err)
 				os.Exit(1)
 			}
 			defer configs.Close()
-			err=viper.ReadConfig(configs)
-			if err!=nil{
+			err = viper.ReadConfig(configs)
+			if err != nil {
 				fmt.Fprintf(os.Stderr, "invalid config file (%s): %v", viper.ConfigFileUsed(), err)
 				os.Exit(1)
 			}
@@ -97,7 +97,7 @@ var (
 	logLevel       string
 	logFile        string
 	logger         *log.Logger
-	configFile		string
+	configFile     string
 )
 
 func indexerDbFromFlags(opts idb.IndexerDbOptions) (idb.IndexerDb, chan struct{}) {

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -58,6 +58,20 @@ var rootCmd = &cobra.Command{
 			err = pprof.StartCPUProfile(profFile)
 			maybeFail(err, "%s: start pprof, %v", cpuProfile, err)
 		}
+		if configFile!=""{
+			configs,err:=os.Open(configFile)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%v", err)
+				os.Exit(1)
+			}
+			defer configs.Close()
+			err=viper.ReadConfig(configs)
+			if err!=nil{
+				fmt.Fprintf(os.Stderr, "invalid config file (%s): %v", viper.ConfigFileUsed(), err)
+				os.Exit(1)
+			}
+			fmt.Printf("Using configuration file: %s\n", configFile)
+		}
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		if cpuProfile != "" {
@@ -83,6 +97,7 @@ var (
 	logLevel       string
 	logFile        string
 	logger         *log.Logger
+	configFile		string
 )
 
 func indexerDbFromFlags(opts idb.IndexerDbOptions) (idb.IndexerDb, chan struct{}) {
@@ -117,6 +132,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&dummyIndexerDb, "dummydb", "n", false, "use dummy indexer db")
 	rootCmd.PersistentFlags().StringVarP(&cpuProfile, "cpuprofile", "", "", "file to record cpu profile to")
 	rootCmd.PersistentFlags().StringVarP(&pidFilePath, "pidfile", "", "", "file to write daemon's process id to")
+	rootCmd.PersistentFlags().StringVarP(&configFile, "configfile", "c", "", "file path to configuration file (indexer.yml)")
 	rootCmd.PersistentFlags().BoolVarP(&doVersion, "version", "v", false, "print version and exit")
 
 	viper.RegisterAlias("postgres", "postgres-connection-string")


### PR DESCRIPTION
## Summary

Add a new CLI flag, `--configfile`, to take a file path to the configs file. Values set on the CLI would overwrite the values set in this file. 
