### PR TITLE
Block fetcher: catchup without algod

### DIFF
--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -362,18 +362,15 @@ func blockHandler(imp importer.Importer, retryDelay time.Duration) func(context.
 	return func(ctx context.Context, block *rpcs.EncodedBlockCert) error {
 		for {
 			err := handleBlock(block, imp)
-			if err == nil {
-				// return on success.
-				return nil
-			}
+			return err
 
-			// Delay or terminate before next attempt.
-			select {
-			case <-ctx.Done():
-				return err
-			case <-time.After(retryDelay):
-				break
-			}
+			// // Delay or terminate before next attempt.
+			// select {
+			// case <-ctx.Done():
+			// 	return err
+			// case <-time.After(retryDelay):
+			// 	break
+			// }
 		}
 	}
 }

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -381,15 +381,18 @@ func blockHandler(imp importer.Importer, retryDelay time.Duration) func(context.
 	return func(ctx context.Context, block *rpcs.EncodedBlockCert) error {
 		for {
 			err := handleBlock(block, imp)
-			return err
+			if err == nil {
+				// return on success.
+				return nil
+			}
 
-			// // Delay or terminate before next attempt.
-			// select {
-			// case <-ctx.Done():
-			// 	return err
-			// case <-time.After(retryDelay):
-			// 	break
-			// }
+			// Delay or terminate before next attempt.
+			select {
+			case <-ctx.Done():
+				return err
+			case <-time.After(retryDelay):
+				break
+			}
 		}
 	}
 }

--- a/fetcher/catchupservice.go
+++ b/fetcher/catchupservice.go
@@ -3,6 +3,9 @@ package fetcher
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
+	"time"
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"
@@ -10,6 +13,8 @@ import (
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/network"
+	"github.com/algorand/go-algorand/rpcs"
+	"github.com/algorand/indexer/util/metrics"
 	"github.com/labstack/gommon/log"
 )
 
@@ -33,6 +38,8 @@ type nodeInfo struct {
 	ctx context.Context
 }
 
+type task func() basics.Round
+
 func (n nodeInfo) IsParticipating() bool { return false }
 
 // MakeCatchupService creats a catchup service and initialzes a gossipnode
@@ -44,6 +51,125 @@ func MakeCatchupService(genesis bookkeeping.Genesis, ctx context.Context) (servi
 	nodeinfo := makeNodeInfo(ctx)
 	serviceDr.net, _ = network.NewWebsocketNetwork(serviceDr.log, serviceDr.cfg, nil, genesis.ID(), genesis.Network, nodeinfo)
 	return serviceDr
+}
+
+func (s *catchupService) pipelineCallback(r basics.Round, thisFetchComplete chan bool, prevFetchCompleteChan chan bool, lookbackChan chan bool, bot *fetcherImpl, ctx context.Context) func() basics.Round {
+	return func() basics.Round {
+		psp, _ := s.peerSelector.getNextPeer()
+		for {
+			start := time.Now()
+			if psp.Peer == nil {
+				psp, _ = s.peerSelector.getNextPeer()
+			} else {
+				blk, cert, err1 := s.directNetworkFetch(ctx, uint64(r), psp, psp.Peer)
+				if err1 != nil {
+					psp, _ = s.peerSelector.getNextPeer()
+					// If context has expired.
+					if ctx.Err() != nil {
+						return 0
+					}
+				} else if uint64(blk.Round()) == uint64(r) {
+					block := new(rpcs.EncodedBlockCert)
+					block.Block = *blk
+					block.Certificate = *cert
+					select {
+					case <-ctx.Done():
+						return 0
+					case prevFetchSuccess := <-prevFetchCompleteChan:
+						if prevFetchSuccess {
+							bot.blockQueue <- block
+							thisFetchComplete <- true
+							thisFetchComplete <- true
+							bot.nextRound++
+							dt := time.Since(start)
+							metrics.GetAlgodRawBlockTimeSeconds.Observe(dt.Seconds())
+							// If we successfully handle the block, clear out any transient error which may have occurred.
+							bot.setError(nil)
+							bot.failingSince = time.Time{}
+							return r
+						}
+						thisFetchComplete <- false
+						thisFetchComplete <- false
+						return 0
+					}
+				}
+			}
+		}
+	}
+}
+
+// parallelization attempt
+func (s *catchupService) pipelinedFetch(seedLookback uint64, bot *fetcherImpl, ctx context.Context) error {
+	var err error
+	s.peerSelector = s.createPeerSelector(true)
+	if _, err := s.peerSelector.getNextPeer(); err != nil {
+		fmt.Println(err)
+	}
+
+	// pipeline fetch code
+	parallelRequests := uint64(32)
+
+	completed := make(chan basics.Round, parallelRequests)
+	taskCh := make(chan task, parallelRequests)
+	var wg sync.WaitGroup
+
+	defer func() {
+		close(taskCh)
+		wg.Wait()
+		close(completed)
+	}()
+
+	wg.Add(int(parallelRequests))
+	for i := uint64(0); i < parallelRequests; i++ {
+		go func() {
+			defer wg.Done()
+			for t := range taskCh {
+				completed <- t() // This write to completed comes after a read from taskCh, so the invariant is preserved.
+			}
+		}()
+	}
+
+	recentReqs := make([]chan bool, 0)
+	for i := 0; i < int(seedLookback); i++ {
+		// the fetch result will be read at most twice (once as the lookback block and once as the prev block, so we write the result twice)
+		reqComplete := make(chan bool, 2)
+		reqComplete <- true
+		reqComplete <- true
+		recentReqs = append(recentReqs, reqComplete)
+	}
+	from := basics.Round(bot.nextRound)
+	nextRound := from
+	// loop to catchup
+	for ; nextRound < from+basics.Round(parallelRequests); nextRound++ {
+		currentRoundComplete := make(chan bool, 2)
+		// len(taskCh) + (# pending writes to completed) increases by 1
+		taskCh <- s.pipelineCallback(nextRound, currentRoundComplete, recentReqs[len(recentReqs)-1], recentReqs[len(recentReqs)-int(seedLookback)], bot, ctx)
+		recentReqs = append(recentReqs[1:], currentRoundComplete)
+	}
+	completedRounds := make(map[basics.Round]bool)
+	for {
+		select {
+		case round := <-completed:
+			if round == 0 {
+				// there was an error
+				return err
+			}
+			completedRounds[round] = true
+			// keep checking if the round has been sent to completed channel, thereby updating completedRounds
+			// keep incrementing nextRound until to find a false or not existing nextRound-parallelRequests Since that-
+			// -round has not been registered into completedRounds yet!
+			for completedRounds[nextRound-basics.Round(parallelRequests)] {
+				delete(completedRounds, nextRound)
+				currentRoundComplete := make(chan bool, 2)
+				// len(taskCh) + (# pending writes to completed) increases by 1
+				taskCh <- s.pipelineCallback(nextRound, currentRoundComplete, recentReqs[len(recentReqs)-1], recentReqs[0], bot, ctx)
+				recentReqs = append(recentReqs[1:], currentRoundComplete)
+				nextRound++
+			}
+		case <-ctx.Done():
+			return err
+		}
+	}
 }
 
 func (s *catchupService) createPeerSelector(pipelineFetch bool) *peerSelector {
@@ -125,7 +251,6 @@ func (s *catchupService) directNetworkFetch(ctx context.Context, rnd uint64, psp
 		if _, ok := config.Consensus[blk.BlockHeader.CurrentProtocol]; !ok {
 			log.Errorf("fetchAndWrite(%v): unsupported protocol version detected: '%v'", rnd, blk.BlockHeader.CurrentProtocol)
 		}
-
 		log.Warnf("fetchAndWrite(%v): block contents do not match header (attempt %d)", rnd, 1)
 		// continue // retry the fetch: add a loop over here
 		err = errors.New("invalid block download")

--- a/fetcher/catchupservice.go
+++ b/fetcher/catchupservice.go
@@ -21,20 +21,21 @@ type catchupService struct {
 	peerSelector *peerSelector
 }
 
-// makeNodeInfo initializes the node provider.
+// makeNodeInfo initializes nodeInfo.
 func makeNodeInfo(ctx context.Context) nodeInfo {
 	return nodeInfo{
 		ctx: ctx,
 	}
 }
 
-// nodeInfo implements two services required to start the catchpoint catchup service.
+// nodeInfo has context and implements one service required to create a gossip node
 type nodeInfo struct {
 	ctx context.Context
 }
 
 func (n nodeInfo) IsParticipating() bool { return false }
 
+// MakeCatchupService creats a catchup service and initialzes a gossipnode
 func MakeCatchupService(genesis bookkeeping.Genesis, ctx context.Context) (serviceDr *catchupService) {
 	serviceDr = &catchupService{}
 	serviceDr.cfg = config.AutogenLocal
@@ -111,6 +112,7 @@ func (s *catchupService) createPeerSelector(pipelineFetch bool) *peerSelector {
 	return makePeerSelector(s.net, peerClasses)
 }
 
+// directNetworkFetch given a block number and peer, fetches the block from the network.
 func (s *catchupService) directNetworkFetch(ctx context.Context, rnd uint64, psp *peerSelectorPeer, peer network.Peer) (blk *bookkeeping.Block, cert *agreement.Certificate, err error) {
 	fetch := makeUniversalBlockFetcher(s.log, s.net, s.cfg)
 	blk, cert, _, err = fetch.fetchBlock(ctx, basics.Round(rnd), peer)

--- a/fetcher/catchupservice.go
+++ b/fetcher/catchupservice.go
@@ -1,0 +1,132 @@
+package fetcher
+
+import (
+	"context"
+	"errors"
+
+	"github.com/algorand/go-algorand/agreement"
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/network"
+	"github.com/labstack/gommon/log"
+)
+
+type catchupService struct {
+	net          network.GossipNode
+	log          logging.Logger
+	cfg          config.Local
+	genesis      bookkeeping.Genesis
+	peerSelector *peerSelector
+}
+
+// makeNodeInfo initializes the node provider.
+func makeNodeInfo(ctx context.Context) nodeInfo {
+	return nodeInfo{
+		ctx: ctx,
+	}
+}
+
+// nodeInfo implements two services required to start the catchpoint catchup service.
+type nodeInfo struct {
+	ctx context.Context
+}
+
+func (n nodeInfo) IsParticipating() bool { return false }
+
+func MakeCatchupService(genesis bookkeeping.Genesis, ctx context.Context) (serviceDr *catchupService) {
+	serviceDr = &catchupService{}
+	serviceDr.cfg = config.AutogenLocal
+	serviceDr.genesis = genesis
+	serviceDr.log = logging.NewLogger()
+	nodeinfo := makeNodeInfo(ctx)
+	serviceDr.net, _ = network.NewWebsocketNetwork(serviceDr.log, serviceDr.cfg, nil, genesis.ID(), genesis.Network, nodeinfo)
+	return serviceDr
+}
+
+func (s *catchupService) createPeerSelector(pipelineFetch bool) *peerSelector {
+	var peerClasses []peerClass
+	if s.cfg.EnableCatchupFromArchiveServers {
+		if pipelineFetch {
+			if s.cfg.NetAddress != "" { // Relay node
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookArchivers},
+					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
+					{initialRank: peerRankInitialFourthPriority, peerClass: network.PeersConnectedIn},
+				}
+			} else {
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersPhonebookArchivers},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
+				}
+			}
+		} else {
+			if s.cfg.NetAddress != "" { // Relay node
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersConnectedIn},
+					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
+					{initialRank: peerRankInitialFourthPriority, peerClass: network.PeersPhonebookArchivers},
+				}
+			} else {
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
+					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookArchivers},
+				}
+			}
+		}
+	} else {
+		if pipelineFetch {
+			if s.cfg.NetAddress != "" { // Relay node
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
+					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersConnectedIn},
+				}
+			} else {
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
+				}
+			}
+		} else {
+			if s.cfg.NetAddress != "" { // Relay node
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersConnectedIn},
+					{initialRank: peerRankInitialThirdPriority, peerClass: network.PeersPhonebookRelays},
+				}
+			} else {
+				peerClasses = []peerClass{
+					{initialRank: peerRankInitialFirstPriority, peerClass: network.PeersConnectedOut},
+					{initialRank: peerRankInitialSecondPriority, peerClass: network.PeersPhonebookRelays},
+				}
+			}
+		}
+	}
+	return makePeerSelector(s.net, peerClasses)
+}
+
+func (s *catchupService) directNetworkFetch(ctx context.Context, rnd uint64, psp *peerSelectorPeer, peer network.Peer) (blk *bookkeeping.Block, cert *agreement.Certificate, err error) {
+	fetch := makeUniversalBlockFetcher(s.log, s.net, s.cfg)
+	blk, cert, _, err = fetch.fetchBlock(ctx, basics.Round(rnd), peer)
+	// Check that the block's contents match the block header (necessary with an untrusted block because b.Hash() only hashes the header)
+	if blk == nil || cert == nil {
+		err = errors.New("invalid block download")
+	} else if !blk.ContentsMatchHeader() && blk.Round() > 0 {
+		s.peerSelector.rankPeer(psp, peerRankInvalidDownload)
+		// Check if this mismatch is due to an unsupported protocol version
+		if _, ok := config.Consensus[blk.BlockHeader.CurrentProtocol]; !ok {
+			log.Errorf("fetchAndWrite(%v): unsupported protocol version detected: '%v'", rnd, blk.BlockHeader.CurrentProtocol)
+		}
+
+		log.Warnf("fetchAndWrite(%v): block contents do not match header (attempt %d)", rnd, 1)
+		// continue // retry the fetch: add a loop over here
+		err = errors.New("invalid block download")
+	}
+	return
+}

--- a/fetcher/catchupservice.go
+++ b/fetcher/catchupservice.go
@@ -26,21 +26,7 @@ type CatchupService struct {
 	peerSelector *peerSelector
 }
 
-// nodeInfo has context and implements one service required to create a gossip node
-type nodeInfo struct {
-	ctx context.Context
-}
-
 type task func() basics.Round
-
-// makeNodeInfo initializes nodeInfo.
-func makeNodeInfo(ctx context.Context) nodeInfo {
-	return nodeInfo{
-		ctx: ctx,
-	}
-}
-
-func (n nodeInfo) IsParticipating() bool { return false }
 
 // MakeCatchupService creats a catchup service and initialzes a gossipnode
 func MakeCatchupService(ctx context.Context, genesis bookkeeping.Genesis) (s *CatchupService) {
@@ -49,8 +35,7 @@ func MakeCatchupService(ctx context.Context, genesis bookkeeping.Genesis) (s *Ca
 	s.cfg = config.AutogenLocal
 	s.genesis = genesis
 	s.log = logging.NewLogger()
-	nodeinfo := makeNodeInfo(ctx)
-	s.net, _ = network.NewWebsocketNetwork(s.log, s.cfg, nil, genesis.ID(), genesis.Network, nodeinfo)
+	s.net, _ = network.NewWebsocketNetwork(s.log, s.cfg, nil, genesis.ID(), genesis.Network, nil)
 
 	return s
 }

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -150,7 +150,7 @@ func (bot *fetcherImpl) catchupLoop(ctx context.Context) error {
 		// // making peerselector, makes sure that dns records are loaded
 		serviceDr.net.RequestConnectOutgoing(false, ctx.Done())
 
-		err = serviceDr.pipelinedFetch(ctx, uint64(2), bot)
+		err = serviceDr.PipelinedFetch(ctx, uint64(2), bot)
 		return err
 
 	}
@@ -182,7 +182,6 @@ func (bot *fetcherImpl) catchupLoop(ctx context.Context) error {
 		bot.nextRound++
 		bot.failingSince = time.Time{}
 	}
-
 }
 
 // wait for algod to notify of a new round, then fetch that block

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -51,11 +51,14 @@ type fetcherImpl struct {
 	// To improve performance, we fetch new blocks and call the block handler concurrently.
 	// This queue contains the blocks that have been fetched but haven't been given to
 	// the handler.
-	blockQueue  chan *rpcs.EncodedBlockCert
-	genesis     bookkeeping.Genesis
+	blockQueue chan *rpcs.EncodedBlockCert
+
+	// is true if blocks to be fetched from the network
 	directFetch bool
+	genesis     bookkeeping.Genesis
 }
 
+// SetDirectFetch initializes bot.genesis
 func SetDirectFetch(genesis bookkeeping.Genesis) (bot Fetcher, err error) {
 	bot = &fetcherImpl{genesis: genesis, directFetch: true}
 	return
@@ -83,6 +86,7 @@ func (bot *fetcherImpl) setError(err error) {
 }
 
 func (bot *fetcherImpl) processQueue(ctx context.Context) error {
+	// flags are used to error handle invalid blocks
 	flg := true
 	flg2 := true
 	prevsuccess := bot.nextRound - 1

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -137,16 +137,20 @@ func TestDirectCatchupService(t *testing.T) {
 
 	// making peerselector, makes sure that dns records are loaded
 	serviceDr.net.RequestConnectOutgoing(false, ctx.Done())
-	bot := &fetcherImpl{genesis: genesis, directFetch: true}
-	bot.nextRound = uint64(0)
-	bot.blockQueue = make(chan *rpcs.EncodedBlockCert, 5000)
-	go func() {
-		_ = serviceDr.PipelinedFetch(ctx, uint64(2), bot)
-	}()
-	for {
-		if bot.nextRound > uint64(10) {
-			f()
-			break
+	serviceDr.peerSelector = serviceDr.createPeerSelector(false)
+	if _, err := serviceDr.peerSelector.getNextPeer(); err == nil {
+		bot := &fetcherImpl{genesis: genesis, directFetch: true}
+		bot.nextRound = uint64(0)
+		bot.blockQueue = make(chan *rpcs.EncodedBlockCert, 5000)
+		go func() {
+			_ = serviceDr.PipelinedFetch(ctx, uint64(2), bot)
+		}()
+		for {
+			if bot.nextRound > uint64(10) {
+				f()
+				break
+			}
 		}
 	}
+	f()
 }

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -123,7 +123,7 @@ func TestFetcherImplCatchupLoopBlockError(t *testing.T) {
 
 func TestDirectCatchupService(t *testing.T) {
 	nextRound := uint64(0)
-	ctx, _ := context.WithCancel(context.Background())
+	ctx, f := context.WithCancel(context.Background())
 
 	// load genesis from disk
 	genesisFile := "/Users/ganesh/go-algorand/installer/genesis/mainnet/genesis.json"
@@ -158,4 +158,5 @@ func TestDirectCatchupService(t *testing.T) {
 			}
 		}
 	}
+	f()
 }

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -147,7 +147,7 @@ func TestDirectCatchupService(t *testing.T) {
 		if psp.Peer == nil {
 			psp, _ = serviceDr.peerSelector.getNextPeer()
 		} else {
-			blk, cert, err1 := serviceDr.directNetworkFetch(ctx, nextRound, psp, psp.Peer)
+			blk, cert, err1 := serviceDr.DirectNetworkFetch(ctx, nextRound, psp, psp.Peer)
 			if err1 != nil {
 				psp, _ = serviceDr.peerSelector.getNextPeer()
 			} else if uint64(blk.Round()) == nextRound {

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -132,7 +132,7 @@ func TestDirectCatchupService(t *testing.T) {
 	_ = protocol.DecodeJSON(genesisText, &genesis)
 
 	// make catchup service
-	serviceDr := MakeCatchupService(genesis, ctx)
+	serviceDr := MakeCatchupService(ctx, genesis)
 	serviceDr.net.Start()
 	serviceDr.cfg.NetAddress, _ = serviceDr.net.Address()
 

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -152,6 +152,6 @@ func TestDirectCatchupService(t *testing.T) {
 				}
 			}
 		}
-		f()
 	}
+	f()
 }

--- a/fetcher/peerSelector.go
+++ b/fetcher/peerSelector.go
@@ -1,0 +1,549 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package fetcher
+
+import (
+	"errors"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/algorand/go-deadlock"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/network"
+)
+
+const (
+	// peerRankInitialFirstPriority is the high-priority peers group ( typically, archivers )
+	peerRankInitialFirstPriority = 0
+	peerRank0LowBlockTime        = 1
+	peerRank0HighBlockTime       = 199
+
+	// peerRankInitialSecondPriority is the second priority peers group ( typically, relays )
+	peerRankInitialSecondPriority = 200
+	peerRank1LowBlockTime         = 201
+	peerRank1HighBlockTime        = 399
+
+	peerRankInitialThirdPriority = 400
+	peerRank2LowBlockTime        = 401
+	peerRank2HighBlockTime       = 599
+
+	peerRankInitialFourthPriority = 600
+	peerRank3LowBlockTime         = 601
+	peerRank3HighBlockTime        = 799
+
+	// peerRankDownloadFailed is used for responses which could be temporary, such as missing files, or such that we don't
+	// have clear resolution
+	peerRankDownloadFailed = 900
+	// peerRankInvalidDownload is used for responses which are likely to be invalid - whether it's serving the wrong content
+	// or attempting to serve malicious content
+	peerRankInvalidDownload = 1000
+
+	// once a block is downloaded, the download duration is clamped into the range of [lowBlockDownloadThreshold..highBlockDownloadThreshold] and
+	// then mapped into the a ranking range.
+	lowBlockDownloadThreshold  = 50 * time.Millisecond
+	highBlockDownloadThreshold = 8 * time.Second
+
+	// Is the lookback window size of peer usage statistics
+	peerHistoryWindowSize = 100
+)
+
+var errPeerSelectorNoPeerPoolsAvailable = errors.New("no peer pools available")
+
+// peerSelectorPeer is a peer wrapper, adding to it the peerClass information
+// There can be multiple peer elements with the same address but different peer classes, and it is important to distinguish between them.
+type peerSelectorPeer struct {
+	network.Peer
+	peerClass network.PeerOption
+}
+
+// peerClass defines the type of peer we want to have in a particular "class",
+// and define the network.PeerOption that would be used to retrieve that type of
+// peer
+type peerClass struct {
+	initialRank int
+	peerClass   network.PeerOption
+}
+
+// the peersRetriever is a subset of the network.GossipNode used to ensure that we can create an instance of the peerSelector
+// for testing purposes, providing just the above function.
+type peersRetriever interface {
+	// Get a list of Peers we could potentially send a direct message to.
+	GetPeers(options ...network.PeerOption) []network.Peer
+}
+
+// peerPoolEntry represents a single peer entry in the pool. It contains
+// the underlying network peer as well as the peer class.
+type peerPoolEntry struct {
+	peer    network.Peer
+	class   peerClass
+	history *historicStats
+}
+
+// peerPool is a single pool of peers that shares the same rank.
+type peerPool struct {
+	rank  int
+	peers []peerPoolEntry
+}
+
+// peerSelector is a helper struct used to select the next peer to try and connect to
+// for various catchup purposes. Unlike the underlying network GetPeers(), it allows the
+// client to provide feedback regarding the peer's performance, and to have the subsequent
+// query(s) take advantage of that intel.
+type peerSelector struct {
+	mu          deadlock.Mutex
+	net         peersRetriever
+	peerClasses []peerClass
+	pools       []peerPool
+	counter     uint64
+}
+
+// historicStats stores the past windowSize ranks for the peer passed
+// into RankPeer (i.e. no averaging or penalty). The purpose of this
+// structure is to compute the rank based on the performance of the
+// peer in the past, and to be forgiving of occasional performance
+// variations which may not be representative of the peer's overall
+// performance. It also stores the penalty history in the form or peer
+// selection gaps, and the count of peerRankDownloadFailed incidents.
+type historicStats struct {
+	windowSize       int
+	rankSamples      []int
+	rankSum          uint64
+	requestGaps      []uint64
+	gapSum           float64
+	counter          uint64
+	downloadFailures int
+}
+
+func makeHistoricStatus(windowSize int, class peerClass) *historicStats {
+	// Initialize the window (rankSamples) with zeros but rankSum with the equivalent sum of class initial rank.
+	// This way, every peer will slowly build up its profile.
+	// Otherwise, if the best peer gets a bad download the first time,
+	// that will determine the rank of the peer.
+	hs := historicStats{
+		windowSize:  windowSize,
+		rankSamples: make([]int, windowSize, windowSize),
+		requestGaps: make([]uint64, 0, windowSize),
+		rankSum:     uint64(class.initialRank) * uint64(windowSize),
+		gapSum:      0.0}
+	for i := 0; i < windowSize; i++ {
+		hs.rankSamples[i] = class.initialRank
+	}
+	return &hs
+}
+
+// computerPenalty is the formula (exponential) used to calculate the
+// penalty from the sum of gaps.
+func (hs *historicStats) computerPenalty() float64 {
+	return 1 + (math.Exp(hs.gapSum/10.0) / 1000)
+}
+
+// updateRequestPenalty is given a counter, which is the most recent
+// counter for ranking a peer. It calculates newGap, which is the
+// number of counter ticks since it last was updated (i.e. last ranked
+// after being selected). The number of gaps stored is bounded by the
+// windowSize. Calculates and returns the new penalty.
+func (hs *historicStats) updateRequestPenalty(counter uint64) float64 {
+	newGap := counter - hs.counter
+	hs.counter = counter
+
+	if len(hs.requestGaps) == hs.windowSize {
+		hs.gapSum -= 1.0 / float64(hs.requestGaps[0])
+		hs.requestGaps = hs.requestGaps[1:]
+	}
+
+	hs.requestGaps = append(hs.requestGaps, newGap)
+	hs.gapSum += 1.0 / float64(newGap)
+
+	return hs.computerPenalty()
+}
+
+// resetRequestPenalty removes steps least recent gaps and recomputes the new penalty.
+// Returns the new rank calculated with the new penalty.
+// If steps is 0, it is a full reset i.e. drops all gap values.
+func (hs *historicStats) resetRequestPenalty(steps int, initialRank int, class peerClass) (rank int) {
+	if len(hs.requestGaps) == 0 {
+		return initialRank
+	}
+	// resetRequestPenalty cannot move the peer to a better class if the peer was moved
+	// to a lower class (e.g. failed downloads or invalid downloads)
+	if upperBound(class) < initialRank {
+		return initialRank
+	}
+	// if setps is 0, it is a full reset
+	if steps == 0 {
+		hs.requestGaps = make([]uint64, 0, hs.windowSize)
+		hs.gapSum = 0.0
+		return int(float64(hs.rankSum) / float64(len(hs.rankSamples)))
+	}
+
+	if steps > len(hs.requestGaps) {
+		steps = len(hs.requestGaps)
+	}
+	for s := 0; s < steps; s++ {
+		hs.gapSum -= 1.0 / float64(hs.requestGaps[s])
+	}
+	hs.requestGaps = hs.requestGaps[steps:]
+	return boundRankByClass(int(hs.computerPenalty()*(float64(hs.rankSum)/float64(len(hs.rankSamples)))), class)
+}
+
+// push pushes a new rank to the historicStats, and returns the new
+// rank based on the average of ranks in the windowSize window and the
+// penlaty.
+func (hs *historicStats) push(value int, counter uint64, class peerClass) (averagedRank int) {
+
+	// This is the lowest ranking class, and is not subject to giving another chance.
+	// Do not modify this value with historical data.
+	if value == peerRankInvalidDownload {
+		return value
+	}
+
+	// This is a moving window. Remore the least recent value once the window is full
+	if len(hs.rankSamples) == hs.windowSize {
+		hs.rankSum -= uint64(hs.rankSamples[0])
+		hs.rankSamples = hs.rankSamples[1:]
+	}
+
+	initialRank := value
+
+	// Download may fail for various reasons. Give it additional tries
+	// and see if it recovers/improves.
+	if value == peerRankDownloadFailed {
+		hs.downloadFailures++
+		// - Set the rank to the class upper bound multiplied
+		//   by the number of downloadFailures.
+		// - Each downloadFailure increments the counter, and
+		//   each non-failure decrements it, until it gets to 0.
+		// - When the peer is consistently failing to
+		//   download, the value added to rankSum will
+		//   increase at an increasing rate to evict the peer
+		//   from the class sooner.
+		value = upperBound(class) * int(math.Exp2(float64(hs.downloadFailures)))
+	} else {
+		if hs.downloadFailures > 0 {
+			hs.downloadFailures--
+		}
+	}
+
+	hs.rankSamples = append(hs.rankSamples, value)
+	hs.rankSum += uint64(value)
+
+	// The average performance of the peer
+	average := float64(hs.rankSum) / float64(len(hs.rankSamples))
+
+	if int(average) > upperBound(class) && initialRank == peerRankDownloadFailed {
+		// peerRankDownloadFailed will be delayed, to give the peer
+		// additional time to improve. If does not improve over time,
+		// the average will exceed the class limit. At this point,
+		// it will be pushed down to download failed class.
+		return peerRankDownloadFailed
+	}
+
+	// A penalty is added relative to how freequently the peer is used
+	penalty := hs.updateRequestPenalty(counter)
+
+	// The rank based on the performance and the freequency
+	avgWithPenalty := int(penalty * average)
+
+	// Keep the peer in the same class. The value passed will be
+	// within bounds (unless it is downloadFailed or
+	// invalidDownload), but the penalty may push it over. Prevent
+	// the penalty pushing it off the class bounds.
+	bounded := boundRankByClass(avgWithPenalty, class)
+	return bounded
+}
+
+// makePeerSelector creates a peerSelector, given a peersRetriever and peerClass array.
+func makePeerSelector(net peersRetriever, initialPeersClasses []peerClass) *peerSelector {
+	selector := &peerSelector{
+		net:         net,
+		peerClasses: initialPeersClasses,
+	}
+	return selector
+}
+
+// getNextPeer returns the next peer. It randomally selects a peer from a pool that has
+// the lowest rank value. Given that the peers are grouped by their ranks, allow us to
+// prioritize peers based on their class and/or performance.
+func (ps *peerSelector) getNextPeer() (psp *peerSelectorPeer, err error) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	ps.refreshAvailablePeers()
+	for _, pool := range ps.pools {
+		if len(pool.peers) > 0 {
+			// the previous call to refreshAvailablePeers ensure that this would always be the case;
+			// however, if we do have a zero length pool, we don't want to divide by zero, so this would
+			// provide the needed test.
+			// pick one of the peers from this pool at random
+			peerIdx := crypto.RandUint64() % uint64(len(pool.peers))
+			psp = &peerSelectorPeer{pool.peers[peerIdx].peer, pool.peers[peerIdx].class.peerClass}
+			return
+		}
+	}
+	return nil, errPeerSelectorNoPeerPoolsAvailable
+}
+
+// rankPeer ranks a given peer.
+// return the old value and the new updated value.
+// updated value could be different from the input rank.
+func (ps *peerSelector) rankPeer(psp *peerSelectorPeer, rank int) (int, int) {
+	if psp == nil {
+		return -1, -1
+	}
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	poolIdx, peerIdx := ps.findPeer(psp)
+	if poolIdx < 0 || peerIdx < 0 {
+		return -1, -1
+	}
+	sortNeeded := false
+
+	// we need to remove the peer from the pool so we can place it in a different location.
+	pool := ps.pools[poolIdx]
+	ps.counter++
+	initialRank := pool.rank
+	rank = pool.peers[peerIdx].history.push(rank, ps.counter, pool.peers[peerIdx].class)
+	if pool.rank != rank {
+		class := pool.peers[peerIdx].class
+		peerHistory := pool.peers[peerIdx].history
+		if len(pool.peers) > 1 {
+			pool.peers = append(pool.peers[:peerIdx], pool.peers[peerIdx+1:]...)
+			ps.pools[poolIdx] = pool
+		} else {
+			// the last peer was removed from the pool; delete this pool.
+			ps.pools = append(ps.pools[:poolIdx], ps.pools[poolIdx+1:]...)
+		}
+
+		sortNeeded = ps.addToPool(psp.Peer, rank, class, peerHistory)
+	}
+
+	// Update the ranks of the peers by reducing the penalty for not being selected
+	for pl := len(ps.pools) - 1; pl >= 0; pl-- {
+		pool := ps.pools[pl]
+		for pr := len(pool.peers) - 1; pr >= 0; pr-- {
+			localPeer := pool.peers[pr]
+			if pool.peers[pr].peer == psp.Peer {
+				continue
+			}
+			// make the removal of penalty at a faster rate than adding it, so that the
+			// performance of the peer dominates in the evaluation over the freequency.
+			// Otherwise, the peer selection will oscillate between the good performing and
+			// a bad performing peers when sufficient penalty is accumulated to the good peer.
+			newRank := localPeer.history.resetRequestPenalty(5, pool.rank, pool.peers[pr].class)
+			if newRank != pool.rank {
+				upeer := pool.peers[pr].peer
+				class := pool.peers[pr].class
+				peerHistory := pool.peers[pr].history
+				if len(pool.peers) > 1 {
+					pool.peers = append(pool.peers[:pr], pool.peers[pr+1:]...)
+					ps.pools[pl] = pool
+				} else {
+					// the last peer was removed from the pool; delete this pool.
+					ps.pools = append(ps.pools[:pl], ps.pools[pl+1:]...)
+				}
+				sortNeeded = ps.addToPool(upeer, newRank, class, peerHistory) || sortNeeded
+			}
+		}
+	}
+	if sortNeeded {
+		ps.sort()
+	}
+	return initialRank, rank
+}
+
+// peerDownloadDurationToRank calculates the rank for a peer given a peer and the block download time.
+func (ps *peerSelector) peerDownloadDurationToRank(psp *peerSelectorPeer, blockDownloadDuration time.Duration) (rank int) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	poolIdx, peerIdx := ps.findPeer(psp)
+	if poolIdx < 0 || peerIdx < 0 {
+		return peerRankInvalidDownload
+	}
+
+	switch ps.pools[poolIdx].peers[peerIdx].class.initialRank {
+	case peerRankInitialFirstPriority:
+		return downloadDurationToRank(blockDownloadDuration, lowBlockDownloadThreshold, highBlockDownloadThreshold, peerRank0LowBlockTime, peerRank0HighBlockTime)
+	case peerRankInitialSecondPriority:
+		return downloadDurationToRank(blockDownloadDuration, lowBlockDownloadThreshold, highBlockDownloadThreshold, peerRank1LowBlockTime, peerRank1HighBlockTime)
+	case peerRankInitialThirdPriority:
+		return downloadDurationToRank(blockDownloadDuration, lowBlockDownloadThreshold, highBlockDownloadThreshold, peerRank2LowBlockTime, peerRank2HighBlockTime)
+	default: // i.e. peerRankInitialFourthPriority
+		return downloadDurationToRank(blockDownloadDuration, lowBlockDownloadThreshold, highBlockDownloadThreshold, peerRank3LowBlockTime, peerRank3HighBlockTime)
+	}
+}
+
+// addToPool adds a given peer to the correct group. If no group exists for that peer's rank,
+// a new group is created.
+// The method return true if a new group was created ( suggesting that the pools list would need to be re-ordered ), or false otherwise.
+func (ps *peerSelector) addToPool(peer network.Peer, rank int, class peerClass, peerHistory *historicStats) bool {
+	// see if we already have a list with that rank:
+	for i, pool := range ps.pools {
+		if pool.rank == rank {
+			// we found an existing group, add this peer to the list.
+			ps.pools[i].peers = append(pool.peers, peerPoolEntry{peer: peer, class: class, history: peerHistory})
+			return false
+		}
+	}
+	ps.pools = append(ps.pools, peerPool{rank: rank, peers: []peerPoolEntry{{peer: peer, class: class, history: peerHistory}}})
+	return true
+}
+
+// sort the pools array in an ascending order according to the rank of each pool.
+func (ps *peerSelector) sort() {
+	sort.SliceStable(ps.pools, func(i, j int) bool {
+		return ps.pools[i].rank < ps.pools[j].rank
+	})
+}
+
+// peerAddress returns the peer's underlying address. The network.Peer object cannot be compared
+// to itself, since the network package dynamically creating a new instance on every network.GetPeers() call.
+// The method retrun the peer address or an empty string if the peer is not one of HTTPPeer/UnicastPeer
+func peerAddress(peer network.Peer) string {
+	if httpPeer, ok := peer.(network.HTTPPeer); ok {
+		return httpPeer.GetAddress()
+	} else if unicastPeer, ok := peer.(network.UnicastPeer); ok {
+		return unicastPeer.GetAddress()
+	}
+	return ""
+}
+
+// refreshAvailablePeers reload the available peers from the network package, add new peers along with their
+// corresponding initial rank, and deletes peers that have been dropped by the network package.
+func (ps *peerSelector) refreshAvailablePeers() {
+	existingPeers := make(map[network.PeerOption]map[string]bool)
+	for _, pool := range ps.pools {
+		for _, localPeer := range pool.peers {
+			if peerAddress := peerAddress(localPeer.peer); peerAddress != "" {
+				// Init the existingPeers map
+				if _, has := existingPeers[localPeer.class.peerClass]; !has {
+					existingPeers[localPeer.class.peerClass] = make(map[string]bool)
+				}
+				existingPeers[localPeer.class.peerClass][peerAddress] = true
+			}
+		}
+	}
+	sortNeeded := false
+	for _, initClass := range ps.peerClasses {
+		peers := ps.net.GetPeers(initClass.peerClass)
+		for _, peer := range peers {
+			peerAddress := peerAddress(peer)
+			if peerAddress == "" {
+				continue
+			}
+			if _, has := existingPeers[initClass.peerClass][peerAddress]; has {
+				// Setting to false instead of deleting the element to be safe against duplicate peer addresses.
+				existingPeers[initClass.peerClass][peerAddress] = false
+				continue
+			}
+			// it's an entry which we did not have before.
+			sortNeeded = ps.addToPool(peer, initClass.initialRank, initClass, makeHistoricStatus(peerHistoryWindowSize, initClass)) || sortNeeded
+		}
+	}
+
+	// delete from the pools array the peers that do not exist on the network anymore.
+	for poolIdx := len(ps.pools) - 1; poolIdx >= 0; poolIdx-- {
+		pool := ps.pools[poolIdx]
+		for peerIdx := len(pool.peers) - 1; peerIdx >= 0; peerIdx-- {
+			peer := pool.peers[peerIdx].peer
+			if peerAddress := peerAddress(peer); peerAddress != "" {
+				if toRemove, _ := existingPeers[pool.peers[peerIdx].class.peerClass][peerAddress]; toRemove {
+					// need to be removed.
+					pool.peers = append(pool.peers[:peerIdx], pool.peers[peerIdx+1:]...)
+				}
+			}
+		}
+		if len(pool.peers) == 0 {
+			ps.pools = append(ps.pools[:poolIdx], ps.pools[poolIdx+1:]...)
+			sortNeeded = true
+		} else {
+			ps.pools[poolIdx] = pool
+		}
+	}
+
+	if sortNeeded {
+		ps.sort()
+	}
+}
+
+// findPeer look into the peer pool and find the given peer.
+// The method returns the pool and peer indices if a peer was found, or (-1, -1) otherwise.
+func (ps *peerSelector) findPeer(psp *peerSelectorPeer) (poolIdx, peerIdx int) {
+	peerAddr := peerAddress(psp.Peer)
+	if peerAddr == "" {
+		return -1, -1
+	}
+	for i, pool := range ps.pools {
+		for j, localPeerEntry := range pool.peers {
+			if peerAddress(localPeerEntry.peer) == peerAddr &&
+				localPeerEntry.class.peerClass == psp.peerClass {
+				return i, j
+			}
+		}
+	}
+	return -1, -1
+}
+
+// calculate the duration rank by mapping the range of [minDownloadDuration..maxDownloadDuration] into the rank range of [minRank..maxRank]
+func downloadDurationToRank(downloadDuration, minDownloadDuration, maxDownloadDuration time.Duration, minRank, maxRank int) (rank int) {
+	// clamp the downloadDuration into the range of [minDownloadDuration .. maxDownloadDuration]
+	if downloadDuration < minDownloadDuration {
+		downloadDuration = minDownloadDuration
+	} else if downloadDuration > maxDownloadDuration {
+		downloadDuration = maxDownloadDuration
+	}
+	// the formula below maps an element in the range of [minDownloadDuration .. maxDownloadDuration] onto the range of [minRank .. maxRank]
+	rank = minRank + int((downloadDuration-minDownloadDuration).Nanoseconds()*int64(maxRank-minRank)/(maxDownloadDuration-minDownloadDuration).Nanoseconds())
+	return
+}
+
+func lowerBound(class peerClass) int {
+	switch class.initialRank {
+	case peerRankInitialFirstPriority:
+		return peerRank0LowBlockTime
+	case peerRankInitialSecondPriority:
+		return peerRank1LowBlockTime
+	case peerRankInitialThirdPriority:
+		return peerRank2LowBlockTime
+	default: // i.e. peerRankInitialFourthPriority
+		return peerRank3LowBlockTime
+	}
+}
+
+func upperBound(class peerClass) int {
+	switch class.initialRank {
+	case peerRankInitialFirstPriority:
+		return peerRank0HighBlockTime
+	case peerRankInitialSecondPriority:
+		return peerRank1HighBlockTime
+	case peerRankInitialThirdPriority:
+		return peerRank2HighBlockTime
+	default: // i.e. peerRankInitialFourthPriority
+		return peerRank3HighBlockTime
+	}
+}
+
+func boundRankByClass(rank int, class peerClass) int {
+	if rank < lowerBound(class) {
+		return lowerBound(class)
+	}
+	if rank > upperBound(class) {
+		return upperBound(class)
+	}
+	return rank
+}

--- a/fetcher/universalFetcher.go
+++ b/fetcher/universalFetcher.go
@@ -1,0 +1,380 @@
+// Copyright (C) 2019-2022 Algorand, Inc.
+// This file is part of go-algorand
+//
+// go-algorand is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// go-algorand is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with go-algorand.  If not, see <https://www.gnu.org/licenses/>.
+
+package fetcher
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/algorand/go-deadlock"
+
+	"github.com/algorand/go-algorand/agreement"
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/network"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/rpcs"
+)
+
+// UniversalFetcher fetches blocks either from an http peer or ws peer.
+type universalBlockFetcher struct {
+	config config.Local
+	net    network.GossipNode
+	log    logging.Logger
+}
+
+// makeUniversalFetcher returns a fetcher for http and ws peers.
+func makeUniversalBlockFetcher(log logging.Logger, net network.GossipNode, config config.Local) *universalBlockFetcher {
+	return &universalBlockFetcher{
+		config: config,
+		net:    net,
+		log:    log}
+}
+
+// fetchBlock returns a block from the peer. The peer can be either an http or ws peer.
+func (uf *universalBlockFetcher) fetchBlock(ctx context.Context, round basics.Round, peer network.Peer) (blk *bookkeeping.Block,
+	cert *agreement.Certificate, downloadDuration time.Duration, err error) {
+
+	var fetchedBuf []byte
+	var address string
+	blockDownloadStartTime := time.Now()
+	if wsPeer, validWSPeer := peer.(network.UnicastPeer); validWSPeer {
+		fetcherClient := &wsFetcherClient{
+			target: wsPeer,
+			config: &uf.config,
+		}
+		fetchedBuf, err = fetcherClient.getBlockBytes(ctx, round)
+		if err != nil {
+			return nil, nil, time.Duration(0), err
+		}
+		address = fetcherClient.address()
+	} else if httpPeer, validHTTPPeer := peer.(network.HTTPPeer); validHTTPPeer {
+		fetcherClient := &HTTPFetcher{
+			peer:    httpPeer,
+			rootURL: httpPeer.GetAddress(),
+			net:     uf.net,
+			client:  httpPeer.GetHTTPClient(),
+			log:     uf.log,
+			config:  &uf.config}
+		fetchedBuf, err = fetcherClient.getBlockBytes(ctx, round)
+		if err != nil {
+			return nil, nil, time.Duration(0), err
+		}
+		address = fetcherClient.address()
+	} else {
+		return nil, nil, time.Duration(0), fmt.Errorf("fetchBlock: UniversalFetcher only supports HTTPPeer and UnicastPeer")
+	}
+	downloadDuration = time.Now().Sub(blockDownloadStartTime)
+	block, cert, err := processBlockBytes(fetchedBuf, round, address)
+	if err != nil {
+		return nil, nil, time.Duration(0), err
+	}
+	uf.log.Debugf("fetchBlock: downloaded block %d in %d from %s", uint64(round), downloadDuration, address)
+	return block, cert, downloadDuration, err
+}
+
+func processBlockBytes(fetchedBuf []byte, r basics.Round, peerAddr string) (blk *bookkeeping.Block, cert *agreement.Certificate, err error) {
+	var decodedEntry rpcs.EncodedBlockCert
+	err = protocol.Decode(fetchedBuf, &decodedEntry)
+	if err != nil {
+		err = makeErrCannotDecodeBlock(r, peerAddr, err)
+		return
+	}
+
+	if decodedEntry.Block.Round() != r {
+		err = makeErrWrongBlockFromPeer(r, decodedEntry.Block.Round(), peerAddr)
+		return
+	}
+
+	if decodedEntry.Certificate.Round != r {
+		err = makeErrWrongCertFromPeer(r, decodedEntry.Certificate.Round, peerAddr)
+		return
+	}
+	return &decodedEntry.Block, &decodedEntry.Certificate, nil
+}
+
+// a stub fetcherClient to satisfy the NetworkFetcher interface
+type wsFetcherClient struct {
+	target network.UnicastPeer // the peer where we're going to send the request.
+	config *config.Local
+
+	mu deadlock.Mutex
+}
+
+// getBlockBytes implements FetcherClient
+func (w *wsFetcherClient) getBlockBytes(ctx context.Context, r basics.Round) ([]byte, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	childCtx, cancelFunc := context.WithTimeout(ctx, time.Duration(w.config.CatchupGossipBlockFetchTimeoutSec)*time.Second)
+	w.mu.Unlock()
+
+	defer func() {
+		cancelFunc()
+		// note that we don't need to have additional Unlock here since
+		// we already have a defered Unlock above ( which executes in reversed order )
+		w.mu.Lock()
+	}()
+
+	blockBytes, err := w.requestBlock(childCtx, r)
+	if err != nil {
+		return nil, err
+	}
+	if len(blockBytes) == 0 { // This case may never happen
+		return nil, fmt.Errorf("wsFetcherClient(%d): empty response", r)
+	}
+	return blockBytes, nil
+}
+
+// Address implements FetcherClient
+func (w *wsFetcherClient) address() string {
+	return fmt.Sprintf("[ws] (%s)", w.target.GetAddress())
+}
+
+// requestBlock send a request for block <round> and wait until it receives a response or a context expires.
+func (w *wsFetcherClient) requestBlock(ctx context.Context, round basics.Round) ([]byte, error) {
+	roundBin := make([]byte, binary.MaxVarintLen64)
+	binary.PutUvarint(roundBin, uint64(round))
+	topics := network.Topics{
+		network.MakeTopic(rpcs.RequestDataTypeKey,
+			[]byte(rpcs.BlockAndCertValue)),
+		network.MakeTopic(
+			rpcs.RoundKey,
+			roundBin),
+	}
+	resp, err := w.target.Request(ctx, protocol.UniEnsBlockReqTag, topics)
+	if err != nil {
+		return nil, makeErrWsFetcherRequestFailed(round, w.target.GetAddress(), err.Error())
+	}
+
+	if errMsg, found := resp.Topics.GetValue(network.ErrorKey); found {
+		return nil, makeErrWsFetcherRequestFailed(round, w.target.GetAddress(), string(errMsg))
+	}
+
+	blk, found := resp.Topics.GetValue(rpcs.BlockDataKey)
+	if !found {
+		return nil, makeErrWsFetcherRequestFailed(round, w.target.GetAddress(), "Block data not found")
+	}
+	cert, found := resp.Topics.GetValue(rpcs.CertDataKey)
+	if !found {
+		return nil, makeErrWsFetcherRequestFailed(round, w.target.GetAddress(), "Cert data not found")
+	}
+
+	blockCertBytes := protocol.EncodeReflect(rpcs.PreEncodedBlockCert{
+		Block:       blk,
+		Certificate: cert})
+
+	return blockCertBytes, nil
+}
+
+// set max fetcher size to 5MB, this is enough to fit the block and certificate
+const fetcherMaxBlockBytes = 5 << 20
+
+var errNoBlockForRound = errors.New("No block available for given round")
+
+// HTTPFetcher implements FetcherClient doing an HTTP GET of the block
+type HTTPFetcher struct {
+	peer    network.HTTPPeer
+	rootURL string
+	net     network.GossipNode
+
+	client *http.Client
+
+	log    logging.Logger
+	config *config.Local
+}
+
+// getBlockBytes gets a block.
+// Core piece of FetcherClient interface
+func (hf *HTTPFetcher) getBlockBytes(ctx context.Context, r basics.Round) (data []byte, err error) {
+	parsedURL, err := network.ParseHostOrURL(hf.rootURL)
+	if err != nil {
+		return nil, err
+	}
+
+	parsedURL.Path = rpcs.FormatBlockQuery(uint64(r), parsedURL.Path, hf.net)
+	blockURL := parsedURL.String()
+	hf.log.Debugf("block GET %#v peer %#v %T", blockURL, hf.peer, hf.peer)
+	request, err := http.NewRequest("GET", blockURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	requestCtx, requestCancel := context.WithTimeout(ctx, time.Duration(hf.config.CatchupHTTPBlockFetchTimeoutSec)*time.Second)
+	defer requestCancel()
+	request = request.WithContext(requestCtx)
+	network.SetUserAgentHeader(request.Header)
+	response, err := hf.client.Do(request)
+	if err != nil {
+		hf.log.Debugf("GET %#v : %s", blockURL, err)
+		return nil, err
+	}
+
+	// check to see that we had no errors.
+	switch response.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound: // server could not find a block with that round numbers.
+		response.Body.Close()
+		return nil, errNoBlockForRound
+	default:
+		bodyBytes, err := rpcs.ResponseBytes(response, hf.log, fetcherMaxBlockBytes)
+		hf.log.Warnf("HTTPFetcher.getBlockBytes: response status code %d from '%s'. Response body '%s' ", response.StatusCode, blockURL, string(bodyBytes))
+		if err == nil {
+			err = makeErrHTTPResponse(response.StatusCode, blockURL, fmt.Sprintf("Response body '%s'", string(bodyBytes)))
+		} else {
+			err = makeErrHTTPResponse(response.StatusCode, blockURL, err.Error())
+		}
+		return nil, err
+	}
+
+	// at this point, we've already receieved the response headers. ensure that the
+	// response content type is what we'd like it to be.
+	contentTypes := response.Header["Content-Type"]
+	if len(contentTypes) != 1 {
+		err = errHTTPResponseContentType{contentTypeCount: len(contentTypes)}
+		hf.log.Warn(err)
+		response.Body.Close()
+		return nil, err
+	}
+
+	// TODO: Temporarily allow old and new content types so we have time for lazy upgrades
+	// Remove this 'old' string after next release.
+	const blockResponseContentTypeOld = "application/algorand-block-v1"
+	if contentTypes[0] != rpcs.BlockResponseContentType && contentTypes[0] != blockResponseContentTypeOld {
+		hf.log.Warnf("http block fetcher response has an invalid content type : %s", contentTypes[0])
+		response.Body.Close()
+		return nil, errHTTPResponseContentType{contentTypeCount: 1, contentType: contentTypes[0]}
+	}
+
+	return rpcs.ResponseBytes(response, hf.log, fetcherMaxBlockBytes)
+}
+
+// Address is part of FetcherClient interface.
+// Returns the root URL of the connected peer.
+func (hf *HTTPFetcher) address() string {
+	return hf.rootURL
+}
+
+type errWrongCertFromPeer struct {
+	round     basics.Round
+	peer      string
+	certRound basics.Round
+}
+
+func makeErrWrongCertFromPeer(round, certRound basics.Round, peer string) errWrongCertFromPeer {
+	return errWrongCertFromPeer{
+		round:     round,
+		peer:      peer,
+		certRound: certRound}
+}
+
+func (wcfpe errWrongCertFromPeer) Error() string {
+	return fmt.Sprintf("processBlockBytes: got wrong cert from peer %s: wanted %d, got %d",
+		wcfpe.peer, wcfpe.round, wcfpe.certRound)
+}
+
+type errWrongBlockFromPeer struct {
+	round     basics.Round
+	peer      string
+	certRound basics.Round
+}
+
+func makeErrWrongBlockFromPeer(round, certRound basics.Round, peer string) errWrongBlockFromPeer {
+	return errWrongBlockFromPeer{
+		round:     round,
+		peer:      peer,
+		certRound: certRound}
+}
+
+func (wbfpe errWrongBlockFromPeer) Error() string {
+	return fmt.Sprintf("processBlockBytes: got wrong block from peer %s: wanted %d, got %d",
+		wbfpe.peer, wbfpe.round, wbfpe.certRound)
+}
+
+type errCannotDecodeBlock struct {
+	round basics.Round
+	peer  string
+	err   error
+}
+
+func makeErrCannotDecodeBlock(round basics.Round, peer string, err error) errCannotDecodeBlock {
+	return errCannotDecodeBlock{
+		round: round,
+		peer:  peer,
+		err:   err}
+}
+
+func (cdbe errCannotDecodeBlock) Error() string {
+	return fmt.Sprintf("processBlockBytes: cannot decode block %d from peer %s: %s",
+		cdbe.round, cdbe.peer, cdbe.err.Error())
+}
+
+func (cdbe errCannotDecodeBlock) Unwrap() error {
+	return cdbe.err
+}
+
+type errWsFetcherRequestFailed struct {
+	round basics.Round
+	peer  string
+	cause string
+}
+
+func makeErrWsFetcherRequestFailed(round basics.Round, peer, cause string) errWsFetcherRequestFailed {
+	return errWsFetcherRequestFailed{
+		round: round,
+		peer:  peer,
+		cause: cause}
+}
+
+func (wrfe errWsFetcherRequestFailed) Error() string {
+	return fmt.Sprintf("wsFetcherClient(%s).requestBlock(%d): Request failed: %s",
+		wrfe.peer, wrfe.round, wrfe.cause)
+}
+
+type errHTTPResponse struct {
+	responseStatus int
+	blockURL       string
+	cause          string
+}
+
+func makeErrHTTPResponse(responseStatus int, blockURL string, cause string) errHTTPResponse {
+	return errHTTPResponse{
+		responseStatus: responseStatus,
+		blockURL:       blockURL,
+		cause:          cause}
+}
+
+func (hre errHTTPResponse) Error() string {
+	return fmt.Sprintf("HTTPFetcher.getBlockBytes: error response status code %d when requesting '%s': %s", hre.responseStatus, hre.blockURL, hre.cause)
+}
+
+type errHTTPResponseContentType struct {
+	contentTypeCount int
+	contentType      string
+}
+
+func (cte errHTTPResponseContentType) Error() string {
+	if cte.contentTypeCount == 1 {
+		return fmt.Sprintf("HTTPFetcher.getBlockBytes: invalid content type: %s", cte.contentType)
+	}
+	return fmt.Sprintf("HTTPFetcher.getBlockBytes: invalid content type count: %d", cte.contentTypeCount)
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary
This implementation of fetcher directly fetches blocks from the network instead of fetching from an algod server.

`./algorand-indexer daemon -P <postgres credentials> --catchup <path to genesis.json> -i <indexer datadir>`
starts indexer and fetches blocks directly from the network

## Test Plan
`TestDirectCatchupService` in `fetcher_test.go` implements the logic and fetches first 10 blocks from the `mainnet` network.