### PR TITLE
Support for custom consensus on private networks

### DIFF
--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -93,7 +93,7 @@ var daemonCmd = &cobra.Command{
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Unable to load optional consensus protocols file: %s/consensus.json %v\n", indexerDataDir, err)
 			}else{
-				fmt.Printf("consensus loaded\n");
+				fmt.Printf("consensus loaded\n")
 			}
 		}
 

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -87,17 +87,14 @@ var daemonCmd = &cobra.Command{
 		// Detect the various auto-loading configs from data directory
 		indexerConfigFound := util.FileExists(filepath.Join(indexerDataDir, autoLoadIndexerConfigName))
 		paramConfigFound := util.FileExists(filepath.Join(indexerDataDir, autoLoadParameterConfigName))
-		consensusConfigFound := util.FileExists("/app")
-
+		consensusConfigFound := util.FileExists(filepath.Join(indexerDataDir, "consensus.json"))
 		if consensusConfigFound {
-			err = goconfig.LoadConfigurableConsensusProtocols("/app")
+			err = goconfig.LoadConfigurableConsensusProtocols(indexerDataDir)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Unable to load optional consensus protocols file: /app %v\n", err)
+				fmt.Fprintf(os.Stderr, "Unable to load optional consensus protocols file: %s/consensus.json %v\n", indexerDataDir, err)
 			}else{
-				fmt.Printf("/app loaded\n");
+				fmt.Printf("consensus loaded\n");
 			}
-		}else{
-			fmt.Printf("/app does not exists\n");
 		}
 
 		// If we auto-loaded configs but a user supplied them as well, we have an error

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -92,7 +92,7 @@ var daemonCmd = &cobra.Command{
 		if consensusConfigFound {
 			err = goconfig.LoadConfigurableConsensusProtocols("/app/consensus.json")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Unable to load optional consensus protocols file: /app/consensus.json\n")
+				fmt.Fprint(os.Stderr, "Unable to load optional consensus protocols file: /app/consensus.json %v\n", err)
 			}else{
 				fmt.Printf("/app/consensus.json loaded\n");
 			}

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -92,7 +92,7 @@ var daemonCmd = &cobra.Command{
 			err = goconfig.LoadConfigurableConsensusProtocols(indexerDataDir)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Unable to load optional consensus protocols file: %s/consensus.json %v\n", indexerDataDir, err)
-			}else{
+			} else {
 				fmt.Printf("consensus loaded\n")
 			}
 		}

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -87,17 +87,17 @@ var daemonCmd = &cobra.Command{
 		// Detect the various auto-loading configs from data directory
 		indexerConfigFound := util.FileExists(filepath.Join(indexerDataDir, autoLoadIndexerConfigName))
 		paramConfigFound := util.FileExists(filepath.Join(indexerDataDir, autoLoadParameterConfigName))
-		consensusConfigFound := util.FileExists("/app/consensus.json")
+		consensusConfigFound := util.FileExists("/app")
 
 		if consensusConfigFound {
-			err = goconfig.LoadConfigurableConsensusProtocols("/app/consensus.json")
+			err = goconfig.LoadConfigurableConsensusProtocols("/app")
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Unable to load optional consensus protocols file: /app/consensus.json %v\n", err)
+				fmt.Fprintf(os.Stderr, "Unable to load optional consensus protocols file: /app %v\n", err)
 			}else{
-				fmt.Printf("/app/consensus.json loaded\n");
+				fmt.Printf("/app loaded\n");
 			}
 		}else{
-			fmt.Printf("/app/consensus.json does not exists\n");
+			fmt.Printf("/app does not exists\n");
 		}
 
 		// If we auto-loaded configs but a user supplied them as well, we have an error

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -92,7 +92,7 @@ var daemonCmd = &cobra.Command{
 		if consensusConfigFound {
 			err = goconfig.LoadConfigurableConsensusProtocols("/app/consensus.json")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Unable to load optional consensus protocols file: /app/consensus.json %v\n", err)
+				fmt.Fprintf(os.Stderr, "Unable to load optional consensus protocols file: /app/consensus.json %v\n", err)
 			}else{
 				fmt.Printf("/app/consensus.json loaded\n");
 			}

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -87,17 +87,17 @@ var daemonCmd = &cobra.Command{
 		// Detect the various auto-loading configs from data directory
 		indexerConfigFound := util.FileExists(filepath.Join(indexerDataDir, autoLoadIndexerConfigName))
 		paramConfigFound := util.FileExists(filepath.Join(indexerDataDir, autoLoadParameterConfigName))
-		consensusConfigFound := util.FileExists("consensus.json")
+		consensusConfigFound := util.FileExists("/app/consensus.json")
 
 		if consensusConfigFound {
-			err = goconfig.LoadConfigurableConsensusProtocols("consensus.json")
+			err = goconfig.LoadConfigurableConsensusProtocols("/app/consensus.json")
 			if err != nil {
-				fmt.Fprint(os.Stderr, "Unable to load optional consensus protocols file: consensus.json")
+				fmt.Fprint(os.Stderr, "Unable to load optional consensus protocols file: /app/consensus.json\n")
 			}else{
-				fmt.Printf("consensus.json loaded");
+				fmt.Printf("/app/consensus.json loaded\n");
 			}
 		}else{
-			fmt.Printf("consensus.json does not exists");
+			fmt.Printf("/app/consensus.json does not exists\n");
 		}
 
 		// If we auto-loaded configs but a user supplied them as well, we have an error

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -24,6 +24,9 @@ import (
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/importer"
 	"github.com/algorand/indexer/util/metrics"
+
+	goconfig "github.com/algorand/go-algorand/config"
+
 )
 
 var (
@@ -84,6 +87,18 @@ var daemonCmd = &cobra.Command{
 		// Detect the various auto-loading configs from data directory
 		indexerConfigFound := util.FileExists(filepath.Join(indexerDataDir, autoLoadIndexerConfigName))
 		paramConfigFound := util.FileExists(filepath.Join(indexerDataDir, autoLoadParameterConfigName))
+		consensusConfigFound := util.FileExists("consensus.json")
+
+		if consensusConfigFound {
+			err = goconfig.LoadConfigurableConsensusProtocols("consensus.json")
+			if err != nil {
+				fmt.Fprint(os.Stderr, "Unable to load optional consensus protocols file: consensus.json")
+			}else{
+				fmt.Printf("consensus.json loaded");
+			}
+		}else{
+			fmt.Printf("consensus.json does not exists");
+		}
 
 		// If we auto-loaded configs but a user supplied them as well, we have an error
 		if indexerConfigFound {


### PR DESCRIPTION
## Summary

Algorand indexer at the moment does not allow using custom consensus on private networks. This pull request adds this feature.

## Test Plan

I tested it manually on custom made private network with custom consensus.