### PR TITLE
Enable Validation and Acceptance of New Parameter Configuration

### DIFF
--- a/api/disabled_parameters_test.go
+++ b/api/disabled_parameters_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestToDisabledMapConfigFromFile(t *testing.T) {
-	expectedValue := &DisabledMapConfig{Data: map[string]map[string][]string{
+	expectedValue := DisabledMapConfig{Data: map[string]map[string][]string{
 		"/sampleEndpoint": {http.MethodGet: {"p2"}},
 	}}
 
@@ -27,9 +27,8 @@ func TestToDisabledMapConfigFromFile(t *testing.T) {
 	// to be run on the config (they are made up endpoints)
 	loadedConfig, err := MakeDisabledMapConfigFromFile(nil, configFile)
 	require.NoError(t, err)
-
-	require.True(t, reflect.DeepEqual(*expectedValue, *loadedConfig))
-
+	require.NotNil(t, loadedConfig)
+	require.Equal(t, expectedValue, *loadedConfig)
 }
 
 func TestToDisabledMapConfig(t *testing.T) {

--- a/api/disabled_parameters_test.go
+++ b/api/disabled_parameters_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -14,6 +15,22 @@ import (
 
 	"github.com/algorand/indexer/api/generated/v2"
 )
+
+func TestToDisabledMapConfigFromFile(t *testing.T) {
+	expectedValue := &DisabledMapConfig{Data: map[string]map[string][]string{
+		"/sampleEndpoint": {http.MethodGet: {"p2"}},
+	}}
+
+	configFile := filepath.Join("test_resources", "mock_disabled_map_config.yaml")
+
+	// Nil pointer for openapi3.swagger because we don't want any validation
+	// to be run on the config (they are made up endpoints)
+	loadedConfig, err := MakeDisabledMapConfigFromFile(nil, configFile)
+	require.NoError(t, err)
+
+	require.True(t, reflect.DeepEqual(*expectedValue, *loadedConfig))
+
+}
 
 func TestToDisabledMapConfig(t *testing.T) {
 	type testingStruct struct {
@@ -41,6 +58,8 @@ func TestToDisabledMapConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
+			// Nil pointer for openapi3.swagger because we don't want any validation
+			// to be run on the config
 			dmc, err := test.ddm.toDisabledMapConfig(nil)
 
 			if test.expectError {

--- a/api/disabled_parameters_test.go
+++ b/api/disabled_parameters_test.go
@@ -36,7 +36,7 @@ func TestToDisabledMapConfig(t *testing.T) {
 		name        string
 		ddm         *DisplayDisabledMap
 		dmc         *DisabledMapConfig
-		expectError bool
+		expectError string
 	}
 
 	tests := []testingStruct{
@@ -50,7 +50,7 @@ func TestToDisabledMapConfig(t *testing.T) {
 				"/sampleEndpoint": {http.MethodGet: {"p2"}},
 			}},
 
-			false,
+			"",
 		},
 	}
 
@@ -61,8 +61,9 @@ func TestToDisabledMapConfig(t *testing.T) {
 			// to be run on the config
 			dmc, err := test.ddm.toDisabledMapConfig(nil)
 
-			if test.expectError {
+			if test.expectError != "" {
 				require.Error(t, err)
+				require.Contains(t, err.Error(), test.expectError)
 			} else {
 				require.NoError(t, err)
 				require.True(t, reflect.DeepEqual(*dmc, *test.dmc))
@@ -76,7 +77,7 @@ func TestSchemaCheck(t *testing.T) {
 	type testingStruct struct {
 		name        string
 		ddm         *DisplayDisabledMap
-		expectError bool
+		expectError string
 	}
 	tests := []testingStruct{
 		{"test param types - good",
@@ -86,7 +87,7 @@ func TestSchemaCheck(t *testing.T) {
 					"optional": {{"p3": "enabled"}},
 				}},
 			},
-			false,
+			"",
 		},
 
 		{"test param types - bad required",
@@ -96,7 +97,7 @@ func TestSchemaCheck(t *testing.T) {
 					"optional":      {{"p3": "enabled"}},
 				}},
 			},
-			true,
+			"required-FAKE",
 		},
 
 		{"test param types - bad optional",
@@ -106,7 +107,7 @@ func TestSchemaCheck(t *testing.T) {
 					"optional-FAKE": {{"p3": "enabled"}},
 				}},
 			},
-			true,
+			"optional-FAKE",
 		},
 
 		{"test param types - bad both",
@@ -116,7 +117,7 @@ func TestSchemaCheck(t *testing.T) {
 					"optional-FAKE": {{"p3": "enabled"}},
 				}},
 			},
-			true,
+			"required-FAKE optional-FAKE",
 		},
 
 		{"test param status - good",
@@ -126,7 +127,7 @@ func TestSchemaCheck(t *testing.T) {
 					"optional": {{"p3": "enabled"}},
 				}},
 			},
-			false,
+			"",
 		},
 
 		{"test param status - bad required",
@@ -136,7 +137,7 @@ func TestSchemaCheck(t *testing.T) {
 					"optional": {{"p3": "enabled"}},
 				}},
 			},
-			true,
+			"p2",
 		},
 
 		{"test param status - bad optional",
@@ -146,7 +147,7 @@ func TestSchemaCheck(t *testing.T) {
 					"optional": {{"p3": "enabled-FAKE"}},
 				}},
 			},
-			true,
+			"p3",
 		},
 
 		{"test param status - bad both",
@@ -156,7 +157,7 @@ func TestSchemaCheck(t *testing.T) {
 					"optional": {{"p3": "enabled-FAKE"}},
 				}},
 			},
-			true,
+			"p1",
 		},
 	}
 
@@ -164,8 +165,9 @@ func TestSchemaCheck(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.ddm.validateSchema()
 
-			if test.expectError {
+			if test.expectError != "" {
 				require.Error(t, err)
+				require.Contains(t, err.Error(), test.expectError)
 			} else {
 				require.NoError(t, err)
 			}

--- a/api/test_resources/mock_disabled_map_config.yaml
+++ b/api/test_resources/mock_disabled_map_config.yaml
@@ -1,0 +1,6 @@
+/sampleEndpoint:
+  required:
+    - p1 : enabled
+    - p2 : disabled
+  optional:
+    - p3 : enabled

--- a/cmd/algorand-indexer/api_config.go
+++ b/cmd/algorand-indexer/api_config.go
@@ -12,14 +12,14 @@ import (
 )
 
 var (
-	showAllDisabled bool
+	suppliedAPIConfigFile string
+	showAllDisabled       bool
 )
 
 var apiConfigCmd = &cobra.Command{
 	Use:   "api-config",
-	Short: "dump api configuration",
-	Long:  "dump api configuration",
-	//Args:
+	Short: "api configuration",
+	Long:  "api configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
 		config.BindFlags(cmd)
@@ -36,6 +36,14 @@ var apiConfigCmd = &cobra.Command{
 		}
 
 		options := makeOptions()
+		if suppliedAPIConfigFile != "" {
+			potentialDisabledMapConfig, err := api.MakeDisabledMapConfigFromFile(swag, suppliedAPIConfigFile)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to created disabled map config from file: %v", err)
+				os.Exit(1)
+			}
+			options.DisabledMapConfig = potentialDisabledMapConfig
+		}
 
 		var displayDisabledMapConfig *api.DisplayDisabledMap
 		// Show a limited subset
@@ -60,4 +68,5 @@ var apiConfigCmd = &cobra.Command{
 
 func init() {
 	apiConfigCmd.Flags().BoolVar(&showAllDisabled, "all", false, "show all api config parameters, enabled and disabled")
+	apiConfigCmd.Flags().StringVar(&suppliedAPIConfigFile, "api-config-file", "", "supply an API config file to enable/disable parameters")
 }

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -53,6 +53,13 @@ var daemonCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		// If someone supplied a configuration file but also said to enable all parameters,
+		// that's an error
+		if suppliedAPIConfigFile != "" && enableAllParameters {
+			fmt.Fprint(os.Stderr, "not allowed to supply an api config file and enable all parameters")
+			os.Exit(1)
+		}
+
 		if algodDataDir == "" {
 			algodDataDir = os.Getenv("ALGORAND_DATA")
 		}
@@ -169,7 +176,7 @@ func init() {
 	daemonCmd.Flags().DurationVarP(&readTimeout, "read-timeout", "", 5*time.Second, "set the maximum duration for reading the entire request")
 	daemonCmd.Flags().Uint32VarP(&maxConn, "max-conn", "", 0, "set the maximum connections allowed in the connection pool, if the maximum is reached subsequent connections will wait until a connection becomes available, or timeout according to the read-timeout setting")
 	daemonCmd.Flags().StringVar(&suppliedAPIConfigFile, "api-config-file", "", "supply an API config file to enable/disable parameters")
-	daemonCmd.Flags().BoolVar(&enableAllParameters, "enable-all-parameters", false, "override supplied or default configuration and enable all parameters")
+	daemonCmd.Flags().BoolVar(&enableAllParameters, "enable-all-parameters", false, "override default configuration and enable all parameters. Can't be used with --api-config-file")
 
 	viper.RegisterAlias("algod", "algod-data-dir")
 	viper.RegisterAlias("algod-net", "algod-address")

--- a/test/common.sh
+++ b/test/common.sh
@@ -200,6 +200,7 @@ function start_indexer_with_connection_string() {
   ALGORAND_DATA= ../cmd/algorand-indexer/algorand-indexer daemon \
     -S $NET "$RO" \
     -P "$1" \
+    --enable-all-parameters \
     "$RO" \
     --pidfile $PIDFILE 2>&1 > /dev/null &
 }


### PR DESCRIPTION
Resolves #3584

- Allows for the supplying of configuration files for the daemon and
api-config subcommands.
- Properly validates the schema and contents of the supplied config file
- Enables default parameters to be disabled, allows integration tests to
  run with all parameters enabled

