### PR TITLE
Temporarily revert to inline glob search

### DIFF
--- a/misc/buildtestdata.sh
+++ b/misc/buildtestdata.sh
@@ -33,9 +33,6 @@ if [ -z "${E2EDATA}" ]; then
     E2EDATA="${HOME}/Algorand/e2edata"
 fi
 
-tests="${INDEXER_BTD_TESTS:-"test/scripts/e2e_subs/{*.py,*.sh}"}"
-echo "Configured tests = ${tests}"
-
 # TODO: EXPERIMENTAL
 # run faster rounds? 1000 down from 2000
 export ALGOSMALLLAMBDAMSEC=1000
@@ -44,7 +41,7 @@ rm -rf "${E2EDATA}"
 mkdir -p "${E2EDATA}"
 (cd "${GOALGORAND}" && \
   TEMPDIR="${E2EDATA}" \
-  python3 test/scripts/e2e_client_runner.py --keep-temps "$tests")
+  python3 test/scripts/e2e_client_runner.py --keep-temps test/scripts/e2e_subs/{*.py,*.sh})
 
 (cd "${E2EDATA}" && tar -j -c -f net_done.tar.bz2 --exclude node.log --exclude agreement.cdv net)
 


### PR DESCRIPTION
## Summary

https://github.com/algorand/indexer/pull/888 introduces a bug due to bash's ordering of brace and parameter expansion.  The commit supports parameter expansion at the expense of dropping the environment variable.  

I'll restore external configuration in a subsequent PR.

## Test Plan

Running the script shows inclusion of expanded test files:  [script_output.txt](https://github.com/algorand/indexer/files/8099574/script_output.txt)

