### PR TITLE
Use main logger in handler and fetcher.

### DIFF
--- a/processor/blockprocessor/initialize_test.go
+++ b/processor/blockprocessor/initialize_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/jarcoal/httpmock"
-	"github.com/sirupsen/logrus"
 	test2 "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
@@ -65,9 +64,9 @@ func TestRunMigration(t *testing.T) {
 	}
 
 	// migrate 3 rounds
-	err = InitializeLedgerSimple(context.Background(), logrus.New(), 3, &opts)
-	assert.NoError(t, err)
 	log, _ := test2.NewNullLogger()
+	err = InitializeLedgerSimple(context.Background(), log, 3, &opts)
+	assert.NoError(t, err)
 	l, err := util.MakeLedger(log, false, &genesis, opts.IndexerDatadir)
 	assert.NoError(t, err)
 	// check 3 rounds written to ledger
@@ -75,7 +74,7 @@ func TestRunMigration(t *testing.T) {
 	l.Close()
 
 	// migration continues from last round
-	err = InitializeLedgerSimple(context.Background(), logrus.New(), 6, &opts)
+	err = InitializeLedgerSimple(context.Background(), log, 6, &opts)
 	assert.NoError(t, err)
 
 	l, err = util.MakeLedger(log, false, &genesis, opts.IndexerDatadir)


### PR DESCRIPTION
## Summary

There were a couple more places where we were still creating a second logger, and logging to stdout instead of the log file.