### PR TITLE
Fix missing algorand-indexer_VERSION_armhf.deb.sig

### DIFF
--- a/mule/sign.sh
+++ b/mule/sign.sh
@@ -21,7 +21,7 @@ make_hashes () {
     for ext in ${EXTENSIONS[*]}
     do
         if ls *"$VERSION"*."$ext"; then
-            HASHFILE="hashes_${OS_TYPE}_${ARCH}_${VERSION}_${ext}"
+            HASHFILE="hashes_${OS_TYPE}_${ARCH}_${VERSION}_${ext/./}"
             {
                 md5sum *"$VERSION"*."$ext" ;
                 shasum -a 256 *"$VERSION"*."$ext" ;


### PR DESCRIPTION
## Summary

Fix missing algorand-indexer_VERSION_armhf.deb.sig because the signer skips over the armhf file to sign.

## Test Plan

Will need to test it on the next indexer release.
Makes sure the armhf file gets signed and uploaded to S3 in the armhf pipeline.
