### PR TITLE
CICD: Update build docker run command

### DIFF
--- a/misc/Dockerfile
+++ b/misc/Dockerfile
@@ -4,8 +4,8 @@ FROM $GO_IMAGE
 RUN echo "Go image: $GO_IMAGE"
 
 # Misc dependencies
-ENV HOME /opt    
-ENV DEBIAN_FRONTEND noninteractive    
+ENV HOME /opt
+ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y apt-utils curl git git-core bsdmainutils python3 python3-pip make bash libtool libboost-math-dev libffi-dev
 
 # Install algod nightly binaries to the path
@@ -18,7 +18,7 @@ RUN find /opt/algorand
 ENV PATH="/opt/algorand/bin:${PATH}"
 
 # Setup files for test
-run mkdir -p /opt/go/indexer
+RUN mkdir -p /opt/go/indexer
 COPY . /opt/go/indexer
 WORKDIR /opt/go/indexer
 RUN rm /opt/go/indexer/cmd/algorand-indexer/algorand-indexer

--- a/misc/package_linux_arch.sh
+++ b/misc/package_linux_arch.sh
@@ -57,4 +57,4 @@ docker run ${DOCKER_RUN_OPTS} \
     -v `pwd`:/go/src/github.com/algorand/indexer \
     --workdir /go/src/github.com/algorand/indexer \
     "${BUILD_IMAGE}" \
-    bash -c "git config --global --add safe.directory '*' && make ${MAKE_TARGET}"
+    bash -c "git config --global --add safe.directory '/go/src/github.com/algorand/indexer/*' && make ${MAKE_TARGET}"

--- a/misc/package_linux_arch.sh
+++ b/misc/package_linux_arch.sh
@@ -57,4 +57,4 @@ docker run ${DOCKER_RUN_OPTS} \
     -v `pwd`:/go/src/github.com/algorand/indexer \
     --workdir /go/src/github.com/algorand/indexer \
     "${BUILD_IMAGE}" \
-    bash -c "make ${MAKE_TARGET}"
+    bash -c "git config --global --add safe.directory /go/src/github.com/algorand/indexer && make ${MAKE_TARGET}"

--- a/misc/package_linux_arch.sh
+++ b/misc/package_linux_arch.sh
@@ -57,4 +57,4 @@ docker run ${DOCKER_RUN_OPTS} \
     -v `pwd`:/go/src/github.com/algorand/indexer \
     --workdir /go/src/github.com/algorand/indexer \
     "${BUILD_IMAGE}" \
-    bash -c "git config --global --add safe.directory /go/src/github.com/algorand/indexer && make ${MAKE_TARGET}"
+    bash -c "git config --global --add safe.directory '*' && make ${MAKE_TARGET}"

--- a/misc/package_linux_arch.sh
+++ b/misc/package_linux_arch.sh
@@ -57,4 +57,4 @@ docker run ${DOCKER_RUN_OPTS} \
     -v `pwd`:/go/src/github.com/algorand/indexer \
     --workdir /go/src/github.com/algorand/indexer \
     "${BUILD_IMAGE}" \
-    bash -c "git config --global --add safe.directory '/go/src/github.com/algorand/indexer/*' && make ${MAKE_TARGET}"
+    bash -c "git config --global --add safe.directory '*' && make ${MAKE_TARGET}"


### PR DESCRIPTION
## Summary

**Cause**: a new update to git cli checks for using a submodule of another user's git repo. 
We are building the indexer in a container before running it in a separate docker run command (a different user): [https://github.com/algorand/indexer/blob/develop/misc/package_linux_arch.sh](https://www.google.com/url?q=https://github.com/algorand/indexer/blob/develop/misc/package_linux_arch.sh&sa=D&source=calendar&ust=1651672180598827&usg=AOvVaw2oXwWj5GScI26hpzK3_6IY)

**Error**: 
```
git submodule update --init && cd third_party/go-algorand && \    make crypto/libs/`scripts/ostype.sh`/`scripts/archtype.sh`/lib/libsodium.afatal: unsafe repository' is owned by someone else)
```
## Test Plan
Tried just adding 
`git config --global --add safe.directory /go/src/github.com/algorand/indexer` but got an additional error `git config --global --add safe.directory /go/src/github.com/algorand/indexer/third_party/go-algorand`. Decided to just use a wildcard, but can be convinced otherwise from using the following : `git config --global --add safe.directory '*'`

Rerun build to get past these errors.
