### PR TITLE
Bug Fix: Fix auto-loading search

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Below is a snippet of the output from `algorand-indexer api-config`:
 
 Seeing this we know that the `/v2/accounts` endpoint will return an error if either `currency-greater-than` or `currency-less-than` is provided.  Additionally, because a "required" parameter is provided for `/v2/assets/{asset-id}/transactions` then we know this entire endpoint is disabled.  The optional parameters are provided so that you can understand what else is disabled if you enable all "required" parameters.
 
+**NOTE: An empty parameter configuration file results in all parameters being ENABLED.**
+
 For more information on disabling parameters see the [Disabling Parameters Guide](docs/DisablingParametersGuide.md).
 
 ## Metrics
@@ -211,6 +213,8 @@ The command line arguments always take priority over the config file and environ
 The Indexer data directory is the location where the Indexer can store and/or load data needed for runtime operation and configuration.
 
 **It is a required argument for Indexer daemon operation. Supply it to the Indexer via the `--data-dir` flag.**
+
+**It is HIGHLY recommended placing the data directory in a separate, stateful directory for production usage of the Indexer.**
 
 
 ### Auto-Loading Configuration

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -346,12 +346,12 @@ func makeOptions() (options api.ExtraOptions) {
 		}
 
 		if len((*potentialDisabledMapConfig).Data) == 0 {
-			logger.Infof("NOTICE: All parameters are enabled since the provided parameter configuration file (%s) is empty.", suppliedAPIConfigFile)
+			logger.Warnf("All parameters are enabled since the provided parameter configuration file (%s) is empty.", suppliedAPIConfigFile)
 		}
 
 		options.DisabledMapConfig = potentialDisabledMapConfig
 	} else {
-		logger.Infof("NOTICE: Enable all parameters flag is set to: %v", enableAllParameters)
+		logger.Infof("Enable all parameters flag is set to: %v", enableAllParameters)
 	}
 
 	return

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -94,6 +94,14 @@ var daemonCmd = &cobra.Command{
 				panic(exit{1})
 			}
 
+			if autoFoundConfigPath != "" {
+				logger.Errorf(
+					"indexer configuration was automatically found (%s) as well found in the data directory (%s).  Make sure only one is present",
+					autoFoundConfigPath,
+					filepath.Join(indexerDataDir, autoLoadIndexerConfigName))
+				panic(exit{1})
+			}
+
 			configFile = filepath.Join(indexerDataDir, autoLoadIndexerConfigName)
 			fmt.Printf("Auto-loading indexer configuration found: %s\n", configFile)
 		}
@@ -109,6 +117,7 @@ var daemonCmd = &cobra.Command{
 				maybeFail(err, "invalid config file (%s): %v", viper.ConfigFileUsed(), err)
 			}
 			fmt.Printf("Using configuration file: %s\n", configFile)
+			config.BindFlags(cmd)
 		}
 
 		if paramConfigFound {
@@ -119,7 +128,7 @@ var daemonCmd = &cobra.Command{
 				panic(exit{1})
 			}
 			suppliedAPIConfigFile = filepath.Join(indexerDataDir, autoLoadParameterConfigName)
-			fmt.Printf("Auto-loading parameter configuration file: %s", suppliedAPIConfigFile)
+			fmt.Printf("Auto-loading parameter configuration file: %s\n", suppliedAPIConfigFile)
 
 		}
 

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -94,14 +94,6 @@ var daemonCmd = &cobra.Command{
 				panic(exit{1})
 			}
 
-			if autoFoundConfigPath != "" {
-				logger.Errorf(
-					"indexer configuration was automatically found (%s) as well found in the data directory (%s).  Make sure only one is present",
-					autoFoundConfigPath,
-					filepath.Join(indexerDataDir, autoLoadIndexerConfigName))
-				panic(exit{1})
-			}
-
 			configFile = filepath.Join(indexerDataDir, autoLoadIndexerConfigName)
 			fmt.Printf("Auto-loading indexer configuration found: %s\n", configFile)
 		}
@@ -352,7 +344,14 @@ func makeOptions() (options api.ExtraOptions) {
 			fmt.Fprintf(os.Stderr, "failed to created disabled map config from file: %v", err)
 			panic(exit{1})
 		}
+
+		if len((*potentialDisabledMapConfig).Data) == 0 {
+			logger.Infof("NOTICE: All parameters are enabled since the provided parameter configuration file (%s) is empty.", suppliedAPIConfigFile)
+		}
+
 		options.DisabledMapConfig = potentialDisabledMapConfig
+	} else {
+		logger.Infof("NOTICE: Enable all parameters flag is set to: %v", enableAllParameters)
 	}
 
 	return

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -79,7 +79,6 @@ var (
 	logLevel            string
 	logFile             string
 	logger              *log.Logger
-	autoFoundConfigPath string
 )
 
 func indexerDbFromFlags(opts idb.IndexerDbOptions) (idb.IndexerDb, chan struct{}) {
@@ -96,7 +95,6 @@ func indexerDbFromFlags(opts idb.IndexerDbOptions) (idb.IndexerDb, chan struct{}
 }
 
 func init() {
-	autoFoundConfigPath = ""
 	// Utilities subcommand for more convenient access to useful testing utilities.
 	utilsCmd := &cobra.Command{
 		Use:   "util",
@@ -138,22 +136,7 @@ func init() {
 	// Setup configuration file
 	viper.SetConfigName(config.FileName)
 	viper.SetConfigType(config.FileType)
-	for _, k := range config.ConfigPaths {
-		viper.AddConfigPath(k)
-	}
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			// Config file not found, not an error since it may be set on the CLI.
-		} else {
-			fmt.Fprintf(os.Stderr, "invalid config file (%s): %v", viper.ConfigFileUsed(), err)
-			panic(exit{1})
-		}
-	} else {
-		fmt.Printf("Using configuration file via auto-search path: %s\n", viper.ConfigFileUsed())
-		autoFoundConfigPath = viper.ConfigFileUsed()
-	}
 
 	viper.SetEnvPrefix(config.EnvPrefix)
 	viper.AutomaticEnv()

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -72,13 +72,13 @@ var rootCmd = &cobra.Command{
 }
 
 var (
-	postgresAddr        string
-	dummyIndexerDb      bool
-	doVersion           bool
-	profFile            io.WriteCloser
-	logLevel            string
-	logFile             string
-	logger              *log.Logger
+	postgresAddr   string
+	dummyIndexerDb bool
+	doVersion      bool
+	profFile       io.WriteCloser
+	logLevel       string
+	logFile        string
+	logger         *log.Logger
 )
 
 func indexerDbFromFlags(opts idb.IndexerDbOptions) (idb.IndexerDb, chan struct{}) {

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -72,13 +72,14 @@ var rootCmd = &cobra.Command{
 }
 
 var (
-	postgresAddr   string
-	dummyIndexerDb bool
-	doVersion      bool
-	profFile       io.WriteCloser
-	logLevel       string
-	logFile        string
-	logger         *log.Logger
+	postgresAddr        string
+	dummyIndexerDb      bool
+	doVersion           bool
+	profFile            io.WriteCloser
+	logLevel            string
+	logFile             string
+	logger              *log.Logger
+	autoFoundConfigPath string
 )
 
 func indexerDbFromFlags(opts idb.IndexerDbOptions) (idb.IndexerDb, chan struct{}) {
@@ -95,6 +96,7 @@ func indexerDbFromFlags(opts idb.IndexerDbOptions) (idb.IndexerDb, chan struct{}
 }
 
 func init() {
+	autoFoundConfigPath = ""
 	// Utilities subcommand for more convenient access to useful testing utilities.
 	utilsCmd := &cobra.Command{
 		Use:   "util",
@@ -149,7 +151,8 @@ func init() {
 			panic(exit{1})
 		}
 	} else {
-		fmt.Printf("Using configuration file: %s\n", viper.ConfigFileUsed())
+		fmt.Printf("Using configuration file via auto-search path: %s\n", viper.ConfigFileUsed())
+		autoFoundConfigPath = viper.ConfigFileUsed()
 	}
 
 	viper.SetEnvPrefix(config.EnvPrefix)

--- a/config/config.go
+++ b/config/config.go
@@ -19,9 +19,6 @@ const FileType = "yml"
 // gets confused and thinks the binary is a config file with no extension.
 const FileName = "indexer"
 
-// ConfigPaths are the different locations that algorand-indexer should look for config files.
-var ConfigPaths = [...]string{".", "$HOME", "$HOME/.algorand-indexer/", "$HOME/.config/algorand-indexer/", "/etc/algorand-indexer/"}
-
 // BindFlags glues the cobra and viper libraries together.
 func BindFlags(cmd *cobra.Command) {
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {

--- a/docs/DisablingParametersGuide.md
+++ b/docs/DisablingParametersGuide.md
@@ -45,6 +45,8 @@ The first "level" is a key-value pair where the key is the REST path to the endp
 
 As a concrete example: in the above snippet the endpoint `/v2/accounts` has two optional parameters that are disabled: `currency-greater-than` and `currency-less-than`.  Querying that endpoint and providing either of those two parameters would result in an error being returned.
 
+**NOTE: An empty parameter configuration file results in all parameters being ENABLED.**
+
 ### Error Return Value
 
 If you query an endpoint with a required parameter you will receive a `400` response with a json message explaining the error.


### PR DESCRIPTION
Resolves #1064

1. Auto searching of configurations can clash with supplied data directory configurations.  To simplify this, providing configurations in both the auto-searched directories and data directory will result in an error.

2. Because the config file load code was moved around, the command that ties the go-lang variables to the read-in config file was not positioned correctly.  Once fixed the read-in configuration will bind with the variables correctly.

This code was manually tested by enabling parameters via the data
directory config and validating that certain endpoints were
enabled/disabled.
