### PR TITLE
Add default and max limits for applications endpoint.

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -60,6 +60,10 @@ const defaultAssetsLimit = 100
 const maxBalancesLimit = 10000
 const defaultBalancesLimit = 1000
 
+// Applications
+const maxApplicationsLimit = 1000
+const defaultApplicationsLimit = 100
+
 //////////////////////
 // Helper functions //
 //////////////////////
@@ -297,6 +301,7 @@ func (si *ServerImplementation) LookupApplicationByID(ctx echo.Context, applicat
 	p := generated.SearchForApplicationsParams{
 		ApplicationId: &applicationID,
 		IncludeAll:    params.IncludeAll,
+		Limit:         uint64Ptr(1),
 	}
 
 	apps, round, err := si.fetchApplications(ctx.Request().Context(), p)
@@ -615,6 +620,7 @@ func notFound(ctx echo.Context, err string) error {
 
 // fetchApplications fetches all results
 func (si *ServerImplementation) fetchApplications(ctx context.Context, params generated.SearchForApplicationsParams) ([]generated.Application, uint64, error) {
+	params.Limit = uint64Ptr(min(uintOrDefaultValue(params.Limit, defaultApplicationsLimit), maxApplicationsLimit))
 	var apps []generated.Application
 	var round uint64
 	err := callWithTimeout(ctx, si.log, si.timeout, func(ctx context.Context) error {

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -914,6 +915,59 @@ func TestTimeouts(t *testing.T) {
 			require.Equal(t, http.StatusServiceUnavailable, rec1.Code)
 			require.Contains(t, bodyStr, tc.errString)
 			require.Contains(t, bodyStr, "timeout")
+		})
+	}
+}
+
+func TestApplicationLimits(t *testing.T) {
+	testcases := []struct {
+		name string
+		limit *uint64
+		expected uint64
+	} {
+		{
+			name: "Default",
+			limit: nil,
+			expected: defaultApplicationsLimit,
+		},
+		{
+			name: "Max",
+			limit: uint64Ptr(math.MaxUint64),
+			expected: maxApplicationsLimit,
+		},
+	}
+
+	// Mock backend to capture default limits
+	mockIndexer := &mocks.IndexerDb{}
+	si := ServerImplementation{
+		db:      mockIndexer,
+		timeout: 5 * time.Millisecond,
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup context...
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec1 := httptest.NewRecorder()
+			c := e.NewContext(req, rec1)
+
+			// check parameters passed to the backend
+			mockIndexer.
+				On("Applications", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil, uint64(0)).
+				Run(func(args mock.Arguments) {
+					require.Len(t, args, 2)
+					require.IsType(t, &generated.SearchForApplicationsParams{}, args[1])
+					params := args[1].(*generated.SearchForApplicationsParams)
+					require.NotNil(t, params.Limit)
+					require.Equal(t, *params.Limit, tc.expected)
+				})
+
+			err := si.SearchForApplications(c, generated.SearchForApplicationsParams{
+				Limit: tc.limit,
+			})
+			require.NoError(t, err)
 		})
 	}
 }

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -921,18 +921,18 @@ func TestTimeouts(t *testing.T) {
 
 func TestApplicationLimits(t *testing.T) {
 	testcases := []struct {
-		name string
-		limit *uint64
+		name     string
+		limit    *uint64
 		expected uint64
-	} {
+	}{
 		{
-			name: "Default",
-			limit: nil,
+			name:     "Default",
+			limit:    nil,
 			expected: defaultApplicationsLimit,
 		},
 		{
-			name: "Max",
-			limit: uint64Ptr(math.MaxUint64),
+			name:     "Max",
+			limit:    uint64Ptr(math.MaxUint64),
 			expected: maxApplicationsLimit,
 		},
 	}


### PR DESCRIPTION
## Summary

Add a default/max limit for the application endpoint.

## Test Plan

New unit test, and manually tested by running in read-only mode against an existing mainnet DB.