### PR TITLE
REST API: count include-all results when checking max resources limit

### DIFF
--- a/api/disabled_parameters.go
+++ b/api/disabled_parameters.go
@@ -98,7 +98,7 @@ func GetDefaultDisabledMapConfigForPostgres() *DisabledMapConfig {
 	get("/v2/accounts", []string{"currency-greater-than", "currency-less-than"})
 	get("/v2/accounts/{account-id}/transactions", []string{"note-prefix", "tx-type", "sig-type", "asset-id", "before-time", "after-time", "rekey-to"})
 	get("/v2/assets", []string{"name", "unit"})
-	get("/v2/assets/{asset-id}/balances", []string{"round", "currency-greater-than", "currency-less-than"})
+	get("/v2/assets/{asset-id}/balances", []string{"currency-greater-than", "currency-less-than"})
 	get("/v2/transactions", []string{"note-prefix", "tx-type", "sig-type", "asset-id", "before-time", "after-time", "currency-greater-than", "currency-less-than", "address-role", "exclude-close-to", "rekey-to", "application-id"})
 	get("/v2/assets/{asset-id}/transactions", []string{"note-prefix", "tx-type", "sig-type", "asset-id", "before-time", "after-time", "currency-greater-than", "currency-less-than", "address-role", "exclude-close-to", "rekey-to"})
 

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -269,6 +269,9 @@ type AccountQueryOptions struct {
 	// IncludeDeleted indicated whether to include deleted Assets, Applications, etc within the account.
 	IncludeDeleted bool
 
+	// CountOnly returns a count of assets and applications, rather than data.
+	CountOnly bool
+
 	Limit uint64
 }
 

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -269,9 +269,6 @@ type AccountQueryOptions struct {
 	// IncludeDeleted indicated whether to include deleted Assets, Applications, etc within the account.
 	IncludeDeleted bool
 
-	// CountOnly returns a count of assets and applications, rather than data.
-	CountOnly bool
-
 	Limit uint64
 }
 


### PR DESCRIPTION
## Summary

Handle include-all when checking max resources limit by adding option to perform count queries to buildAccountQuery rather than fetch full results. Follow-up to #872

## Test Plan

Extended TestAccountMaxResultsLimit to create and destroy assets and apps, check behavior of include-all with limits.