### PR TITLE
use fetch/reset instead of pull for go-algorand in nightly test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ test-generate:
 	test/test_generate.py
 
 nightly-setup:
-	cd third_party/go-algorand && git pull origin master
+	cd third_party/go-algorand && git fetch && git reset --hard origin/master
 
 nightly-teardown:
 	git submodule update


### PR DESCRIPTION
## Tweaking the Nightly Test

GOAL: avoid [this type of failure](https://app.circleci.com/pipelines/github/algorand/indexer/661/workflows/85c26a2b-9bb4-4736-9d33-016c3d93cacf/jobs/1234/parallel-runs/0/steps/0-120) due to circle config flakiness going forward.

See [this slack thread](https://algorand-internal.slack.com/archives/C02ND31K0HG/p1644984211237929) for more context.

## Test Plan

See what happens to the nightly test next morning.