### PR TITLE
Validator: Fix processorNum variable.

### DIFF
--- a/cmd/validator/core/command.go
+++ b/cmd/validator/core/command.go
@@ -42,7 +42,7 @@ func init() {
 	ValidatorCmd.Flags().IntVarP(&config.RetryDelayMS, "retry-delay", "", 1000, "Time in milliseconds to sleep between retries.")
 	ValidatorCmd.Flags().StringVar(&addr, "addr", "", "If provided validate a single address instead of reading Stdin.")
 	ValidatorCmd.Flags().IntVar(&threads, "threads", 4, "Number of worker threads to initialize.")
-	ValidatorCmd.Flags().IntVar(&threads, "processor", 0, "Choose compare algorithm [0 = Struct, 1 = Reflection]")
+	ValidatorCmd.Flags().IntVar(&processorNum, "processor", 0, "Choose compare algorithm [0 = Struct, 1 = Reflection]")
 	ValidatorCmd.Flags().BoolVar(&printCurl, "print-commands", false, "Print curl commands, including tokens, to query algod and indexer.")
 }
 


### PR DESCRIPTION
## Summary

When the validator was converted to using cobra, the processorNum variable was set incorrectly. This was causing the threads variable default to be 0, which caused the worker to exit immediately.