### PR TITLE
Bugfix: Correctly auto loads config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,18 @@ You should use a process manager, like systemd, to ensure the daemon is always r
 
 To start indexer as a daemon in update mode, provide the required fields:
 ```
-~$ algorand-indexer daemon --algod-net yournode.com:1234 --algod-token token --genesis ~/path/to/genesis.json  --postgres "user=readonly password=YourPasswordHere {other connection string options for your database}"
+~$ algorand-indexer daemon --data-dir /tmp --algod-net yournode.com:1234 --algod-token token --genesis ~/path/to/genesis.json  --postgres "user=readonly password=YourPasswordHere {other connection string options for your database}"
 ```
 
 Alternatively if indexer is running on the same host as the archival node, a simplified command may be used:
 ```
-~$ algorand-indexer daemon --algod-net yournode.com:1234 -d /path/to/algod/data/dir --postgres "user=readonly password=YourPasswordHere {other connection string options for your database}"
+~$ algorand-indexer daemon --data-dir /tmp --algod-net yournode.com:1234 -d /path/to/algod/data/dir --postgres "user=readonly password=YourPasswordHere {other connection string options for your database}"
 ```
 
 ### Read only
 It is possible to set up one daemon as a writer and one or more readers. The Indexer pulling new data from algod can be started as above. Starting the indexer daemon without $ALGORAND_DATA or -d/--algod/--algod-net/--algod-token will start it without writing new data to the database. For further isolation, a `readonly` user can be created for the database.
 ```
-~$ algorand-indexer daemon --no-algod --postgres "user=readonly password=YourPasswordHere {other connection string options for your database}"
+~$ algorand-indexer daemon --data-dir /tmp --no-algod --postgres "user=readonly password=YourPasswordHere {other connection string options for your database}"
 ```
 
 The Postgres backend does specifically note the username "readonly" and changes behavior to avoid writing to the database. But the primary benefit is that Postgres can enforce restricted access to this user. This can be configured with:
@@ -203,7 +203,7 @@ Settings can be provided from the command line, a configuration file, or an envi
 The command line arguments always take priority over the config file and environment variables.
 
 ```
-~$ ./algorand-indexer daemon --pidfile /var/lib/algorand/algorand-indexer.pid --algod /var/lib/algorand --postgres "host=mydb.mycloud.com user=postgres password=password dbname=mainnet"`
+~$ ./algorand-indexer daemon --data-dir /tmp --pidfile /var/lib/algorand/algorand-indexer.pid --algod /var/lib/algorand --postgres "host=mydb.mycloud.com user=postgres password=password dbname=mainnet"`
 ```
 
 ## Data Directory
@@ -233,6 +233,7 @@ The same indexer configuration from earlier can be made in bash with the followi
 ~$ export INDEXER_POSTGRES_CONNECTION_STRING="host=mydb.mycloud.com user=postgres password=password dbname=mainnet"
 ~$ export INDEXER_PIDFILE="/var/lib/algorand/algorand-indexer.pid"
 ~$ export INDEXER_ALGOD_DATA_DIR="/var/lib/algorand"
+~$ export INDEXER_DATA="/tmp"
 ~$ ./algorand-indexer daemon
 ```
 
@@ -262,7 +263,7 @@ Place this file in the data directory (`/tmp/data-dir` in this example) and supp
 ```
 [Service]
 ExecStart=
-ExecStart=/usr/bin/algorand-indexer daemon --pidfile /var/lib/algorand/algorand-indexer.pid --algod /var/lib/algorand --postgres "host=mydb.mycloud.com user=postgres password=password dbname=mainnet"
+ExecStart=/usr/bin/algorand-indexer daemon --data-dir /tmp --pidfile /var/lib/algorand/algorand-indexer.pid --algod /var/lib/algorand --postgres "host=mydb.mycloud.com user=postgres password=password dbname=mainnet"
 PIDFile=/var/lib/algorand/algorand-indexer.pid
 
 ```

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -94,19 +94,21 @@ var daemonCmd = &cobra.Command{
 				panic(exit{1})
 			}
 
-			configToLoad := filepath.Join(indexerDataDir, autoLoadIndexerConfigName)
-			fmt.Printf("Auto-loading indexer configuration file: %s\n", configToLoad)
+			configFile = filepath.Join(indexerDataDir, autoLoadIndexerConfigName)
+			fmt.Printf("Auto-loading indexer configuration found: %s\n", configFile)
+		}
 
-			// No config file supplied via command line, auto-load it
-			configs, err := os.Open(configToLoad)
+		if configFile != "" {
+			configs, err := os.Open(configFile)
 			if err != nil {
-				maybeFail(err, "error with config file (%s): %v", configToLoad, err)
+				maybeFail(err, "error with config file (%s): %v", configFile, err)
 			}
 			defer configs.Close()
 			err = viper.ReadConfig(configs)
 			if err != nil {
 				maybeFail(err, "invalid config file (%s): %v", viper.ConfigFileUsed(), err)
 			}
+			fmt.Printf("Using configuration file: %s\n", configFile)
 		}
 
 		if paramConfigFound {
@@ -145,19 +147,6 @@ var daemonCmd = &cobra.Command{
 			err = pprof.StartCPUProfile(profFile)
 			maybeFail(err, "%s: start pprof, %v", cpuProfile, err)
 			defer pprof.StopCPUProfile()
-		}
-
-		if configFile != "" {
-			configs, err := os.Open(configFile)
-			if err != nil {
-				maybeFail(err, "%v", err)
-			}
-			defer configs.Close()
-			err = viper.ReadConfig(configs)
-			if err != nil {
-				maybeFail(err, "invalid config file (%s): %v", viper.ConfigFileUsed(), err)
-			}
-			fmt.Printf("Using configuration file: %s\n", configFile)
 		}
 
 		// If someone supplied a configuration file but also said to enable all parameters,

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -93,10 +93,14 @@ var daemonCmd = &cobra.Command{
 					filepath.Join(indexerDataDir, autoLoadIndexerConfigName))
 				panic(exit{1})
 			}
+
+			configToLoad := filepath.Join(indexerDataDir, autoLoadIndexerConfigName)
+			fmt.Printf("Auto-loading indexer configuration file: %s\n", configToLoad)
+
 			// No config file supplied via command line, auto-load it
-			configs, err := os.Open(configFile)
+			configs, err := os.Open(configToLoad)
 			if err != nil {
-				maybeFail(err, "%v", err)
+				maybeFail(err, "error with config file (%s): %v", configToLoad, err)
 			}
 			defer configs.Close()
 			err = viper.ReadConfig(configs)


### PR DESCRIPTION
Resolves #1052

Correctly loads the auto-loading configuration and fixes some README
lines to make data-dir more prominent

The following has been done to test this:

Create a file `/tmp/indexer/indexer.yml` and put in it:

```
postgres-connection-string: ""
server-address: ":8980"
noalgod: true
metrics-mode: "ON"
```

Run a local node and issue the following commands validating that the autoloading config is used:

`./algorand-indexer daemon -i /tmp/indexer`
`export INDEXER_DATA=/tmp/indexer; ./algorand-indexer daemon -i /tmp/indexer`

Additionally, specify a new directory and make sure that the right config is loaded and the directory is created:
`./algorand-indexer daemon -i /tmp/test -c /tmp/indexer/indexer.yml`
