### PR TITLE
Fix dev mode by addressing off by one error.

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -147,6 +147,7 @@ func (bot *fetcherImpl) followLoop(ctx context.Context) error {
 	aclient := bot.Algod()
 	for {
 		for retries := 0; retries < 3; retries++ {
+			// nextRound - 1 because the endpoint waits until "StatusAfterBlock"
 			_, err = aclient.StatusAfterBlock(bot.nextRound - 1).Do(ctx)
 			if err != nil {
 				// If context has expired.

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -147,7 +147,7 @@ func (bot *fetcherImpl) followLoop(ctx context.Context) error {
 	aclient := bot.Algod()
 	for {
 		for retries := 0; retries < 3; retries++ {
-			_, err = aclient.StatusAfterBlock(bot.nextRound).Do(ctx)
+			_, err = aclient.StatusAfterBlock(bot.nextRound - 1).Do(ctx)
 			if err != nil {
 				// If context has expired.
 				if ctx.Err() != nil {


### PR DESCRIPTION
## Summary

"StatusAfterBlock" needs to be given the current round in order to wait for the next round. Because we give it the next round, it waits until the round after the next round. This adds unnecessary latency and breaks entirely when dev mode is enabled and there is no next round to keep flushing the latest changes.

Thanks to @achidlow [for the suggestion](https://github.com/MakerXStudio/algorand-sandbox-dev/blob/main/indexer/fastFollowLoop.patch).

## Test Plan

Existing integration tests start a network and use this code.