### PR TITLE
validator: skip comparison of deleted accounts.

### DIFF
--- a/api/error_messages.go
+++ b/api/error_messages.go
@@ -23,7 +23,7 @@ const (
 	errFailedSearchingApplication      = "failed while searching for application"
 	errFailedLookingUpHealth           = "failed while getting indexer health"
 	errNoApplicationsFound             = "no application found for application-id"
-	errNoAccountsFound                 = "no accounts found for address"
+	ErrNoAccountsFound                 = "no accounts found for address"
 	errNoAssetsFound                   = "no assets found for asset-id"
 	errNoTransactionFound              = "no transaction found for transaction id"
 	errMultipleTransactions            = "multiple transactions found for this txid, please contact us, this shouldn't happen"

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -196,7 +196,7 @@ func (si *ServerImplementation) LookupAccountByID(ctx echo.Context, accountID st
 	}
 
 	if len(accounts) == 0 {
-		return notFound(ctx, fmt.Sprintf("%s: %s", errNoAccountsFound, accountID))
+		return notFound(ctx, fmt.Sprintf("%s: %s", ErrNoAccountsFound, accountID))
 	}
 
 	if len(accounts) > 1 {

--- a/cmd/validator/core/command.go
+++ b/cmd/validator/core/command.go
@@ -146,6 +146,7 @@ func resultsPrinter(config Params, printCurl bool, results <-chan Result) int {
 		duration := endTime.Sub(startTime)
 		fmt.Printf("\n\nNumber of errors: [%d / %d]\n", numErrors, numResults)
 		fmt.Printf("Skipped (%s): %d\n", SkipLimitReached, skipCounts[SkipLimitReached])
+		fmt.Printf("Skipped (%s): %d\n", SkipAccountNotFound, skipCounts[SkipAccountNotFound])
 		fmt.Printf("Retry count: %d\n", numRetries)
 		fmt.Printf("Checks per second: %f\n", float64(numResults+numRetries)/duration.Seconds())
 		fmt.Printf("Test duration: %s\n", time.Time{}.Add(duration).Format("15:04:05"))
@@ -189,6 +190,8 @@ func resultsPrinter(config Params, printCurl bool, results <-chan Result) int {
 				switch r.SkipReason {
 				case SkipLimitReached:
 					ErrorLog.Printf("Address skipped: too many asset and/or accounts to return\n")
+				case SkipAccountNotFound:
+					ErrorLog.Printf("Address skipped: account not found, probably deleted\n")
 				default:
 					ErrorLog.Printf("Address skipped: Unknown reason (%s)\n", r.SkipReason)
 				}

--- a/cmd/validator/core/validator.go
+++ b/cmd/validator/core/validator.go
@@ -42,11 +42,10 @@ type Processor interface {
 // Skip indicates why something was skipped.
 type Skip string
 
+// constants relating to different skip cases
 const (
 	// NotSkipped is the default value indicated the results are not skipped.
-	NotSkipped Skip = ""
-	// SkipLimitReached is used when the result is skipped because an account
-	// resource limit prevents fetching results.
+	NotSkipped          Skip = ""
 	SkipLimitReached    Skip = "account-limit"
 	SkipAccountNotFound Skip = "missing-account"
 )

--- a/misc/generate_accounts.sh
+++ b/misc/generate_accounts.sh
@@ -22,8 +22,8 @@ function help () {
 }
 
 #default selection queries
-SELECTION_QUERY="select encode(addr,'base64') from account where deleted is not null limit 1000"
-SELECTION_QUERY_COPY="COPY (select encode(addr, 'base64') from account) TO stdout"
+SELECTION_QUERY="select encode(addr,'base64') from account where deleted is false limit 1000"
+SELECTION_QUERY_COPY="COPY (select encode(addr, 'base64') from account where deleted is false) TO stdout"
 
 START_TIME=$SECONDS
 PGUSER=


### PR DESCRIPTION
## Summary

The recent validator change causes all HTTP errors to log an error, previously they were ignored and zero values would be compared. In the case of a deleted account, the zero values are equal. This previously ignored case must now be specifically skipped.

## Test Plan

Manual testing.
