### PR TITLE
ci: add version to golint install command.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ commands:
 
       - run: 
           name: Install golint
-          command: go install golang.org/x/lint/golint
+          command: go install golang.org/x/lint/golint@latest
 
   run_tests:
     steps:


### PR DESCRIPTION
## Summary

The nightly CI job fails when golint is installed. Add a version to see if the issue is resolved.

## Test Plan

Wait for nightly CI job.
