### PR TITLE
Do not show block not found error after fetcher has finished catchup.

### DIFF
--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -139,6 +139,8 @@ func init() {
 	rootCmd.AddCommand(daemonCmd)
 	rootCmd.AddCommand(apiConfigCmd)
 
+	// Version should be available globally
+	rootCmd.Flags().BoolVarP(&doVersion, "version", "v", false, "print version and exit")
 	// Not applied globally to avoid adding to utility commands.
 	addFlags := func(cmd *cobra.Command) {
 		cmd.Flags().StringVarP(&logLevel, "loglevel", "l", "info", "verbosity of logs: [error, warn, info, debug, trace]")

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -124,7 +124,6 @@ func (bot *fetcherImpl) catchupLoop(ctx context.Context) error {
 			if ctx.Err() != nil {
 				return fmt.Errorf("catchupLoop() fetch err: %w", err)
 			}
-			bot.setError(err)
 			bot.log.WithError(err).Errorf("catchup block %d", bot.nextRound)
 			return nil
 		}


### PR DESCRIPTION
## Summary

Addresses feedback in https://github.com/algorand/sandbox/pull/110 for making the version command global again.  
Also addresses #486 by not setting the error status during catchup when receiving algod client errors.
## Test Plan

Tested via repro using sandbox. Fresh sandbox up commands no longer show algod error in the health status command which were produced by the final catchup lookup.
