### PR TITLE
Revert: update ubuntu from 18.04 to 20.04 (#1072)

### DIFF
--- a/misc/docker/build.ubuntu.Dockerfile
+++ b/misc/docker/build.ubuntu.Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH="amd64"
-FROM ${ARCH}/ubuntu:20.04
+FROM ${ARCH}/ubuntu:18.04
 ARG GOLANG_VERSION
 ARG GOARCH="amd64"
 ARG ARCH="amd64"


### PR DESCRIPTION
## Summary

Since we want to continue supporting ubuntu 18.04 until around fall this year, we need to revert this premature ubuntu version update from our builds.
