### PR TITLE
api: return empty lists from fetchApplications and fetchAppLocalStates

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -833,8 +833,8 @@ func notFound(ctx echo.Context, err string) error {
 
 // fetchApplications fetches all results
 func (si *ServerImplementation) fetchApplications(ctx context.Context, params idb.ApplicationQuery) ([]generated.Application, uint64, error) {
-	var apps []generated.Application
 	var round uint64
+	apps := make([]generated.Application, 0)
 	err := callWithTimeout(ctx, si.log, si.timeout, func(ctx context.Context) error {
 		var results <-chan idb.ApplicationRow
 		results, round = si.db.Applications(ctx, params)
@@ -857,8 +857,8 @@ func (si *ServerImplementation) fetchApplications(ctx context.Context, params id
 
 // fetchAppLocalStates fetches all generated.AppLocalState from a query
 func (si *ServerImplementation) fetchAppLocalStates(ctx context.Context, params idb.ApplicationQuery) ([]generated.ApplicationLocalState, uint64, error) {
-	var als []generated.ApplicationLocalState
 	var round uint64
+	als := make([]generated.ApplicationLocalState, 0)
 	err := callWithTimeout(ctx, si.log, si.timeout, func(ctx context.Context) error {
 		var results <-chan idb.AppLocalStateRow
 		results, round = si.db.AppLocalState(ctx, params)


### PR DESCRIPTION
Currently, `fetchApplications` and `fetchAppLocalStates` in `handlers.go` declare their result slices using `var`. This causes those slices to be initialized to `nil`. In turn, when there are no applications/app local states to be found, the rest endpoints that use these methods end up returning `null` in the response json instead of an empty list. E.g. querying `/v2/accounts/{account-id}/apps-local-state` for an account not participating in any contracts will return `{ 'apps-local-states': null, 'round': ... }`. This has caused some confusion, as the rest api docs do not acknowledge this possibility. 

This PR changes the behavior of those two methods to create their slices using `make`. This causes the endpoints to return empty lists instead of null.