### PR TITLE
Skip validator errors resulting from the account resource limit.

### DIFF
--- a/api/converter_utils.go
+++ b/api/converter_utils.go
@@ -647,7 +647,7 @@ func (si *ServerImplementation) maxAccountsErrorToAccountsErrorResponse(maxErr i
 		"total-created-apps":    maxErr.TotalAppParams,
 	}
 	return generated.ErrorResponse{
-		Message: "Result limit exceeded",
+		Message: ErrResultLimitReached,
 		Data:    &extraData,
 	}
 }

--- a/api/error_messages.go
+++ b/api/error_messages.go
@@ -36,6 +36,7 @@ const (
 	errZeroAddressCloseRemainderToRole = "searching transactions by zero address with close address role is not supported"
 	errZeroAddressAssetSenderRole      = "searching transactions by zero address with asset sender role is not supported"
 	errZeroAddressAssetCloseToRole     = "searching transactions by zero address with asset close address role is not supported"
+	ErrResultLimitReached              = "Result limit exceeded"
 )
 
 var errUnknownAddressRole string

--- a/api/error_messages.go
+++ b/api/error_messages.go
@@ -7,6 +7,7 @@ import (
 	"github.com/algorand/indexer/util"
 )
 
+// constant error messages.
 const (
 	errInvalidRoundAndMinMax           = "cannot specify round and min-round/max-round"
 	errInvalidRoundMinMax              = "min-round must be less than max-round"

--- a/cmd/validator/core/validator.go
+++ b/cmd/validator/core/validator.go
@@ -39,10 +39,14 @@ type Processor interface {
 	ProcessAddress(algodData []byte, indexerData []byte) (Result, error)
 }
 
+// Skip indicates why something was skipped.
 type Skip string
 
 const (
-	NotSkipped       Skip = ""
+	// NotSkipped is the default value indicated the results are not skipped.
+	NotSkipped Skip = ""
+	// SkipLimitReached is used when the result is skipped because an account
+	// resource limit prevents fetching results.
 	SkipLimitReached Skip = "account-limit"
 )
 

--- a/cmd/validator/core/validator.go
+++ b/cmd/validator/core/validator.go
@@ -3,7 +3,6 @@ package core
 import (
 	"encoding/base64"
 	"fmt"
-	sdk_types "github.com/algorand/go-algorand-sdk/types"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -11,6 +10,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
+
+	"github.com/algorand/indexer/api"
 )
 
 // Params are the program arguments which need to be passed between objects.
@@ -36,11 +39,19 @@ type Processor interface {
 	ProcessAddress(algodData []byte, indexerData []byte) (Result, error)
 }
 
+type Skip string
+
+const (
+	NotSkipped       Skip = ""
+	SkipLimitReached Skip = "account-limit"
+)
+
 // Result is the output of ProcessAddress.
 type Result struct {
 	// Error is set if there were errors running the test.
-	Error     error
-	SameRound bool
+	Error      error
+	SameRound  bool
+	SkipReason Skip
 
 	Equal   bool
 	Retries int
@@ -126,7 +137,12 @@ func CallProcessor(processor Processor, addrInput string, config Params, results
 	for i := 0; true; i++ {
 		indexerData, err := getData(indexerDataURL, config.IndexerToken)
 		if err != nil {
-			results <- resultError(err, addrInput)
+			switch {
+			case strings.Contains(string(indexerData), api.ErrResultLimitReached):
+				results <- resultSkip(err, addrInput, SkipLimitReached)
+			default:
+				results <- resultError(err, addrInput)
+			}
 			return
 		}
 
@@ -201,14 +217,27 @@ func getData(url, token string) ([]byte, error) {
 		}
 	}()
 
-	return ioutil.ReadAll(resp.Body)
+	data, ioErr := ioutil.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		// We attempted to read the body even though the status was bad.
+		// Return the bad status error, and the data if available.
+		return data, fmt.Errorf("bad status: %s", resp.Status)
+	}
+
+	return data, ioErr
 }
 
 func resultError(err error, address string) Result {
+	return resultSkip(err, address, NotSkipped)
+}
+
+func resultSkip(err error, address string, skip Skip) Result {
 	return Result{
-		Equal:   false,
-		Error:   err,
-		Retries: 0,
+		Equal:      false,
+		Error:      err,
+		SkipReason: skip,
+		Retries:    0,
 		Details: &ErrorDetails{
 			Address: address,
 		},


### PR DESCRIPTION
## Summary

Do not generate errors if validator detects a mismatch between algod and indexer due to the account resource limit.

## Test Plan

Manual testing.

```
$ ./validator --algod-token _ --indexer-token _ --indexer-url "" --algod-url "" --addr IACII2KW5LSVKZKSJ5MMC77745CSVROOV47CEZQ7K75Q7TFKWXK5HNCK5Q 2>err.log

0        : _

Number of errors: [0 / 1]
Skipped (account-limit): 1
Retry count: 0
Checks per second: 1.701474
Test duration: 00:00:00
```
```
$ cat err.log 
===================================================================
2022-04-25 11:34:30 AM
Account: IACII2KW5LSVKZKSJ5MMC77745CSVROOV47CEZQ7K75Q7TFKWXK5HNCK5Q
Error #: 0
Retries: 0
Rounds Match: false
Address skipped: too many asset and/or accounts to return
```