### PR TITLE
Fix log permissions to not be executable.

### DIFF
--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -178,7 +178,7 @@ func configureLogger() error {
 	if logFile == "-" {
 		logger.SetOutput(os.Stdout)
 	} else if logFile != "" {
-		f, err := os.OpenFile(logFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0755)
+		f, err := os.OpenFile(logFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Small fix for log file permissions which enable the executable bit.

## Test Plan

Build a version of algorand-indexer and verify that it opens as 644, not 755.
