### PR TITLE
build: Lock to mockery minor version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ idb/postgres/internal/schema/setup_postgres_sql.go:	idb/postgres/internal/schema
 	cd idb/postgres/internal/schema && go generate
 
 idb/mocks/IndexerDb.go:	idb/idb.go
-	go install github.com/vektra/mockery/v2@latest
+	go install github.com/vektra/mockery/v2@v2.12.3
 	cd idb && mockery --name=IndexerDb
 
 # check that all packages (except tests) compile


### PR DESCRIPTION


## Summary

Mockery bumped the golang version without doing a major version bump of their package. This breaks us since we're just pulling v2 latest. More discussion https://github.com/vektra/mockery/pull/456 about this decision and why they say not to use mockery via go install/go generate.

## Test Plan

CI
