### PR TITLE
Fix network validation during database upgrade case.

### DIFF
--- a/idb/dummy/dummy.go
+++ b/idb/dummy/dummy.go
@@ -87,3 +87,8 @@ func (db *dummyIndexerDb) Health(ctx context.Context) (state idb.Health, err err
 func (db *dummyIndexerDb) GetNetworkState() (state idb.NetworkState, err error) {
 	return idb.NetworkState{}, nil
 }
+
+// SetNetworkState is part of idb.IndexerDB
+func (db *dummyIndexerDb) SetNetworkState(genesis bookkeeping.Genesis) error {
+	return nil
+}

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -169,6 +169,7 @@ type IndexerDb interface {
 	GetNextRoundToAccount() (uint64, error)
 	GetSpecialAccounts(ctx context.Context) (transactions.SpecialAddresses, error)
 	GetNetworkState() (NetworkState, error)
+	SetNetworkState(genesis bookkeeping.Genesis) error
 
 	GetBlock(ctx context.Context, round uint64, options GetBlockOptions) (blockHeader bookkeeping.BlockHeader, transactions []TxnRow, err error)
 

--- a/idb/mocks/IndexerDb.go
+++ b/idb/mocks/IndexerDb.go
@@ -260,6 +260,20 @@ func (_m *IndexerDb) LoadGenesis(genesis bookkeeping.Genesis) error {
 	return r0
 }
 
+// SetNetworkState provides a mock function with given fields: genesis
+func (_m *IndexerDb) SetNetworkState(genesis bookkeeping.Genesis) error {
+	ret := _m.Called(genesis)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bookkeeping.Genesis) error); ok {
+		r0 = rf(genesis)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Transactions provides a mock function with given fields: ctx, tf
 func (_m *IndexerDb) Transactions(ctx context.Context, tf idb.TransactionFilter) (<-chan idb.TxnRow, uint64) {
 	ret := _m.Called(ctx, tf)

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -2305,10 +2305,18 @@ func (db *IndexerDb) GetAccountData(addresses []basics.Address) (map[basics.Addr
 func (db *IndexerDb) GetNetworkState() (idb.NetworkState, error) {
 	state, err := db.getNetworkState(context.Background(), nil)
 	if err != nil {
-		return idb.NetworkState{}, fmt.Errorf("GetNetworkState() err: %w", err)
+		return idb.NetworkState{}, err
 	}
 	networkState := idb.NetworkState{
 		GenesisHash: state.GenesisHash,
 	}
 	return networkState, nil
+}
+
+// SetNetworkState is part of idb.IndexerDB
+func (db *IndexerDb) SetNetworkState(genesis bookkeeping.Genesis) error {
+	networkState := types.NetworkState{
+		GenesisHash: crypto.HashObj(genesis),
+	}
+	return db.setNetworkState(nil, &networkState)
 }

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -2305,7 +2305,7 @@ func (db *IndexerDb) GetAccountData(addresses []basics.Address) (map[basics.Addr
 func (db *IndexerDb) GetNetworkState() (idb.NetworkState, error) {
 	state, err := db.getNetworkState(context.Background(), nil)
 	if err != nil {
-		return idb.NetworkState{}, err
+		return idb.NetworkState{}, fmt.Errorf("GetNetworkState() err: %w", err)
 	}
 	networkState := idb.NetworkState{
 		GenesisHash: state.GenesisHash,

--- a/importer/helper.go
+++ b/importer/helper.go
@@ -267,10 +267,6 @@ func GetGenesisFile(genesisJSONPath string, client *algod.Client, l *log.Logger)
 }
 
 func checkGenesisHash(db idb.IndexerDb, genesisReader io.Reader) error {
-	network, err := db.GetNetworkState()
-	if err != nil {
-		return fmt.Errorf("unable to fetch network state from db %w", err)
-	}
 	var genesis bookkeeping.Genesis
 	gbytes, err := ioutil.ReadAll(genesisReader)
 	if err != nil {
@@ -279,6 +275,16 @@ func checkGenesisHash(db idb.IndexerDb, genesisReader io.Reader) error {
 	err = protocol.DecodeJSON(gbytes, &genesis)
 	if err != nil {
 		return fmt.Errorf("error decoding genesis, %w", err)
+	}
+	network, err := db.GetNetworkState()
+	if err == idb.ErrorNotInitialized {
+		err = db.SetNetworkState(genesis)
+		if err != nil {
+			return fmt.Errorf("error setting network state %w", err)
+		}
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("unable to fetch network state from db %w", err)
 	}
 	if network.GenesisHash != crypto.HashObj(genesis) {
 		return fmt.Errorf("genesis hash not matching")

--- a/importer/helper.go
+++ b/importer/helper.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"compress/bzip2"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -277,7 +278,7 @@ func checkGenesisHash(db idb.IndexerDb, genesisReader io.Reader) error {
 		return fmt.Errorf("error decoding genesis, %w", err)
 	}
 	network, err := db.GetNetworkState()
-	if err == idb.ErrorNotInitialized {
+	if errors.Is(err, idb.ErrorNotInitialized) {
 		err = db.SetNetworkState(genesis)
 		if err != nil {
 			return fmt.Errorf("error setting network state %w", err)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary
This PR fixes the following issue received during 2.8.3 indexer upgrade,
`{"error":"unable to fetch network state from db GetNetworkState() err: accounting not initialized","level":"error","msg":"importer.EnsureInitialImport() error","time":"2022-01-31T01:35:47Z"}`
NetworkMetaStateKey is a new addition to metastate table. So, it needs to be set when it returns GetNetworkState() returns ErrorNotInitialized.


## Test Plan
Integration test is updated to validate that when network metadata is correctly initialized before GetNetworkState() calls. 
