### PR TITLE
Testing: remove ghosts of past discrepancies in parity test

### DIFF
--- a/misc/parity/reports/algod2indexer_dropped.yml
+++ b/misc/parity/reports/algod2indexer_dropped.yml
@@ -26,9 +26,6 @@ DryrunTxnResult:
 ErrorResponse:
 - INDEXER: null
 - ALGOD: '{"description":"An error respo...'
-AccountsErrorResponse:
-- INDEXER: null
-- ALGOD: '{"description":"An error respo...'
 ParticipationKey:
 - INDEXER: null
 - ALGOD: '{"description":"Represents a p...'

--- a/misc/parity/reports/algod2indexer_full.yml
+++ b/misc/parity/reports/algod2indexer_full.yml
@@ -100,9 +100,6 @@ DryrunTxnResult:
 ErrorResponse:
 - INDEXER: null
 - ALGOD: '{"description":"An error respo...'
-AccountsErrorResponse:
-- INDEXER: null
-- ALGOD: '{"description":"An error respo...'
 HealthCheck:
 - INDEXER: '{"description":"A health check...'
 - ALGOD: null


### PR DESCRIPTION
## Summary

Nightly test [failed](https://app.circleci.com/pipelines/github/algorand/indexer/872/workflows/6446b890-cde8-4b10-9ad8-4e057e0ea4a7/jobs/1635) because `AccountsErrorResponse` is no longer present in swagger (neither [indexer](https://github.com/algorand/indexer/pull/916) nor [algod](https://github.com/algorand/go-algorand/pull/3737)), so the declared expected discrepancy is no longer accurate and should be removed from the expected diff files.

## Test Plan

The next nightly test should pass (unless there is a new problem).