### PR TITLE
Generate an error if the catchpoint is not valid for initialization.

### DIFF
--- a/processor/blockprocessor/block_processor.go
+++ b/processor/blockprocessor/block_processor.go
@@ -47,7 +47,7 @@ func MakeProcessorWithLedgerInit(ctx context.Context, logger *log.Logger, catchp
 				return &blockProcessor{}, fmt.Errorf("MakeProcessorWithCatchup() label err: %w", err)
 			}
 			if uint64(round) >= nextDBRound {
-				logger.Warnf("round for given catchpoint is ahead of db round. skip fast catchup")
+				return &blockProcessor{}, fmt.Errorf("catchpoint round is ahead of db round: %d > %d", uint64(round), nextDBRound)
 			} else {
 				err = InitializeLedgerFastCatchup(ctx, logger, catchpoint, opts.IndexerDatadir, *genesis)
 				if err != nil {

--- a/processor/blockprocessor/block_processor.go
+++ b/processor/blockprocessor/block_processor.go
@@ -47,7 +47,7 @@ func MakeProcessorWithLedgerInit(ctx context.Context, logger *log.Logger, catchp
 				return &blockProcessor{}, fmt.Errorf("MakeProcessorWithCatchup() label err: %w", err)
 			}
 			if uint64(round) >= nextDBRound {
-				return &blockProcessor{}, fmt.Errorf("catchpoint round is ahead of db round: %d > %d", uint64(round), nextDBRound)
+				return &blockProcessor{}, fmt.Errorf("invalid catchpoint: catchpoint round %d should not be ahead of target round %d", uint64(round), nextDBRound-1)
 			} else {
 				err = InitializeLedgerFastCatchup(ctx, logger, catchpoint, opts.IndexerDatadir, *genesis)
 				if err != nil {

--- a/processor/blockprocessor/block_processor.go
+++ b/processor/blockprocessor/block_processor.go
@@ -48,11 +48,10 @@ func MakeProcessorWithLedgerInit(ctx context.Context, logger *log.Logger, catchp
 			}
 			if uint64(round) >= nextDBRound {
 				return &blockProcessor{}, fmt.Errorf("invalid catchpoint: catchpoint round %d should not be ahead of target round %d", uint64(round), nextDBRound-1)
-			} else {
-				err = InitializeLedgerFastCatchup(ctx, logger, catchpoint, opts.IndexerDatadir, *genesis)
-				if err != nil {
-					return &blockProcessor{}, fmt.Errorf("MakeProcessorWithCatchup() fast catchup err: %w", err)
-				}
+			}
+			err = InitializeLedgerFastCatchup(ctx, logger, catchpoint, opts.IndexerDatadir, *genesis)
+			if err != nil {
+				return &blockProcessor{}, fmt.Errorf("MakeProcessorWithCatchup() fast catchup err: %w", err)
 			}
 		}
 		err := InitializeLedgerSimple(ctx, logger, nextDBRound-1, &opts)

--- a/processor/blockprocessor/block_processor_test.go
+++ b/processor/blockprocessor/block_processor_test.go
@@ -1,20 +1,28 @@
 package blockprocessor_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	test2 "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/rpcs"
-	block_processor "github.com/algorand/indexer/processor/blockprocessor"
+
+	"github.com/algorand/indexer/idb"
+	"github.com/algorand/indexer/processor/blockprocessor"
 	"github.com/algorand/indexer/util/test"
-	"github.com/stretchr/testify/assert"
 )
+
+var noopHandler = func(block *ledgercore.ValidatedBlock) error {
+	return nil
+}
 
 func TestProcess(t *testing.T) {
 	log, _ := test2.NewNullLogger()
@@ -24,10 +32,7 @@ func TestProcess(t *testing.T) {
 	genesisBlock, err := l.Block(basics.Round(0))
 	assert.Nil(t, err)
 	// create processor
-	handler := func(vb *ledgercore.ValidatedBlock) error {
-		return nil
-	}
-	pr, _ := block_processor.MakeProcessorWithLedger(l, handler)
+	pr, _ := blockprocessor.MakeProcessorWithLedger(l, noopHandler)
 	prevHeader := genesisBlock.BlockHeader
 	assert.Equal(t, basics.Round(0), l.Latest())
 	// create a few rounds
@@ -56,9 +61,9 @@ func TestFailedProcess(t *testing.T) {
 	require.NoError(t, err)
 	defer l.Close()
 	// invalid processor
-	pr, err := block_processor.MakeProcessorWithLedger(nil, nil)
+	pr, err := blockprocessor.MakeProcessorWithLedger(nil, nil)
 	assert.Contains(t, err.Error(), "MakeProcessorWithLedger() err: local ledger not initialized")
-	pr, err = block_processor.MakeProcessorWithLedger(l, nil)
+	pr, err = blockprocessor.MakeProcessorWithLedger(l, nil)
 	assert.Nil(t, err)
 	err = pr.Process(nil)
 	assert.Contains(t, err.Error(), "Process(): cannot process a nil block")
@@ -104,9 +109,9 @@ func TestFailedProcess(t *testing.T) {
 	handler := func(vb *ledgercore.ValidatedBlock) error {
 		return fmt.Errorf("handler error")
 	}
-	_, err = block_processor.MakeProcessorWithLedger(l, handler)
+	_, err = blockprocessor.MakeProcessorWithLedger(l, handler)
 	assert.Contains(t, err.Error(), "handler error")
-	pr, _ = block_processor.MakeProcessorWithLedger(l, nil)
+	pr, _ = blockprocessor.MakeProcessorWithLedger(l, nil)
 	txn = test.MakePaymentTxn(0, 10, 0, 1, 1, 0, test.AccountA, test.AccountA, basics.Address{}, basics.Address{})
 	block, err = test.MakeBlockForTxns(genesisBlock.BlockHeader, &txn)
 	assert.Nil(t, err)
@@ -114,4 +119,50 @@ func TestFailedProcess(t *testing.T) {
 	rawBlock = rpcs.EncodedBlockCert{Block: block, Certificate: agreement.Certificate{}}
 	err = pr.Process(&rawBlock)
 	assert.Contains(t, err.Error(), "Process() handler err")
+}
+
+// TestMakeProcessorWithLedgerInit_CatchpointErrors verifies that the catchpoint error handling works properly.
+func TestMakeProcessorWithLedgerInit_CatchpointErrors(t *testing.T) {
+	log, _ := test2.NewNullLogger()
+	var genesis bookkeeping.Genesis
+
+	testCases := []struct {
+		name       string
+		catchpoint string
+		round      uint64
+		errMsg     string
+	}{
+		{
+			name:       "invalid catchpoint string",
+			catchpoint: "asdlgkjasldgkjsadg",
+			round:      1,
+			errMsg:     "catchpoint parsing failed",
+		},
+		{
+			name:       "catchpoint too recent",
+			catchpoint: "21890000#IQ4BQTCNVEDIBNRPNCKWRBQLJ7ILXIJBYKJHF67TLUOYRUGHW7ZA",
+			round:      21889999,
+			errMsg:     "catchpoint round is ahead of db round",
+		},
+		{
+			name:       "get past catchpoint check",
+			catchpoint: "21890000#IQ4BQTCNVEDIBNRPNCKWRBQLJ7ILXIJBYKJHF67TLUOYRUGHW7ZA",
+			round:      21890001,
+			errMsg:     "indexer data directory missing",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := blockprocessor.MakeProcessorWithLedgerInit(
+				context.Background(),
+				log,
+				tc.catchpoint,
+				&genesis,
+				tc.round,
+				idb.IndexerDbOptions{},
+				noopHandler)
+			require.ErrorContains(t, err, tc.errMsg)
+		})
+	}
 }

--- a/processor/blockprocessor/block_processor_test.go
+++ b/processor/blockprocessor/block_processor_test.go
@@ -142,7 +142,7 @@ func TestMakeProcessorWithLedgerInit_CatchpointErrors(t *testing.T) {
 			name:       "catchpoint too recent",
 			catchpoint: "21890000#IQ4BQTCNVEDIBNRPNCKWRBQLJ7ILXIJBYKJHF67TLUOYRUGHW7ZA",
 			round:      21889999,
-			errMsg:     "catchpoint round is ahead of db round",
+			errMsg:     "invalid catchpoint: catchpoint round 21890000 should not be ahead of target round 21889998",
 		},
 		{
 			name:       "get past catchpoint check",


### PR DESCRIPTION
## Summary

If the user provides a catchpoint but it isn't valid for the deployment, we should exit with an error instead of warning.

## Test Plan

New unit test.
