### PR TITLE
Switch from fullNode catchup to catchpoint catchup service.

### DIFF
--- a/processor/blockprocessor/initialize.go
+++ b/processor/blockprocessor/initialize.go
@@ -4,18 +4,13 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/algorand/go-algorand-sdk/client/v2/algod"
-	algodConfig "github.com/algorand/go-algorand/config"
-	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
-	"github.com/algorand/go-algorand/logging"
-	"github.com/algorand/go-algorand/node"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/rpcs"
 
@@ -69,6 +64,9 @@ func InitializeLedgerSimple(ctx context.Context, logger *log.Logger, round uint6
 	return nil
 }
 
+/*
+// TODO: When we are happy with the state of ledger initialization, remove this code.
+//       If we add "stop at round" to the node, it may be useful to change back to this.
 func fullNodeCatchup(ctx context.Context, logger *log.Logger, round basics.Round, catchpoint, dataDir string, genesis bookkeeping.Genesis) error {
 	ctx, cf := context.WithCancel(ctx)
 	defer cf()
@@ -136,6 +134,7 @@ func fullNodeCatchup(ctx context.Context, logger *log.Logger, round basics.Round
 	}
 	return nil
 }
+*/
 
 // InitializeLedgerFastCatchup executes the migration core functionality.
 func InitializeLedgerFastCatchup(ctx context.Context, logger *log.Logger, catchpoint, dataDir string, genesis bookkeeping.Genesis) error {

--- a/processor/blockprocessor/initialize.go
+++ b/processor/blockprocessor/initialize.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/algorand/go-algorand-sdk/client/v2/algod"
 	algodConfig "github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
@@ -16,11 +18,11 @@ import (
 	"github.com/algorand/go-algorand/node"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/rpcs"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/algorand/indexer/fetcher"
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/processor"
+	"github.com/algorand/indexer/processor/blockprocessor/internal"
 )
 
 // InitializeLedgerSimple executes the migration core functionality.
@@ -111,29 +113,10 @@ func fullNodeCatchup(ctx context.Context, logger *log.Logger, round basics.Round
 			logger.Infof("Catchpoint Catchup Total Blocks %d ", status.CatchpointCatchupTotalBlocks)
 			logger.Infof("Catchpoint Catchup Acquired Blocks %d ", status.CatchpointCatchupAcquiredBlocks)
 		}
-
-	}
-	logger.Infof("fast catchup completed in %v", status.CatchupTime.Seconds())
-	return nil
-}
-
-// InitializeLedgerFastCatchup executes the migration core functionality.
-func InitializeLedgerFastCatchup(ctx context.Context, logger *log.Logger, catchpoint, dataDir string, genesis bookkeeping.Genesis) error {
-	if dataDir == "" {
-		return fmt.Errorf("InitializeLedgerFastCatchup() err: indexer data directory missing")
-	}
-	// catchpoint round
-	round, _, err := ledgercore.ParseCatchpointLabel(catchpoint)
-	if err != nil {
-		return fmt.Errorf("InitializeLedgerFastCatchup() err: %w", err)
 	}
 
-	// TODO: switch to catchup service catchup.
-	//err = internal.CatchupServiceCatchup(logger, round, catchpoint, dataDir, genesis)
-	err = fullNodeCatchup(ctx, logger, round, catchpoint, dataDir, genesis)
-	if err != nil {
-		return fmt.Errorf("fullNodeCatchup() err: %w", err)
-	}
+	logger.Infof("fast catchup completed in %v, moving files to data directory", status.CatchupTime.Seconds())
+
 	// remove node directory after fast catchup completes
 	defer os.RemoveAll(filepath.Join(dataDir, genesis.ID()))
 	// move ledger to indexer directory
@@ -148,8 +131,27 @@ func InitializeLedgerFastCatchup(ctx context.Context, logger *log.Logger, catchp
 	for _, f := range ledgerFiles {
 		err = os.Rename(filepath.Join(dataDir, genesis.ID(), f), filepath.Join(dataDir, f))
 		if err != nil {
-			return fmt.Errorf("InitializeLedgerFastCatchup() err: %w", err)
+			return fmt.Errorf("fullNodeCatchup() err: %w", err)
 		}
+	}
+	return nil
+}
+
+// InitializeLedgerFastCatchup executes the migration core functionality.
+func InitializeLedgerFastCatchup(ctx context.Context, logger *log.Logger, catchpoint, dataDir string, genesis bookkeeping.Genesis) error {
+	if dataDir == "" {
+		return fmt.Errorf("InitializeLedgerFastCatchup() err: indexer data directory missing")
+	}
+	// catchpoint round
+	round, _, err := ledgercore.ParseCatchpointLabel(catchpoint)
+	if err != nil {
+		return fmt.Errorf("InitializeLedgerFastCatchup() err: %w", err)
+	}
+
+	err = internal.CatchupServiceCatchup(logger, round, catchpoint, dataDir, genesis)
+	//err = fullNodeCatchup(ctx, logger, round, catchpoint, dataDir, genesis)
+	if err != nil {
+		return fmt.Errorf("InitializeLedgerFastCatchup() err: %w", err)
 	}
 	return nil
 }

--- a/processor/blockprocessor/initialize.go
+++ b/processor/blockprocessor/initialize.go
@@ -148,7 +148,7 @@ func InitializeLedgerFastCatchup(ctx context.Context, logger *log.Logger, catchp
 		return fmt.Errorf("InitializeLedgerFastCatchup() err: %w", err)
 	}
 
-	err = internal.CatchupServiceCatchup(logger, round, catchpoint, dataDir, genesis)
+	err = internal.CatchupServiceCatchup(ctx, logger, round, catchpoint, dataDir, genesis)
 	//err = fullNodeCatchup(ctx, logger, round, catchpoint, dataDir, genesis)
 	if err != nil {
 		return fmt.Errorf("InitializeLedgerFastCatchup() err: %w", err)

--- a/processor/blockprocessor/initialize_test.go
+++ b/processor/blockprocessor/initialize_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/algorand/go-algorand/rpcs"
 
 	"github.com/algorand/indexer/idb"
+	"github.com/algorand/indexer/processor/blockprocessor/internal"
 	"github.com/algorand/indexer/util"
 	"github.com/algorand/indexer/util/test"
 )
@@ -124,9 +125,11 @@ func TestInitializeLedgerFastCatchup_Errors(t *testing.T) {
 
 	// This should hit a couple extra branches
 	ctx, cf = context.WithCancel(context.Background())
+	internal.Delay = 1 * time.Millisecond
+	// cancel after a short delay
 	go func() {
-		time.Sleep(11 * time.Second)
-		cf() // cancel immediately
+		time.Sleep(1 * time.Second)
+		cf()
 	}()
 	tryToRun(ctx)
 }

--- a/processor/blockprocessor/initialize_test.go
+++ b/processor/blockprocessor/initialize_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/sirupsen/logrus"
 	test2 "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand-sdk/client/v2/algod"
 	"github.com/algorand/go-algorand-sdk/encoding/json"
 	"github.com/algorand/go-algorand-sdk/encoding/msgpack"
 	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/rpcs"
 
 	"github.com/algorand/indexer/idb"
@@ -82,4 +84,35 @@ func TestRunMigration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(6), uint64(l.Latest()))
 	l.Close()
+}
+
+func TestInitializeLedgerFastCatchup_Errors(t *testing.T) {
+	log, _ := test2.NewNullLogger()
+	err := InitializeLedgerFastCatchup(context.Background(), log, "asdf", "", bookkeeping.Genesis{})
+	require.EqualError(t, err, "InitializeLedgerFastCatchup() err: indexer data directory missing")
+
+	err = InitializeLedgerFastCatchup(context.Background(), log, "asdf", t.TempDir(), bookkeeping.Genesis{})
+	require.EqualError(t, err, "InitializeLedgerFastCatchup() err: catchpoint parsing failed")
+
+	ctx, cf := context.WithCancel(context.Background())
+	cf() // cancel immediately
+	var addr basics.Address
+	genesis := bookkeeping.Genesis{
+		SchemaID:    "1",
+		Network:     "test",
+		Proto:       "future",
+		Allocation:  nil,
+		RewardsPool: addr.String(),
+		FeeSink:     addr.String(),
+		Timestamp:   0,
+		Comment:     "",
+		DevMode:     false,
+	}
+	err = InitializeLedgerFastCatchup(
+		ctx,
+		logrus.New(),
+		"21890000#BOGUSTCNVEDIBNRPNCKWRBQLJ7ILXIJBYKAHF67TLUOYRUGHW7ZA",
+		t.TempDir(),
+		genesis)
+	require.EqualError(t, err, "InitializeLedgerFastCatchup() err: context canceled")
 }

--- a/processor/blockprocessor/internal/catchupservice.go
+++ b/processor/blockprocessor/internal/catchupservice.go
@@ -68,11 +68,10 @@ func CatchupServiceCatchup(logger *log.Logger, round basics.Round, catchpoint, d
 	if err != nil {
 		return fmt.Errorf("CatchupServiceCatchup() NewWebsocketNetwork err: %w", err)
 	}
-	// TODO: Do we need to implement the peer prioritization interface?
-	//p2pNode.SetPrioScheme(node)
 	p2pNode.Start()
 
-	// TODO: if the ledger already has a catchpoint, use MakeResumedCatchpointCatchupService
+	// TODO: Can use MakeResumedCatchpointCatchupService if ledger exists.
+	//       Without this ledger is re-initialized instead of resumed on restart.
 	service, err := catchup.MakeNewCatchpointCatchupService(
 		catchpoint,
 		node,

--- a/processor/blockprocessor/internal/catchupservice.go
+++ b/processor/blockprocessor/internal/catchupservice.go
@@ -17,6 +17,8 @@ import (
 	"github.com/algorand/indexer/util"
 )
 
+var Delay = 5 * time.Second
+
 // makeNodeProvider initializes the node provider.
 func makeNodeProvider(ctx context.Context) nodeProvider {
 	return nodeProvider{
@@ -89,7 +91,7 @@ func CatchupServiceCatchup(ctx context.Context, logger *log.Logger, round basics
 	}
 
 	select {
-	case <-time.After(5 * time.Second):
+	case <-time.After(Delay):
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -98,7 +100,7 @@ func CatchupServiceCatchup(ctx context.Context, logger *log.Logger, round basics
 	running := true
 	for running {
 		select {
-		case <-time.After(5 * time.Second):
+		case <-time.After(Delay):
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/processor/blockprocessor/internal/catchupservice.go
+++ b/processor/blockprocessor/internal/catchupservice.go
@@ -62,7 +62,10 @@ func CatchupServiceCatchup(ctx context.Context, logger *log.Logger, round basics
 	if err != nil {
 		return fmt.Errorf("CatchupServiceCatchup() MakeLedger err: %w", err)
 	}
-	defer l.Close()
+	defer func() {
+		l.WaitForCommit(l.Latest())
+		l.Close()
+	}()
 
 	p2pNode, err := network.NewWebsocketNetwork(wrappedLogger, cfg, nil, genesis.ID(), genesis.Network, node)
 	if err != nil {


### PR DESCRIPTION
## Summary

Disable full node catchup routine, enable catchpoint catchup service routine.

## Test Plan

Manual testing:
1) Initialize ledger when postgres is within 10 rounds of the catchpoint.
2) Restart indexer after the initialization has already started and made some progress.
3) Ctrl-C stops the catchup.