### PR TITLE
block-generator: Improve payment algorithm to allow sending many more transactions.

### DIFF
--- a/cmd/block-generator/generator/generate.go
+++ b/cmd/block-generator/generator/generate.go
@@ -467,12 +467,14 @@ func (g *generator) generatePaymentTxnInternal(selection TxTypeID, round uint64,
 	case paymentTx:
 		receiveIndex = rand.Uint64() % g.numAccounts
 	case paymentAcctCreateTx:
+		// give new accounts extra algos for sending other transactions (optin/optout)
+		amount = minbal * 100
 		g.balances = append(g.balances, 0)
+		receiveIndex = g.numAccounts
 		// increment at the end in case it needs to be referenced later.
 		defer func() {
 			g.numAccounts++
 		}()
-		receiveIndex = g.numAccounts - 1
 	}
 
 	// Select a sender from genesis account

--- a/cmd/block-generator/generator/generate.go
+++ b/cmd/block-generator/generator/generate.go
@@ -451,13 +451,13 @@ func (g *generator) generatePaymentTxn(round uint64, intra uint64) (transactions
 	return g.generatePaymentTxnInternal(selection.(TxTypeID), round, intra)
 }
 
-const minbal = uint64(100000)
+const minBal = uint64(100000)
 
 func (g *generator) generatePaymentTxnInternal(selection TxTypeID, round uint64, intra uint64) (transactions.SignedTxn, transactions.ApplyData, error) {
 	defer g.recordData(track(selection))
 
 	// amounts
-	amount := minbal
+	amount := minBal
 	fee := uint64(1000)
 	total := amount + fee
 
@@ -468,7 +468,7 @@ func (g *generator) generatePaymentTxnInternal(selection TxTypeID, round uint64,
 		receiveIndex = rand.Uint64() % g.numAccounts
 	case paymentAcctCreateTx:
 		// give new accounts extra algos for sending other transactions (optin/optout)
-		amount = minbal * 100
+		amount = minBal * 100
 		g.balances = append(g.balances, 0)
 		receiveIndex = g.numAccounts
 		// increment at the end in case it needs to be referenced later.
@@ -480,7 +480,7 @@ func (g *generator) generatePaymentTxnInternal(selection TxTypeID, round uint64,
 	// Select a sender from genesis account
 	sendIndex := (g.numPayments + g.paymentOffset) % g.config.NumGenesisAccounts
 	// if the genesis account has insufficient balance... start checking others
-	for n := uint64(1); g.balances[sendIndex] < (total + minbal); n++ {
+	for n := uint64(1); g.balances[sendIndex] < (total + minBal); n++ {
 		g.paymentOffset++
 		sendIndex = (g.numPayments + g.paymentOffset) % g.numAccounts
 		fmt.Printf(" (%d) the sender account does not have enough algos for the transfer. idx %d, payment number %d\n", n, sendIndex, g.numPayments)

--- a/cmd/block-generator/generator/generate.go
+++ b/cmd/block-generator/generator/generate.go
@@ -459,7 +459,6 @@ func (g *generator) generatePaymentTxnInternal(selection TxTypeID, round uint64,
 	// amounts
 	amount := uint64(1)
 	fee := uint64(1000)
-	total := amount + fee
 
 	// Select a receiver
 	var receiveIndex uint64
@@ -476,6 +475,7 @@ func (g *generator) generatePaymentTxnInternal(selection TxTypeID, round uint64,
 			g.numAccounts++
 		}()
 	}
+	total := amount + fee
 
 	// Select a sender from genesis account
 	sendIndex := (g.numPayments + g.paymentOffset) % g.config.NumGenesisAccounts

--- a/cmd/block-generator/generator/generate.go
+++ b/cmd/block-generator/generator/generate.go
@@ -485,7 +485,7 @@ func (g *generator) generatePaymentTxnInternal(selection TxTypeID, round uint64,
 	sendIndex := g.numPayments % g.config.NumGenesisAccounts
 	// if the genesis account has insufficient balance... start checking others
 	for g.balances[sendIndex] < (total + minBal) {
-		fmt.Errorf("generatePaymentTxnInternal(): the sender account does not have enough algos for the transfer. idx %d, payment number %d\n", sendIndex, g.numPayments)
+		fmt.Printf("\n\ngeneratePaymentTxnInternal(): the sender account does not have enough algos for the transfer. idx %d, payment number %d\n\n", sendIndex, g.numPayments)
 		os.Exit(1)
 	}
 

--- a/cmd/block-generator/generator/generate.go
+++ b/cmd/block-generator/generator/generate.go
@@ -457,7 +457,7 @@ func (g *generator) generatePaymentTxnInternal(selection TxTypeID, round uint64,
 	defer g.recordData(track(selection))
 
 	// amounts
-	amount := minBal
+	amount := uint64(1)
 	fee := uint64(1000)
 	total := amount + fee
 

--- a/cmd/block-generator/generator/make_transactions.go
+++ b/cmd/block-generator/generator/make_transactions.go
@@ -14,7 +14,7 @@ func (g *generator) makeTxnHeader(sender basics.Address, round, intra uint64) tr
 
 	return transactions.Header{
 		Sender:      sender,
-		Fee:         basics.MicroAlgos{Raw: fee},
+		Fee:         basics.MicroAlgos{Raw: g.params.MinTxnFee},
 		FirstValid:  basics.Round(round),
 		LastValid:   basics.Round(round + 1000),
 		GenesisID:   g.genesisID,

--- a/cmd/block-generator/run_runner.sh
+++ b/cmd/block-generator/run_runner.sh
@@ -51,5 +51,4 @@ $(dirname "$0")/block-generator runner \
 	--test-duration 30s \
 	--log-level trace \
 	--postgres-connection-string "host=localhost user=algorand password=algorand dbname=generator_db port=15432 sslmode=disable" \
-	--scenario test_config.yml \
-	#--scenario ${CONFIG} \
+	--scenario ${CONFIG}


### PR DESCRIPTION
## Summary

Update the block-generator payment algorithm to cycle through accounts if the genesis account runs out of algos.

## Test Plan

Accounts were running out of algos during a 1hr run of the jumbo payment scenario, now it isn't.