### PR TITLE
Don't lookup big foreign assets.

### DIFF
--- a/accounting/eval_preload.go
+++ b/accounting/eval_preload.go
@@ -1,6 +1,8 @@
 package accounting
 
 import (
+	"math"
+
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger"
@@ -34,9 +36,15 @@ func addToCreatorsRequest(stxnad *transactions.SignedTxnWithAD, assetsReq map[ba
 			appsReq[fields.ApplicationID] = struct{}{}
 		}
 		for _, index := range fields.ForeignApps {
+			if index > basics.AppIndex(math.MaxInt64) {
+				continue
+			}
 			appsReq[index] = struct{}{}
 		}
 		for _, index := range fields.ForeignAssets {
+			if index > basics.AssetIndex(math.MaxInt64) {
+				continue
+			}
 			assetsReq[index] = struct{}{}
 		}
 	}
@@ -161,6 +169,9 @@ func addToAccountsResourcesRequest(stxnad *transactions.SignedTxnWithAD, assetCr
 			addressesReq[address] = struct{}{}
 		}
 		for _, index := range fields.ForeignApps {
+			if index > basics.AppIndex(math.MaxInt64) {
+				continue
+			}
 			if creator := appCreators[index]; creator.Exists {
 				creatable := ledger.Creatable{
 					Index: basics.CreatableIndex(index),
@@ -170,6 +181,9 @@ func addToAccountsResourcesRequest(stxnad *transactions.SignedTxnWithAD, assetCr
 			}
 		}
 		for _, index := range fields.ForeignAssets {
+			if index > basics.AssetIndex(math.MaxInt64) {
+				continue
+			}
 			if creator := assetCreators[index]; creator.Exists {
 				creatable := ledger.Creatable{
 					Index: basics.CreatableIndex(index),

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -9,7 +9,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"math"
 	"os"
 	"strings"
 	"sync"
@@ -181,19 +180,6 @@ func (db *IndexerDb) init(opts idb.IndexerDbOptions) (chan struct{}, error) {
 // Preload asset and app creators.
 func prepareCreators(l *ledger_for_evaluator.LedgerForEvaluator, payset transactions.Payset) (map[basics.AssetIndex]ledger.FoundAddress, map[basics.AppIndex]ledger.FoundAddress, error) {
 	assetsReq, appsReq := accounting.MakePreloadCreatorsRequest(payset)
-
-	for aidx := range assetsReq {
-		if aidx >= basics.AssetIndex(math.MaxInt64) {
-			delete(assetsReq, aidx)
-		}
-	}
-
-	for aidx := range appsReq {
-		if aidx >= basics.AppIndex(math.MaxInt64) {
-			delete(appsReq, aidx)
-		}
-	}
-
 	assets, err := l.GetAssetCreator(assetsReq)
 	if err != nil {
 		return nil, nil, fmt.Errorf("prepareCreators() err: %w", err)
@@ -210,14 +196,6 @@ func prepareCreators(l *ledger_for_evaluator.LedgerForEvaluator, payset transact
 func prepareAccountsResources(l *ledger_for_evaluator.LedgerForEvaluator, payset transactions.Payset, assetCreators map[basics.AssetIndex]ledger.FoundAddress, appCreators map[basics.AppIndex]ledger.FoundAddress) (map[basics.Address]*ledgercore.AccountData, map[basics.Address]map[ledger.Creatable]ledgercore.AccountResource, error) {
 	addressesReq, resourcesReq :=
 		accounting.MakePreloadAccountsResourcesRequest(payset, assetCreators, appCreators)
-
-	for addr := range resourcesReq {
-		for cidx := range resourcesReq[addr] {
-			if cidx.Index >= basics.CreatableIndex(math.MaxInt64) {
-				delete(resourcesReq[addr], cidx)
-			}
-		}
-	}
 
 	accounts, err := l.LookupWithoutRewards(addressesReq)
 	if err != nil {


### PR DESCRIPTION
## Summary

We missed the common code path in the previous hotfix, this is the same fix as before but we avoid adding these assets and apps to begin with.