### PR TITLE
Switch tx gauge vec to counter vec

### DIFF
--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -225,7 +225,7 @@ func handleBlock(block *rpcs.EncodedBlockCert, imp importer.Importer) error {
 			txnCountByType[string(txn.Txn.Type)]++
 		}
 		for k, v := range txnCountByType {
-			metrics.ImportedTxnsPerBlock.WithLabelValues(k).Set(float64(v))
+			metrics.ImportedTxnsPerBlock.WithLabelValues(k).Add(float64(v))
 		}
 	}
 

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -49,8 +49,8 @@ var (
 			Help:      "Block upload time in seconds.",
 		})
 
-	ImportedTxnsPerBlock = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
+	ImportedTxnsPerBlock = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
 			Subsystem: "indexer_daemon",
 			Name:      ImportedTxnsPerBlockName,
 			Help:      "Transactions per block.",


### PR DESCRIPTION
## Summary

Switch gauge vec to counter vec so that the block generator can compute tps. This probably causes problems for the grafana dashboard.

## Test Plan

Manual testing at this point.