### PR TITLE
Nightly Job: Less Blamey Error Message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Failed: $CIRCLE_USERNAME's build of \n<$CIRCLE_BUILD_URL|$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME>\n(<https://app.circleci.com/pipelines/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?branch=$CIRCLE_BRANCH|$CIRCLE_BRANCH>) \n- <$CIRCLE_BUILD_URL|$CIRCLE_JOB> failed\n\nThis is probably a result of `make indexer-v-algod`\nSee <https://algorand.atlassian.net/wiki/spaces/LAMPREY/pages/2339536905/Nightly+Indexer+Tests#Q%3A-What-does-it-mean-that-the-nightly-test-failed-because-of-make-indexer-v-algod%3F|this wiki page> for more details"
+                    "text": "Failed: $CIRCLE_USERNAME's build of \n<$CIRCLE_BUILD_URL|$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME>\n(<https://app.circleci.com/pipelines/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?branch=$CIRCLE_BRANCH|$CIRCLE_BRANCH>) \n- <$CIRCLE_BUILD_URL|$CIRCLE_JOB> failed\n\nIn the event of `make indexer-v-algod` failing see:\n<https://algorand.atlassian.net/wiki/spaces/LAMPREY/pages/2339536905/Nightly+Indexer+Tests#Q%3A-What-does-it-mean-that-the-nightly-test-failed-because-of-make-indexer-v-algod%3F|this wiki page> for more details"
                   }
                 }
               ]


### PR DESCRIPTION
## Summary

The nightly build now fails for various reasons, yet on Slack the parity job gets most of the blame. For example last night's [#dev-alerts channel](https://algorand-internal.slack.com/archives/C02ND31K0HG/p1648180203647059) looked like:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/291133/160128412-e75461b5-4998-4666-aa7b-cb551e7db4b5.png">
but [further investigation](https://app.circleci.com/pipelines/github/algorand/indexer/951/workflows/a85fe43f-58fa-4126-84e6-8b1b6feb6c31/jobs/1805) proved `make indexer-v-algod` to be not guilty:
<img width="661" alt="image" src="https://user-images.githubusercontent.com/291133/160129043-03c12238-2a49-4626-ab59-7bfd1d53a715.png">

The PR introduces:
1. a more circumspect slack error message in the case the nightly job fails

This PR DOES NOT introduce (but would like to with some suggestions)
2. continuation of each step in the nightly job, even after failed steps with the slack notification that gets sent in the end if any of the steps failed

## Test Plan

Wait for the next nightly test to fail