### PR TITLE
Don't do deduplication based on txID when returning inner transactions

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -949,7 +949,9 @@ func (si *ServerImplementation) fetchTransactions(ctx context.Context, filter id
 			}
 
 			// The root txn has already been added.
-			if _, ok := rootTxnDedupeMap[*tx.Id]; ok {
+			// If we also want to return inner txns, we cannot deduplicate the
+			// results as inner txns all share the same txn ID as its root txn.
+			if _, ok := rootTxnDedupeMap[*tx.Id]; ok && !filter.ReturnInnerTxnOnly {
 				continue
 			}
 

--- a/api/handlers_e2e_test.go
+++ b/api/handlers_e2e_test.go
@@ -665,6 +665,14 @@ func TestLookupMultiInnerLogs(t *testing.T) {
 		logs            []string
 	}{
 		{
+			name:            "match on root with appId 123",
+			appID:           123,
+			numTxnsWithLogs: 1,
+			logs: []string{
+				"testing outer appl log",
+				"appId 123 log",
+			},
+		}, {
 			name:            "match on inner with appId 789",
 			appID:           789,
 			numTxnsWithLogs: 1,

--- a/api/handlers_e2e_test.go
+++ b/api/handlers_e2e_test.go
@@ -672,7 +672,8 @@ func TestLookupMultiInnerLogs(t *testing.T) {
 				"testing outer appl log",
 				"appId 123 log",
 			},
-		}, {
+		},
+		{
 			name:            "match on inner with appId 789",
 			appID:           789,
 			numTxnsWithLogs: 1,
@@ -741,9 +742,9 @@ func TestLookupMultiInnerLogs(t *testing.T) {
 			require.Equal(t, tc.numTxnsWithLogs, len(ld))
 
 			logCount := 0
-			for offset, result := range ld {
-				for i, log := range result.Logs {
-					require.Equal(t, []byte(tc.logs[offset*2+i]), log)
+			for txnIndex, result := range ld {
+				for logIndex, log := range result.Logs {
+					require.Equal(t, []byte(tc.logs[txnIndex*2+logIndex]), log)
 					logCount++
 				}
 			}

--- a/api/handlers_e2e_test.go
+++ b/api/handlers_e2e_test.go
@@ -676,7 +676,7 @@ func TestLookupMultiInnerLogs(t *testing.T) {
 		{
 			name:            "match on inner with appId 222",
 			appID:           222,
-			numTxnsWithLogs: 3, // There are 4 logs over 3 transactions
+			numTxnsWithLogs: 3, // There are 6 logs over 3 transactions
 			logs: []string{
 				"testing multiple logs 1",
 				"appId 222 log 1",

--- a/api/handlers_e2e_test.go
+++ b/api/handlers_e2e_test.go
@@ -649,3 +649,97 @@ func TestLookupInnerLogs(t *testing.T) {
 		})
 	}
 }
+
+// TestLookupInnerLogs runs queries for logs given application ids,
+// and checks that logs in inner transactions match properly.
+func TestLookupMultiInnerLogs(t *testing.T) {
+	var appAddr basics.Address
+	appAddr[1] = 99
+
+	params := generated.LookupApplicationLogsByIDParams{}
+
+	testcases := []struct {
+		name            string
+		appID           uint64
+		numTxnsWithLogs int
+		logs            []string
+	}{
+		{
+			name:            "match on inner with appId 789",
+			appID:           789,
+			numTxnsWithLogs: 1,
+			logs: []string{
+				"testing inner log",
+				"appId 789 log",
+			},
+		},
+		{
+			name:            "match on inner with appId 222",
+			appID:           222,
+			numTxnsWithLogs: 3, // There are 4 logs over 3 transactions
+			logs: []string{
+				"testing multiple logs 1",
+				"appId 222 log 1",
+				"testing multiple logs 2",
+				"appId 222 log 2",
+				"testing multiple logs 3",
+				"appId 222 log 3",
+			},
+		},
+	}
+
+	db, shutdownFunc := setupIdb(t, test.MakeGenesis(), test.MakeGenesisBlock())
+	defer shutdownFunc()
+
+	///////////
+	// Given // a DB with some inner txns in it.
+	///////////
+	appCall := test.MakeAppCallWithMultiLogs(test.AccountA)
+
+	block, err := test.MakeBlockForTxns(test.MakeGenesisBlock().BlockHeader, &appCall)
+	require.NoError(t, err)
+
+	err = db.AddBlock(&block)
+	require.NoError(t, err, "failed to commit")
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			//////////
+			// When // we run a query that queries logs based on appID
+			//////////
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetPath("/v2/applications/:appIdx/logs")
+			c.SetParamNames("appIdx")
+			c.SetParamValues(fmt.Sprintf("%d", tc.appID))
+
+			api := &ServerImplementation{db: db, timeout: 30 * time.Second}
+			err = api.LookupApplicationLogsByID(c, tc.appID, params)
+			require.NoError(t, err)
+
+			//////////
+			// Then // The result is the log from the app
+			//////////
+			var response generated.ApplicationLogsResponse
+			require.Equal(t, http.StatusOK, rec.Code)
+			json.Decode(rec.Body.Bytes(), &response)
+			require.NoError(t, err)
+
+			require.Equal(t, uint64(tc.appID), response.ApplicationId)
+			require.NotNil(t, response.LogData)
+			ld := *response.LogData
+			require.Equal(t, tc.numTxnsWithLogs, len(ld))
+
+			logCount := 0
+			for offset, result := range ld {
+				for i, log := range result.Logs {
+					require.Equal(t, []byte(tc.logs[offset*2+i]), log)
+					logCount++
+				}
+			}
+			require.Equal(t, logCount, len(tc.logs))
+		})
+	}
+}

--- a/util/test/account_testutil.go
+++ b/util/test/account_testutil.go
@@ -358,6 +358,13 @@ func MakeAppCallWithInnerTxn(appSender, paymentSender, paymentReceiver, assetSen
 func MakeAppCallWithMultiLogs(appSender basics.Address) transactions.SignedTxnWithAD {
 	createApp := MakeCreateAppTxn(appSender)
 
+	// Add a log to the outer appl call
+	createApp.ApplicationID = 123
+	createApp.ApplyData.EvalDelta.Logs = []string{
+		"testing outer appl log",
+		"appId 123 log",
+	}
+
 	createApp.ApplyData.EvalDelta.InnerTxns = []transactions.SignedTxnWithAD{
 		{
 			SignedTxn: transactions.SignedTxn{

--- a/util/test/account_testutil.go
+++ b/util/test/account_testutil.go
@@ -263,7 +263,7 @@ func MakeAppOptOutTxn(appid uint64, sender basics.Address) transactions.SignedTx
 	}
 }
 
-// MakeAppOptOutTxn makes an appl transaction with a NoOp upon completion.
+// MakeAppCallTxn makes an appl transaction with a NoOp upon completion.
 func MakeAppCallTxn(appid uint64, sender basics.Address) transactions.SignedTxnWithAD {
 	return transactions.SignedTxnWithAD{
 		SignedTxn: transactions.SignedTxn{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

This PR removes deduplication when returning inner transaction results. Without this check, a query that should return all matched inner txns will return only the first result as inner txns all share the same txID as their root txn. Currently, this only affects the `applications/ID/logs` endpoint, as inner txns are otherwise "rolled up" and any queries matches on inner txns return its root txn anyway. 

## Test Plan

Added test case to check that results are returned properly without deduplication based on txID when logs are queried. Tested locally on sandbox as well, and multiple logs with same txIDs show up. 

Prior to this change, the added unit test will only return the first inner txn's logs and fail.