### PR TITLE
Local Ledger cleanup + catchup service

### DIFF
--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -256,7 +256,7 @@ var daemonCmd = &cobra.Command{
 						}
 
 					}
-					err = localledger.RunMigrationSimple(nextDBRound-1, &opts)
+					err = localledger.RunMigrationSimple(logger, nextDBRound-1, &opts)
 					maybeFail(err, "Error running ledger migration")
 				}
 
@@ -264,7 +264,7 @@ var daemonCmd = &cobra.Command{
 				imp := importer.NewImporter(db)
 
 				logger.Info("Initializing local ledger.")
-				proc, err := blockprocessor.MakeProcessor(&genesis, nextDBRound, indexerDataDir, imp.ImportBlock)
+				proc, err := blockprocessor.MakeProcessor(logger, &genesis, nextDBRound, indexerDataDir, imp.ImportBlock)
 				if err != nil {
 					maybeFail(err, "blockprocessor.MakeProcessor() err %v", err)
 				}

--- a/importer/helper.go
+++ b/importer/helper.go
@@ -50,12 +50,29 @@ type ImportHelper struct {
 	Log *log.Logger
 }
 
+func readGenesis(in io.Reader) (bookkeeping.Genesis, error) {
+	var genesis bookkeeping.Genesis
+	gbytes, err := ioutil.ReadAll(in)
+	if err != nil {
+		return bookkeeping.Genesis{}, fmt.Errorf("error reading genesis, %v", err)
+	}
+	err = protocol.DecodeJSON(gbytes, &genesis)
+	if err != nil {
+		return bookkeeping.Genesis{}, fmt.Errorf("error decoding genesis, %v", err)
+	}
+	return genesis, nil
+}
+
 // Import is the main ImportHelper function that glues together a directory full of block files and an Importer objects.
 func (h *ImportHelper) Import(db idb.IndexerDb, args []string) {
 	// Initial import if needed.
 	genesisReader := GetGenesisFile(h.GenesisJSONPath, nil, h.Log)
-	_, err := EnsureInitialImport(db, genesisReader, h.Log)
+	genesis, err := readGenesis(genesisReader)
+	maybeFail(err, h.Log, "readGenesis() error")
+
+	_, err = EnsureInitialImport(db, genesis, h.Log)
 	maybeFail(err, h.Log, "EnsureInitialImport() error")
+
 	imp := NewImporter(db)
 	blocks := 0
 	txCount := 0
@@ -188,29 +205,15 @@ func importFile(fname string, imp Importer, l *log.Logger, genesisPath string) (
 	return
 }
 
-func loadGenesis(db idb.IndexerDb, in io.Reader) (err error) {
-	var genesis bookkeeping.Genesis
-	gbytes, err := ioutil.ReadAll(in)
-	if err != nil {
-		return fmt.Errorf("error reading genesis, %v", err)
-	}
-	err = protocol.DecodeJSON(gbytes, &genesis)
-	if err != nil {
-		return fmt.Errorf("error decoding genesis, %v", err)
-	}
-
-	return db.LoadGenesis(genesis)
-}
-
 // EnsureInitialImport imports the genesis block if needed. Returns true if the initial import occurred.
-func EnsureInitialImport(db idb.IndexerDb, genesisReader io.Reader, l *log.Logger) (bool, error) {
+func EnsureInitialImport(db idb.IndexerDb, genesis bookkeeping.Genesis, l *log.Logger) (bool, error) {
 	_, err := db.GetNextRoundToAccount()
 	// Exit immediately or crash if we don't see ErrorNotInitialized.
 	if err != idb.ErrorNotInitialized {
 		if err != nil {
 			return false, fmt.Errorf("getting import state, %v", err)
 		}
-		err = checkGenesisHash(db, genesisReader)
+		err = checkGenesisHash(db, genesis)
 		if err != nil {
 			return false, err
 		}
@@ -218,7 +221,7 @@ func EnsureInitialImport(db idb.IndexerDb, genesisReader io.Reader, l *log.Logge
 	}
 
 	// Import genesis file from file or algod.
-	err = loadGenesis(db, genesisReader)
+	err = db.LoadGenesis(genesis)
 	if err != nil {
 		return false, fmt.Errorf("could not load genesis json, %v", err)
 	}
@@ -280,19 +283,11 @@ func GetGenesisFile(genesisJSONPath string, client *algod.Client, l *log.Logger)
 	} else {
 		l.Fatal("Neither genesis file path or algod client provided for initial import.")
 	}
+
 	return genesisReader
 }
 
-func checkGenesisHash(db idb.IndexerDb, genesisReader io.Reader) error {
-	var genesis bookkeeping.Genesis
-	gbytes, err := ioutil.ReadAll(genesisReader)
-	if err != nil {
-		return fmt.Errorf("error reading genesis, %w", err)
-	}
-	err = protocol.DecodeJSON(gbytes, &genesis)
-	if err != nil {
-		return fmt.Errorf("error decoding genesis, %w", err)
-	}
+func checkGenesisHash(db idb.IndexerDb, genesis bookkeeping.Genesis) error {
 	network, err := db.GetNetworkState()
 	if errors.Is(err, idb.ErrorNotInitialized) {
 		err = db.SetNetworkState(genesis)

--- a/migrations/local_ledger/internal/catchupservice.go
+++ b/migrations/local_ledger/internal/catchupservice.go
@@ -1,0 +1,112 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/algorand/go-algorand/catchup"
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/network"
+
+	"github.com/algorand/indexer/util"
+)
+
+// makeNodeProvider initializes the node provider.
+func makeNodeProvider(ctx context.Context) nodeProvider {
+	return nodeProvider{
+		ctx: ctx,
+	}
+}
+
+// nodeProvider implements two services required to start the catchpoint catchup service.
+type nodeProvider struct {
+	ctx context.Context
+}
+
+// IsParticipating is from the NodeInfo interface used by the WebsocketNetwork
+// in order to determine which gossip messages to subscribe to.
+func (n nodeProvider) IsParticipating() bool {
+	return false
+}
+
+// SetCatchpointCatchupMode is a callback provided by the catchpoint catchup
+// service which notifies listeners that the catchup mode is changing. The
+// context channel is used to to stop the catchpoint service, or if the channel
+// is closed, indicate that the listener is stopping.
+func (n nodeProvider) SetCatchpointCatchupMode(enabled bool) (newContextCh <-chan context.Context) {
+	ch := make(chan context.Context)
+	go func() {
+		if enabled {
+			ch <- n.ctx
+		}
+	}()
+	return ch
+}
+
+func CatchupServiceCatchup(logger *log.Logger, round basics.Round, catchpoint, dataDir string, genesis bookkeeping.Genesis) error {
+	start := time.Now()
+	ctx := context.Background()
+	cfg := config.AutogenLocal
+
+	node := makeNodeProvider(ctx)
+	//l, err := MakeLedger(rootDir, genesis)
+	l, err := util.MakeLedger(logger, &genesis, dataDir)
+	if err != nil {
+		return fmt.Errorf("CatchupServiceCatchup() MakeLedger err: %w", err)
+	}
+
+	wrappedLogger := logging.NewLogger()
+	// TODO: Use new wrapped logger
+	//wrappedLogger := logging.NewWrappedLogger(logger)
+	p2pNode, err := network.NewWebsocketNetwork(wrappedLogger, cfg, nil, genesis.ID(), genesis.Network, node)
+	if err != nil {
+		return fmt.Errorf("CatchupServiceCatchup() NewWebsocketNetwork err: %w", err)
+	}
+	// TODO: Do we need to implement the peer prioritization interface?
+	//p2pNode.SetPrioScheme(node)
+	p2pNode.Start()
+
+	service, err := catchup.MakeNewCatchpointCatchupService(
+		catchpoint,
+		node,
+		wrappedLogger,
+		p2pNode,
+		l,
+		cfg,
+	)
+	if err != nil {
+		return fmt.Errorf("CatchupServiceCatchup() MakeNewCatchpointCatchupService err: %w", err)
+	}
+
+	time.Sleep(5 * time.Second)
+	service.Start(ctx)
+
+	running := true
+	for running {
+		//time.Sleep(5 * time.Second)
+		stats := service.GetStatistics()
+		/*
+			fmt.Println("==========================")
+			fmt.Printf("Time:               %s\n", time.Now())
+			fmt.Printf("Ledger:             %d\n", l.Latest())
+			fmt.Printf("Processed Accounts: %d / %d\n", stats.ProcessedAccounts, stats.TotalAccounts)
+			fmt.Printf("Verified Accounts:  %d / %d\n", stats.VerifiedAccounts, stats.TotalAccounts)
+			fmt.Printf("Aquired Blocks:     %d / %d\n", stats.AcquiredBlocks, stats.TotalBlocks)
+			fmt.Printf("Verified Blocks:    %d / %d\n", stats.VerifiedBlocks, stats.TotalBlocks)
+		*/
+		running = stats.TotalBlocks == 0 || stats.TotalBlocks != stats.VerifiedBlocks
+	}
+
+	fmt.Printf("Done after: %s\n", time.Since(start))
+	writing := time.Now()
+	l.WaitForCommit(l.Latest())
+	fmt.Printf("Done after: %s\n", time.Since(start))
+	fmt.Printf("Write duration: %s\n", time.Since(writing))
+	return nil
+}

--- a/migrations/local_ledger/migration.go
+++ b/migrations/local_ledger/migration.go
@@ -27,8 +27,7 @@ import (
 )
 
 // RunMigrationSimple executes the migration core functionality.
-func RunMigrationSimple(round uint64, opts *idb.IndexerDbOptions) error {
-	logger := log.New()
+func RunMigrationSimple(logger *log.Logger, round uint64, opts *idb.IndexerDbOptions) error {
 	ctx, cf := context.WithCancel(context.Background())
 	defer cf()
 	{
@@ -59,7 +58,7 @@ func RunMigrationSimple(round uint64, opts *idb.IndexerDbOptions) error {
 		return fmt.Errorf("RunMigrationSimple() err: %w", err)
 	}
 
-	proc, err := blockprocessor.MakeProcessor(&genesis, round, opts.IndexerDatadir, nil)
+	proc, err := blockprocessor.MakeProcessor(logger, &genesis, round, opts.IndexerDatadir, nil)
 	if err != nil {
 		return fmt.Errorf("RunMigration() err: %w", err)
 	}

--- a/processor/blockprocessor/block_processor.go
+++ b/processor/blockprocessor/block_processor.go
@@ -2,8 +2,6 @@ package blockprocessor
 
 import (
 	"fmt"
-	"path/filepath"
-
 	log "github.com/sirupsen/logrus"
 
 	"github.com/algorand/go-algorand/config"
@@ -19,8 +17,6 @@ import (
 	indexerledger "github.com/algorand/indexer/processor/eval"
 	"github.com/algorand/indexer/util"
 )
-
-const prefix = "ledger"
 
 type blockProcessor struct {
 	handler func(block *ledgercore.ValidatedBlock) error
@@ -41,7 +37,7 @@ func MakeProcessorWithLedger(l *ledger.Ledger, handler func(block *ledgercore.Va
 
 // MakeProcessor creates a block processor
 func MakeProcessor(logger *log.Logger, genesis *bookkeeping.Genesis, dbRound uint64, datadir string, handler func(block *ledgercore.ValidatedBlock) error) (processor.Processor, error) {
-	l, err := util.MakeLedger(logger, genesis, filepath.Join(datadir, prefix))
+	l, err := util.MakeLedger(logger, genesis, datadir)
 	if err != nil {
 		return nil, fmt.Errorf("MakeProcessor() err: %w", err)
 	}

--- a/processor/blockprocessor/block_processor.go
+++ b/processor/blockprocessor/block_processor.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 	"path/filepath"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/algorand/go-algorand/config"
-	algodConfig "github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
-	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/rpcs"
+
 	"github.com/algorand/indexer/accounting"
 	"github.com/algorand/indexer/processor"
 	indexerledger "github.com/algorand/indexer/processor/eval"
@@ -39,12 +40,8 @@ func MakeProcessorWithLedger(l *ledger.Ledger, handler func(block *ledgercore.Va
 }
 
 // MakeProcessor creates a block processor
-func MakeProcessor(genesis *bookkeeping.Genesis, dbRound uint64, datadir string, handler func(block *ledgercore.ValidatedBlock) error) (processor.Processor, error) {
-	initState, err := util.CreateInitState(genesis)
-	if err != nil {
-		return nil, fmt.Errorf("MakeProcessor() err: %w", err)
-	}
-	l, err := ledger.OpenLedger(logging.NewLogger(), filepath.Join(datadir, prefix), false, initState, algodConfig.GetDefaultLocal())
+func MakeProcessor(logger *log.Logger, genesis *bookkeeping.Genesis, dbRound uint64, datadir string, handler func(block *ledgercore.ValidatedBlock) error) (processor.Processor, error) {
+	l, err := util.MakeLedger(logger, genesis, filepath.Join(datadir, prefix))
 	if err != nil {
 		return nil, fmt.Errorf("MakeProcessor() err: %w", err)
 	}

--- a/util/ledger_util.go
+++ b/util/ledger_util.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+
+	algodConfig "github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/ledger"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
+	"github.com/algorand/go-algorand/logging"
+)
+
+// CreateInitState makes an initState
+func CreateInitState(genesis *bookkeeping.Genesis) (ledgercore.InitState, error) {
+	balances, err := genesis.Balances()
+	if err != nil {
+		return ledgercore.InitState{}, fmt.Errorf("MakeProcessor() err: %w", err)
+	}
+	genesisBlock, err := bookkeeping.MakeGenesisBlock(genesis.Proto, balances, genesis.ID(), genesis.Hash())
+	if err != nil {
+		return ledgercore.InitState{}, fmt.Errorf("MakeProcessor() err: %w", err)
+	}
+
+	accounts := make(map[basics.Address]basics.AccountData)
+	for _, alloc := range genesis.Allocation {
+		address, err := basics.UnmarshalChecksumAddress(alloc.Address)
+		if err != nil {
+			return ledgercore.InitState{}, fmt.Errorf("openLedger() decode address err: %w", err)
+		}
+		accounts[address] = alloc.State
+	}
+	initState := ledgercore.InitState{
+		Block:       genesisBlock,
+		Accounts:    accounts,
+		GenesisHash: genesisBlock.GenesisHash(),
+	}
+	return initState, nil
+}
+
+func MakeLedger(logger *log.Logger, genesis *bookkeeping.Genesis, dbPrefix string) (*ledger.Ledger, error) {
+	initState, err := CreateInitState(genesis)
+	if err != nil {
+		return nil, fmt.Errorf("MakeProcessor() err: %w", err)
+	}
+	return ledger.OpenLedger(logging.NewLogger(), dbPrefix, false, initState, algodConfig.GetDefaultLocal())
+
+	// TODO: Adding a new logger constructor to go-algorand so that we can wrap the indexer logger.
+	//return ledger.OpenLedger(logging.NewWrappedLogger(logger), dbPrefix, false, initState, algodConfig.GetDefaultLocal())
+}

--- a/util/ledger_util.go
+++ b/util/ledger_util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 
@@ -40,7 +41,9 @@ func CreateInitState(genesis *bookkeeping.Genesis) (ledgercore.InitState, error)
 	return initState, nil
 }
 
-func MakeLedger(logger *log.Logger, genesis *bookkeeping.Genesis, dbPrefix string) (*ledger.Ledger, error) {
+func MakeLedger(logger *log.Logger, genesis *bookkeeping.Genesis, dataDir string) (*ledger.Ledger, error) {
+	const prefix = "ledger"
+	dbPrefix := filepath.Join(dataDir, prefix)
 	initState, err := CreateInitState(genesis)
 	if err != nil {
 		return nil, fmt.Errorf("MakeProcessor() err: %w", err)

--- a/util/util.go
+++ b/util/util.go
@@ -7,9 +7,6 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/algorand/go-algorand/data/basics"
-	"github.com/algorand/go-algorand/data/bookkeeping"
-	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-codec/codec"
 )
 
@@ -54,33 +51,6 @@ func JSONOneLine(obj interface{}) string {
 	enc := codec.NewEncoderBytes(&b, oneLineJSONCodecHandle)
 	enc.MustEncode(obj)
 	return string(b)
-}
-
-// CreateInitState makes an initState
-func CreateInitState(genesis *bookkeeping.Genesis) (ledgercore.InitState, error) {
-	balances, err := genesis.Balances()
-	if err != nil {
-		return ledgercore.InitState{}, fmt.Errorf("MakeProcessor() err: %w", err)
-	}
-	genesisBlock, err := bookkeeping.MakeGenesisBlock(genesis.Proto, balances, genesis.ID(), genesis.Hash())
-	if err != nil {
-		return ledgercore.InitState{}, fmt.Errorf("MakeProcessor() err: %w", err)
-	}
-
-	accounts := make(map[basics.Address]basics.AccountData)
-	for _, alloc := range genesis.Allocation {
-		address, err := basics.UnmarshalChecksumAddress(alloc.Address)
-		if err != nil {
-			return ledgercore.InitState{}, fmt.Errorf("openLedger() decode address err: %w", err)
-		}
-		accounts[address] = alloc.State
-	}
-	initState := ledgercore.InitState{
-		Block:       genesisBlock,
-		Accounts:    accounts,
-		GenesisHash: genesisBlock.GenesisHash(),
-	}
-	return initState, nil
 }
 
 func init() {


### PR DESCRIPTION
## Summary

Minor refactoring:
* cleanup genesis file access.
* put node catchup into a function that can be swapped out with the catchup service.
* pass the indexer logger into the block processor.
* move open ledger into a util function, and move the initial state util function into a new ledger util file.
* add initial catchupservice implementation.

## Test Plan


