### PR TITLE
Point e2elive.py to e2e4 S3 object

### DIFF
--- a/misc/e2elive.py
+++ b/misc/e2elive.py
@@ -59,7 +59,7 @@ def main():
         s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))
         tarname = 'net_done.tar.bz2'
         tarpath = os.path.join(tempdir, tarname)
-        firstFromS3Prefix(s3, bucket, 'indexer/e2e3', tarname, outpath=tarpath)
+        firstFromS3Prefix(s3, bucket, 'indexer/e2e4', tarname, outpath=tarpath)
         source_is_tar = True
         sourcenet = tarpath
     tempnet = os.path.join(tempdir, 'net')


### PR DESCRIPTION
## Summary

Point `misc/e2elive.py` to a different S3 object (_e2e4_) for sourcing its input.  

* After #889, new artifacts including Python tests were uploaded to _e2e3_.  For unknown reasons, the `make e2e` fails (https://circleci.com/gh/algorand/indexer/1341) with the new artifacts.
* @winder moved the new, problematic artifacts to _e2e4_.  The move unblocks open PRs while providing time to debug the problem.
* The PR points to the S3 object containing the problematic artifacts.  Once the problem is understood and resolved, the PR can be merged to include Python tests during `make e2e`.

## Test Plan

I visually confirmed the artifacts exist in S3:  https://s3.console.aws.amazon.com/s3/buckets/algorand-testdata?region=us-east-1&prefix=indexer/e2e4/fbfbf92e/&showversions=false.
