### PR TITLE
Ensure query is canceled after account rewind.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,7 @@ commands:
           command: go get -u golang.org/x/lint/golint
 
   run_tests:
+    no_output_timeout: 15m
     steps:
       - run: test -z `go fmt ./...`
       - run: make lint
@@ -110,6 +111,7 @@ commands:
       - run: make e2e
 
   run_tests_nightly:
+    no_output_timeout: 15m
     steps:
       - run: test -z `go fmt ./...`
       - run: make lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,25 +99,27 @@ commands:
           command: go get -u golang.org/x/lint/golint
 
   run_tests:
-    no_output_timeout: 15m
     steps:
       - run: test -z `go fmt ./...`
       - run: make lint
       - run: make check
       - run: make integration
-      - run: make test
+      - run:
+          command: make test
+          no_output_timeout: 15m
       - run: make test-generate
       - run: make fakepackage
       - run: make e2e
 
   run_tests_nightly:
-    no_output_timeout: 15m
     steps:
       - run: test -z `go fmt ./...`
       - run: make lint
       - run: make check
       - run: make integration
-      - run: make test
+      - run:
+          command: make test
+          no_output_timeout: 15m
       - run: make test-generate
       - run: make fakepackage
       - run: make e2e

--- a/accounting/rewind.go
+++ b/accounting/rewind.go
@@ -102,18 +102,15 @@ func AccountAtRound(ctx context.Context, account models.Account, round uint64, d
 	ctx2, cf := context.WithCancel(ctx)
 	defer cf()
 	txns, r := db.Transactions(ctx2, tf)
+	defer func() {
+		cf()
+		for range txns {
+		}
+	}()
 	if r < account.Round {
 		err = ConsistencyError{fmt.Sprintf("queried round r: %d < account.Round: %d", r, account.Round)}
 		return
 	}
-	return processTransactions(account, addr, round, txns)
-}
-
-func processTransactions(account models.Account, addr basics.Address, round uint64, txns <-chan idb.TxnRow) (acct models.Account, err error) {
-	defer func() {
-		for range txns {
-		}
-	}()
 	txcount := 0
 	for txnrow := range txns {
 		if txnrow.Error != nil {

--- a/accounting/rewind.go
+++ b/accounting/rewind.go
@@ -100,8 +100,10 @@ func AccountAtRound(ctx context.Context, account models.Account, round uint64, d
 		MaxRound: account.Round,
 	}
 	ctx2, cf := context.WithCancel(ctx)
+	// In case of a panic before the next defer, call cf() here.
 	defer cf()
 	txns, r := db.Transactions(ctx2, tf)
+	// In case of an error, make sure the context is cancelled, and the channel is cleaned up.
 	defer func() {
 		cf()
 		for range txns {

--- a/accounting/rewind.go
+++ b/accounting/rewind.go
@@ -99,7 +99,13 @@ func AccountAtRound(ctx context.Context, account models.Account, round uint64, d
 		MinRound: round + 1,
 		MaxRound: account.Round,
 	}
+	ctx, cf := context.WithCancel(ctx)
 	txns, r := db.Transactions(ctx, tf)
+	defer func() {
+		cf()
+		for range txns {
+		}
+	}()
 	if r < account.Round {
 		err = ConsistencyError{fmt.Sprintf("queried round r: %d < account.Round: %d", r, account.Round)}
 		return

--- a/accounting/rewind_test.go
+++ b/accounting/rewind_test.go
@@ -67,10 +67,12 @@ func TestStaleTransactions1(t *testing.T) {
 		Round:   8,
 	}
 
-	var outCh <-chan idb.TxnRow
+	ch := make(chan idb.TxnRow)
+	var outCh <-chan idb.TxnRow = ch
+	close(ch)
 
 	db := &mocks.IndexerDb{}
-	db.On("GetSpecialAccounts").Return(transactions.SpecialAddresses{}, nil)
+	db.On("GetSpecialAccounts", mock.Anything).Return(transactions.SpecialAddresses{}, nil)
 	db.On("Transactions", mock.Anything, mock.Anything).Return(outCh, uint64(7)).Once()
 
 	account, err := AccountAtRound(context.Background(), account, 6, db)

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -879,6 +879,12 @@ func (si *ServerImplementation) fetchAccounts(ctx context.Context, options idb.A
 		var accountchan <-chan idb.AccountRow
 		accountchan, round = si.db.GetAccounts(ctx, options)
 
+		// Make sure accountchan is empty at the end of processing.
+		defer func() {
+			for range accountchan {
+			}
+		}()
+
 		if (atRound != nil) && (*atRound > round) {
 			return fmt.Errorf("%s: the requested round %d > the current round %d",
 				errRewindingAccount, *atRound, round)


### PR DESCRIPTION
## Summary

Make sure the transaction query is canceled when exiting the AccountAtRound function.

## Test Plan

Manual testing. Query psql for active queries. Verified a specific problematic query before and after this change.