### PR TITLE
Start block generator at round 1 to match new behavior, wait for indexer process to exit.

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -148,7 +148,9 @@ func Serve(ctx context.Context, serveAddr string, db idb.IndexerDb, fetcherError
 	}
 
 	go func() {
-		log.Fatal(e.StartServer(s))
+		if err := e.StartServer(s); err != nil {
+			log.Fatal("Serve() err: %s", err)
+		}
 	}()
 
 	<-ctx.Done()

--- a/api/server.go
+++ b/api/server.go
@@ -149,7 +149,7 @@ func Serve(ctx context.Context, serveAddr string, db idb.IndexerDb, fetcherError
 
 	go func() {
 		if err := e.StartServer(s); err != nil {
-			log.Fatal("Serve() err: %s", err)
+			log.Fatalf("Serve() err: %s", err)
 		}
 	}()
 

--- a/cmd/block-generator/generator/generate.go
+++ b/cmd/block-generator/generator/generate.go
@@ -101,7 +101,7 @@ func MakeGenerator(config GenerationConfig) (Generator, error) {
 		genesisHash:               [32]byte{},
 		genesisID:                 "blockgen-test",
 		prevBlockHash:             "",
-		round:                     0,
+		round:                     1,
 		txnCounter:                0,
 		timestamp:                 0,
 		rewardsLevel:              0,

--- a/cmd/block-generator/run_tests.sh
+++ b/cmd/block-generator/run_tests.sh
@@ -5,6 +5,7 @@ INDEXER_BINARY=""
 REPORT_DIR=""
 DURATION="1h"
 LOG_LEVEL="error"
+SCENARIOS=""
 
 help() {
   echo "Usage:"
@@ -12,6 +13,7 @@ help() {
   echo " -c|--connection-string"
   echo "                 PostgreSQL connection string."
   echo " -i|--indexer    path to indexer binary."
+  echo " -s|--scenarios  path to indexer test scenarios."
   echo " -r|--report-dir directory where the report should be written."
   echo " -d|--duration   test duration."
   echo " -l|--level      log level to pass to Indexer."
@@ -60,6 +62,11 @@ if [ -z "$INDEXER_BINARY" ]; then
   exit 1
 fi
 
+if [ -z "$SCENARIOS" ]; then
+  echo "Missing required indexer test scenario parameter (-s / --scenarios)."
+  exit 1
+fi
+
 echo "Running with binary: $INDEXER_BINARY"
 echo "Report directory: $REPORT_DIR"
 echo "Duration: $DURATION"
@@ -68,7 +75,7 @@ echo "Log Level: $LOG_LEVEL"
 "$INDEXER_BINARY" \
          util block-generator runner \
   -i "$INDEXER_BINARY" \
-  -s /home/ubuntu/scenarios/ \
+  -s "$SCENARIOS" \
   -d "$DURATION" \
   -c "$CONNECTION_STRING" \
   --report-directory "$REPORT_DIR" \

--- a/cmd/block-generator/run_tests.sh
+++ b/cmd/block-generator/run_tests.sh
@@ -17,6 +17,7 @@ help() {
   echo " -r|--report-dir directory where the report should be written."
   echo " -d|--duration   test duration."
   echo " -l|--level      log level to pass to Indexer."
+  echo " -g|--generator  use a different indexer binary to run the generator."
   exit
 }
 
@@ -26,6 +27,10 @@ while :; do
   -v | --verbose) set -x ;;
   -c | --connection-string)
     CONNECTION_STRING="${2-}"
+    shift
+    ;;
+  -g | --generator)
+    GENERATOR_BINARY="${2-}"
     shift
     ;;
   -i | --indexer)
@@ -71,12 +76,17 @@ if [ -z "$SCENARIOS" ]; then
   exit 1
 fi
 
+if [ -z "$GENERATOR_BINARY" ]; then
+  echo "Using indexer binary for generator, override with (-g / --generator)."
+  GENERATOR_BINARY="$INDEXER_BINARY"
+fi
+
 echo "Running with binary: $INDEXER_BINARY"
 echo "Report directory: $REPORT_DIR"
 echo "Duration: $DURATION"
 echo "Log Level: $LOG_LEVEL"
 
-"$INDEXER_BINARY" \
+"$GENERATOR_BINARY" \
          util block-generator runner \
   -i "$INDEXER_BINARY" \
   -s "$SCENARIOS" \

--- a/cmd/block-generator/run_tests.sh
+++ b/cmd/block-generator/run_tests.sh
@@ -7,45 +7,45 @@ DURATION="1h"
 LOG_LEVEL="error"
 
 help() {
-	echo "Usage:"
-	echo " -v|--verbose    enable verbose script output."
+  echo "Usage:"
+  echo " -v|--verbose    enable verbose script output."
   echo " -c|--connection-string"
   echo "                 PostgreSQL connection string."
-	echo " -i|--indexer    path to indexer binary."
-	echo " -r|--report-dir directory where the report should be written."
-	echo " -d|--duration   test duration."
+  echo " -i|--indexer    path to indexer binary."
+  echo " -r|--report-dir directory where the report should be written."
+  echo " -d|--duration   test duration."
   echo " -l|--level      log level to pass to Indexer."
-	exit
+  exit
 }
 
 while :; do
-	case "${1-}" in
-	-h | --help) help ;;
-	-v | --verbose) set -x ;;
+  case "${1-}" in
+  -h | --help) help ;;
+  -v | --verbose) set -x ;;
   -c | --connection-string)
-		INDEXER_BINARY="${2-}"
-		shift
-		;;
-	-i | --indexer)
-		CONNECTION_STRING="${2-}"
-		shift
-		;;
-	-r | --report-dir)
-		REPORT_DIR="${2-}"
-		shift
-		;;
-	-d | --duration)
-		DURATION="${2-}"
-		shift
-		;;
-	-l | --level)
-		LOG_LEVEL="${2-}"
-		shift
-		;;
-	-?*) echo "Unknown option: $1" && exit 1;;
-	*) break ;;
-	esac
-	shift
+    CONNECTION_STRING="${2-}"
+    shift
+    ;;
+  -i | --indexer)
+    INDEXER_BINARY="${2-}"
+    shift
+    ;;
+  -r | --report-dir)
+    REPORT_DIR="${2-}"
+    shift
+    ;;
+  -d | --duration)
+    DURATION="${2-}"
+    shift
+    ;;
+  -l | --level)
+    LOG_LEVEL="${2-}"
+    shift
+    ;;
+  -?*) echo "Unknown option: $1" && exit 1;;
+  *) break ;;
+  esac
+  shift
 done
 
 args=("$@")
@@ -66,12 +66,12 @@ echo "Duration: $DURATION"
 echo "Log Level: $LOG_LEVEL"
 
 "$INDEXER_BINARY" \
-       	util block-generator runner \
-	-i "$INDEXER_BINARY" \
-	-s /home/ubuntu/scenarios/ \
-	-d "$DURATION" \
-	-c "$CONNECTION_STRING" \
-	--report-directory "$REPORT_DIR" \
-	--log-level "$LOG_LEVEL" \
-	--reset
+         util block-generator runner \
+  -i "$INDEXER_BINARY" \
+  -s /home/ubuntu/scenarios/ \
+  -d "$DURATION" \
+  -c "$CONNECTION_STRING" \
+  --report-directory "$REPORT_DIR" \
+  --log-level "$LOG_LEVEL" \
+  --reset
 

--- a/cmd/block-generator/run_tests.sh
+++ b/cmd/block-generator/run_tests.sh
@@ -36,6 +36,10 @@ while :; do
     REPORT_DIR="${2-}"
     shift
     ;;
+  -s | --scenarios)
+    SCENARIOS="${2-}"
+    shift
+    ;;
   -d | --duration)
     DURATION="${2-}"
     shift

--- a/cmd/block-generator/run_tests.sh
+++ b/cmd/block-generator/run_tests.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+CONNECTION_STRING=""
+INDEXER_BINARY=""
+REPORT_DIR=""
+DURATION="1h"
+LOG_LEVEL="error"
+
+help() {
+	echo "Usage:"
+	echo " -v|--verbose    enable verbose script output."
+  echo " -c|--connection-string"
+  echo "                 PostgreSQL connection string."
+	echo " -i|--indexer    path to indexer binary."
+	echo " -r|--report-dir directory where the report should be written."
+	echo " -d|--duration   test duration."
+  echo " -l|--level      log level to pass to Indexer."
+	exit
+}
+
+while :; do
+	case "${1-}" in
+	-h | --help) help ;;
+	-v | --verbose) set -x ;;
+  -c | --connection-string)
+		INDEXER_BINARY="${2-}"
+		shift
+		;;
+	-i | --indexer)
+		CONNECTION_STRING="${2-}"
+		shift
+		;;
+	-r | --report-dir)
+		REPORT_DIR="${2-}"
+		shift
+		;;
+	-d | --duration)
+		DURATION="${2-}"
+		shift
+		;;
+	-l | --level)
+		LOG_LEVEL="${2-}"
+		shift
+		;;
+	-?*) echo "Unknown option: $1" && exit 1;;
+	*) break ;;
+	esac
+	shift
+done
+
+args=("$@")
+
+if [ -z "$CONNECTION_STRING" ]; then
+  echo "Missing required connection string parameter (-c / --connection-string)."
+  exit 1
+fi
+
+if [ -z "$INDEXER_BINARY" ]; then
+  echo "Missing required indexer binary parameter (-i / --indexer)."
+  exit 1
+fi
+
+echo "Running with binary: $INDEXER_BINARY"
+echo "Report directory: $REPORT_DIR"
+echo "Duration: $DURATION"
+echo "Log Level: $LOG_LEVEL"
+
+"$INDEXER_BINARY" \
+       	util block-generator runner \
+	-i "$INDEXER_BINARY" \
+	-s /home/ubuntu/scenarios/ \
+	-d "$DURATION" \
+	-c "$CONNECTION_STRING" \
+	--report-directory "$REPORT_DIR" \
+	--log-level "$LOG_LEVEL" \
+	--reset
+

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -447,7 +447,10 @@ func startIndexer(dataDir string, logfile string, loglevel string, indexerBinary
 
 	return func() error {
 		if err := cmd.Process.Signal(os.Interrupt); err != nil {
-			return fmt.Errorf("failed to kill indexer process: %w", err)
+			fmt.Printf("failed to kill indexer process: %w\n", err)
+			if err := cmd.Process.Kill(); err != nil {
+				return fmt.Errorf("failed to kill indexer process: %w\n", err)
+			}
 		}
 		if err := cmd.Wait(); err != nil {
 			return fmt.Errorf("error waiting for process to stop: %w", err)

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -36,6 +36,7 @@ type Args struct {
 	ReportDirectory          string
 	ResetReportDir           bool
 	RunValidation            bool
+	KeepDataDir              bool
 }
 
 // Run is a public helper to run the tests.
@@ -73,7 +74,9 @@ func (r *Args) run() error {
 	reportfile := path.Join(r.ReportDirectory, fmt.Sprintf("%s.report", baseNameNoExt))
 	logfile := path.Join(r.ReportDirectory, fmt.Sprintf("%s.indexer-log", baseNameNoExt))
 	dataDir := path.Join(r.ReportDirectory, fmt.Sprintf("%s_data", baseNameNoExt))
-	//defer os.RemoveAll(dataDir)
+	if !r.KeepDataDir {
+		defer os.RemoveAll(dataDir)
+	}
 
 	// This middleware allows us to lock the block endpoint
 	var freezeMutex sync.Mutex

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -452,9 +452,9 @@ func startIndexer(dataDir string, logfile string, loglevel string, indexerBinary
 
 	return func() error {
 		if err := cmd.Process.Signal(os.Interrupt); err != nil {
-			fmt.Printf("failed to kill indexer process: %w\n", err)
+			fmt.Printf("failed to kill indexer process: %s\n", err)
 			if err := cmd.Process.Kill(); err != nil {
-				return fmt.Errorf("failed to kill indexer process: %w\n", err)
+				return fmt.Errorf("failed to kill indexer process: %w", err)
 			}
 		}
 		if err := cmd.Wait(); err != nil {

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -453,7 +453,7 @@ func startIndexer(dataDir string, logfile string, loglevel string, indexerBinary
 			}
 		}
 		if err := cmd.Wait(); err != nil {
-			return fmt.Errorf("error waiting for process to stop: %w", err)
+			fmt.Printf("ignoring error while waiting for process to stop: %s\n", err)
 		}
 		return nil
 	}, nil

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -73,7 +73,7 @@ func (r *Args) run() error {
 	reportfile := path.Join(r.ReportDirectory, fmt.Sprintf("%s.report", baseNameNoExt))
 	logfile := path.Join(r.ReportDirectory, fmt.Sprintf("%s.indexer-log", baseNameNoExt))
 	dataDir := path.Join(r.ReportDirectory, fmt.Sprintf("%s_data", baseNameNoExt))
-	defer os.RemoveAll(dataDir)
+	//defer os.RemoveAll(dataDir)
 
 	// This middleware allows us to lock the block endpoint
 	var freezeMutex sync.Mutex
@@ -271,15 +271,17 @@ func (r *Args) runTest(report *os.File, indexerURL string, generatorURL string) 
 
 	// Run for r.RunDuration
 	start := time.Now()
+	count := 1
 	for time.Since(start) < r.RunDuration {
 		time.Sleep(r.RunDuration / 10)
 
 		if err := collector.Collect(metrics.AllMetricNames...); err != nil {
-			return fmt.Errorf("problem collecting metrics: %w", err)
+			return fmt.Errorf("problem collecting metrics (%d / %s): %w", count, time.Since(start), err)
 		}
+		count++
 	}
 	if err := collector.Collect(metrics.AllMetricNames...); err != nil {
-		return fmt.Errorf("problem collecting metrics: %w", err)
+		return fmt.Errorf("problem collecting final metrics (%d / %s): %w", count, time.Since(start), err)
 	}
 
 	// Collect results.

--- a/cmd/block-generator/runner/runner.go
+++ b/cmd/block-generator/runner/runner.go
@@ -36,6 +36,7 @@ func init() {
 	RunnerCmd.Flags().StringVarP(&runnerArgs.CPUProfilePath, "cpuprofile", "", "", "Path where Indexer writes its CPU profile.")
 	RunnerCmd.Flags().BoolVarP(&runnerArgs.ResetReportDir, "reset", "", false, "If set any existing report directory will be deleted before running tests.")
 	RunnerCmd.Flags().BoolVarP(&runnerArgs.RunValidation, "validate", "", false, "If set the validator will run after test-duration has elapsed to verify data is correct. An extra line in each report indicates validator success or failure.")
+	RunnerCmd.Flags().BoolVarP(&runnerArgs.KeepDataDir, "keep-data-dir", "k", false, "If set the validator will not delete the data directory after tests complete.")
 
 	RunnerCmd.MarkFlagRequired("scenario")
 	RunnerCmd.MarkFlagRequired("indexer-binary")


### PR DESCRIPTION
## Summary

Fix the perf testing tool. We no longer fetch round 0 so the generator must start at round 1.