### PR TITLE
Default to including Python go-algorand E2E tests in buildtestdata.sh

### DIFF
--- a/misc/buildtestdata.sh
+++ b/misc/buildtestdata.sh
@@ -33,13 +33,18 @@ if [ -z "${E2EDATA}" ]; then
     E2EDATA="${HOME}/Algorand/e2edata"
 fi
 
+tests="${INDEXER_BTD_TESTS:-"test/scripts/e2e_subs/{*.py,*.sh}"}"
+echo "Configured tests = ${tests}"
+
 # TODO: EXPERIMENTAL
 # run faster rounds? 1000 down from 2000
 export ALGOSMALLLAMBDAMSEC=1000
 
 rm -rf "${E2EDATA}"
 mkdir -p "${E2EDATA}"
-(cd "${GOALGORAND}" && TEMPDIR="${E2EDATA}" python3 test/scripts/e2e_client_runner.py --keep-temps test/scripts/e2e_subs/*.sh)
+(cd "${GOALGORAND}" && \
+  TEMPDIR="${E2EDATA}" \
+  python3 test/scripts/e2e_client_runner.py --keep-temps "$tests")
 
 (cd "${E2EDATA}" && tar -j -c -f net_done.tar.bz2 --exclude node.log --exclude agreement.cdv net)
 
@@ -47,4 +52,4 @@ mkdir -p "${E2EDATA}"
 RSTAMP=$(TZ=UTC python -c 'import time; print("{:08x}".format(0xffffffff - int(time.time() - time.mktime((2020,1,1,0,0,0,-1,-1,-1)))))')
 
 echo "COPY AND PASTE THIS TO UPLOAD:"
-echo aws s3 cp --acl public-read "${E2EDATA}/net_done.tar.bz2" s3://algorand-testdata/indexer/e2e3/${RSTAMP}/net_done.tar.bz2
+echo aws s3 cp --acl public-read "${E2EDATA}/net_done.tar.bz2" s3://algorand-testdata/indexer/e2e3/"${RSTAMP}"/net_done.tar.bz2


### PR DESCRIPTION
## Summary

Default to including Python go-algorand E2E tests in `buildtestdata.sh`.

* Prior to the PR, `buildtestdata.sh` did _not_ include go-algorand E2E tests.  The PR closes the test coverage gap.
* Additionally, exposes an environment variable to simplify user control of included tests.  The exposed configuration improves workflows for local testing on select tests. 

## Test Plan
Example invocation with default `INDEXER_BTD_TESTS`:
```
michael@albode indexer % bash misc/buildtestdata.sh
+ set -e
+ '[' -z '' ']'
+ echo 'Using default GOALGORAND'
Using default GOALGORAND
+ GOALGORAND=/Users/michael/.asdf/installs/golang/1.14.15/packages/src/github.com/algorand/go-algorand
+ '[' -z '' ']'
+ echo 'Using default E2EDATA'
Using default E2EDATA
+ E2EDATA=/Users/michael/Algorand/e2edata
+ tests='test/scripts/e2e_subs/{*.py,*.sh}'
+ echo 'Configured tests = test/scripts/e2e_subs/{*.py,*.sh}'
Configured tests = test/scripts/e2e_subs/{*.py,*.sh}
```

Example invocation with override specified:
```
michael@albode indexer % export INDEXER_BTD_TESTS="test/scripts/e2e_subs/app-inner-calls.py"
michael@albode indexer % bash misc/buildtestdata.sh
+ set -e
+ '[' -z '' ']'
+ echo 'Using default GOALGORAND'
Using default GOALGORAND
+ GOALGORAND=/Users/michael/.asdf/installs/golang/1.14.15/packages/src/github.com/algorand/go-algorand
+ '[' -z '' ']'
+ echo 'Using default E2EDATA'
Using default E2EDATA
+ E2EDATA=/Users/michael/Algorand/e2edata
+ tests=test/scripts/e2e_subs/app-inner-calls.py
+ echo 'Configured tests = test/scripts/e2e_subs/app-inner-calls.py'
Configured tests = test/scripts/e2e_subs/app-inner-calls.py
```
```
