### PR TITLE
test fixes: Submodule updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/algorand/falcon v0.0.0-20220130164023-c9e1d466f123 // indirect
 	github.com/algorand/go-deadlock v0.2.2 // indirect
 	github.com/algorand/go-sumhash v0.1.0 // indirect
-	github.com/algorand/graphtrace v0.1.0 // indirect
 	github.com/algorand/msgp v1.1.52 // indirect
 	github.com/algorand/websocket v1.4.5 // indirect
 	github.com/aws/aws-sdk-go v1.30.19 // indirect
@@ -51,6 +50,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/gorilla/mux v1.7.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -333,6 +333,8 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219/go.mod h1:/X8TswGSh1pIozq4ZwCfxS0WA5JGXguxk94ar/4c87Y=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -165,7 +165,8 @@ func TestAssetCloseReopenTransfer(t *testing.T) {
 	// Given // A round scenario requiring subround accounting: AccountA is funded, closed, opts back, and funded again.
 	///////////
 	createAsset := test.MakeAssetConfigTxn(0, total, uint64(6), false, "mcn", "my coin", "http://antarctica.com", test.AccountD)
-	optInA := test.MakeAssetOptInTxn(assetid, test.AccountA)
+	optInA1 := test.MakeAssetOptInTxn(assetid, test.AccountA)
+	optInA2 := test.MakeAssetOptInTxn(assetid, test.AccountA)
 	fundA := test.MakeAssetTransferTxn(assetid, amt, test.AccountD, test.AccountA, basics.Address{})
 	optInB := test.MakeAssetOptInTxn(assetid, test.AccountB)
 	optInC := test.MakeAssetOptInTxn(assetid, test.AccountC)
@@ -173,8 +174,8 @@ func TestAssetCloseReopenTransfer(t *testing.T) {
 	payMain := test.MakeAssetTransferTxn(assetid, amt, test.AccountD, test.AccountA, basics.Address{})
 
 	block, err := test.MakeBlockForTxns(
-		test.MakeGenesisBlock().BlockHeader, &createAsset, &optInA, &fundA, &optInB,
-		&optInC, &closeA, &optInA, &payMain)
+		test.MakeGenesisBlock().BlockHeader, &createAsset, &optInA1, &fundA, &optInB,
+		&optInC, &closeA, &optInA2, &payMain)
 	require.NoError(t, err)
 
 	//////////
@@ -215,7 +216,8 @@ func TestReCreateAssetHolding(t *testing.T) {
 		createAssetFrozen := test.MakeAssetConfigTxn(
 			0, total, uint64(6), frozen, "icicles", "frozen coin",
 			"http://antarctica.com", test.AccountA)
-		optinB := test.MakeAssetOptInTxn(assetid, test.AccountB)
+		optinB1 := test.MakeAssetOptInTxn(assetid, test.AccountB)
+		optinB2 := test.MakeAssetOptInTxn(assetid, test.AccountB)
 		unfreezeB := test.MakeAssetFreezeTxn(
 			assetid, !frozen, test.AccountA, test.AccountB)
 		optoutB := test.MakeAssetTransferTxn(
@@ -223,8 +225,8 @@ func TestReCreateAssetHolding(t *testing.T) {
 
 		var err error
 		block, err = test.MakeBlockForTxns(
-			block.BlockHeader, &createAssetFrozen, &optinB, &unfreezeB,
-			&optoutB, &optinB)
+			block.BlockHeader, &createAssetFrozen, &optinB1, &unfreezeB,
+			&optoutB, &optinB2)
 		require.NoError(t, err)
 
 		//////////
@@ -256,11 +258,12 @@ func TestNoopOptins(t *testing.T) {
 	createAsset := test.MakeAssetConfigTxn(
 		0, uint64(1000000), uint64(6), true, "icicles", "frozen coin",
 		"http://antarctica.com", test.AccountD)
-	optinB := test.MakeAssetOptInTxn(assetid, test.AccountB)
+	optinB1 := test.MakeAssetOptInTxn(assetid, test.AccountB)
+	optinB2 := test.MakeAssetOptInTxn(assetid, test.AccountB)
 	unfreezeB := test.MakeAssetFreezeTxn(assetid, false, test.AccountD, test.AccountB)
 
 	block, err := test.MakeBlockForTxns(
-		test.MakeGenesisBlock().BlockHeader, &createAsset, &optinB, &unfreezeB, &optinB)
+		test.MakeGenesisBlock().BlockHeader, &createAsset, &optinB1, &unfreezeB, &optinB2)
 	require.NoError(t, err)
 
 	//////////

--- a/processor/eval/ledger_for_evaluator.go
+++ b/processor/eval/ledger_for_evaluator.go
@@ -149,6 +149,7 @@ func (l LedgerForEvaluator) LatestTotals() (ledgercore.AccountTotals, error) {
 	return totals, err
 }
 
+// BlockHdrCached is part of go-algorand's indexerLedgerForEval interface.
 func (l LedgerForEvaluator) BlockHdrCached(round basics.Round) (bookkeeping.BlockHeader, error) {
 	return l.Ledger.BlockHdrCached(round)
 }

--- a/processor/eval/ledger_for_evaluator.go
+++ b/processor/eval/ledger_for_evaluator.go
@@ -148,3 +148,7 @@ func (l LedgerForEvaluator) LatestTotals() (ledgercore.AccountTotals, error) {
 	_, totals, err := l.Ledger.LatestTotals()
 	return totals, err
 }
+
+func (l LedgerForEvaluator) BlockHdrCached(round basics.Round) (bookkeeping.BlockHeader, error) {
+	return l.Ledger.BlockHdrCached(round)
+}

--- a/processor/eval/ledger_for_evaluator.go
+++ b/processor/eval/ledger_for_evaluator.go
@@ -151,5 +151,5 @@ func (l LedgerForEvaluator) LatestTotals() (ledgercore.AccountTotals, error) {
 
 // BlockHdrCached is part of go-algorand's indexerLedgerForEval interface.
 func (l LedgerForEvaluator) BlockHdrCached(round basics.Round) (bookkeeping.BlockHeader, error) {
-	return l.Ledger.BlockHdrCached(round)
+	panic("not implemented")
 }

--- a/util/test/account_testutil.go
+++ b/util/test/account_testutil.go
@@ -2,12 +2,13 @@ package test
 
 import (
 	"fmt"
-
+	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/protocol"
+	"math/rand"
 )
 
 var (
@@ -58,6 +59,7 @@ func MakeAssetConfigTxn(configid, total, decimals uint64, defaultFrozen bool, un
 					Sender:      addr,
 					Fee:         basics.MicroAlgos{Raw: 1000},
 					GenesisHash: GenesisHash,
+					Note:        ArbitraryString(),
 				},
 				AssetConfigTxnFields: transactions.AssetConfigTxnFields{
 					ConfigAsset: basics.AssetIndex(configid),
@@ -91,6 +93,7 @@ func MakeAssetFreezeTxn(assetid uint64, frozen bool, sender, freezeAccount basic
 					Sender:      sender,
 					Fee:         basics.MicroAlgos{Raw: 1000},
 					GenesisHash: GenesisHash,
+					Note:        ArbitraryString(),
 				},
 				AssetFreezeTxnFields: transactions.AssetFreezeTxnFields{
 					FreezeAccount: freezeAccount,
@@ -113,6 +116,7 @@ func MakeAssetTransferTxn(assetid, amt uint64, sender, receiver, close basics.Ad
 					Sender:      sender,
 					Fee:         basics.MicroAlgos{Raw: 1000},
 					GenesisHash: GenesisHash,
+					Note:        ArbitraryString(),
 				},
 				AssetTransferTxnFields: transactions.AssetTransferTxnFields{
 					XferAsset:   basics.AssetIndex(assetid),
@@ -142,6 +146,7 @@ func MakeAssetDestroyTxn(assetID uint64, sender basics.Address) transactions.Sig
 				Header: transactions.Header{
 					Sender:      sender,
 					GenesisHash: GenesisHash,
+					Note:        ArbitraryString(),
 				},
 				AssetConfigTxnFields: transactions.AssetConfigTxnFields{
 					ConfigAsset: basics.AssetIndex(assetID),
@@ -165,6 +170,7 @@ func MakePaymentTxn(fee, amt, closeAmt, sendRewards, receiveRewards,
 					GenesisHash: GenesisHash,
 					RekeyTo:     rekeyTo,
 					LastValid:   10,
+					Note:        ArbitraryString(),
 				},
 				PaymentTxnFields: transactions.PaymentTxnFields{
 					Receiver:         receiver,
@@ -193,6 +199,7 @@ func MakeCreateAppTxn(sender basics.Address) transactions.SignedTxnWithAD {
 				Header: transactions.Header{
 					Sender:      sender,
 					GenesisHash: GenesisHash,
+					Note:        ArbitraryString(),
 				},
 				ApplicationCallTxnFields: transactions.ApplicationCallTxnFields{
 					ApprovalProgram:   []byte{0x02, 0x20, 0x01, 0x01, 0x22},
@@ -213,6 +220,7 @@ func MakeAppDestroyTxn(appid uint64, sender basics.Address) transactions.SignedT
 				Header: transactions.Header{
 					Sender:      sender,
 					GenesisHash: GenesisHash,
+					Note:        ArbitraryString(),
 				},
 				ApplicationCallTxnFields: transactions.ApplicationCallTxnFields{
 					ApplicationID:     basics.AppIndex(appid),
@@ -235,6 +243,7 @@ func MakeAppOptInTxn(appid uint64, sender basics.Address) transactions.SignedTxn
 				Header: transactions.Header{
 					Sender:      sender,
 					GenesisHash: GenesisHash,
+					Note:        ArbitraryString(),
 				},
 				ApplicationCallTxnFields: transactions.ApplicationCallTxnFields{
 					ApplicationID: basics.AppIndex(appid),
@@ -255,6 +264,7 @@ func MakeAppOptOutTxn(appid uint64, sender basics.Address) transactions.SignedTx
 				Header: transactions.Header{
 					Sender:      sender,
 					GenesisHash: GenesisHash,
+					Note:        ArbitraryString(),
 				},
 				ApplicationCallTxnFields: transactions.ApplicationCallTxnFields{
 					ApplicationID: basics.AppIndex(appid),
@@ -275,6 +285,7 @@ func MakeAppCallTxn(appid uint64, sender basics.Address) transactions.SignedTxnW
 				Header: transactions.Header{
 					Sender:      sender,
 					GenesisHash: GenesisHash,
+					Note:        ArbitraryString(),
 				},
 				ApplicationCallTxnFields: transactions.ApplicationCallTxnFields{
 					ApplicationID:     basics.AppIndex(appid),
@@ -315,6 +326,7 @@ func MakeAppCallWithInnerTxn(appSender, paymentSender, paymentReceiver, assetSen
 					Type: protocol.PaymentTx,
 					Header: transactions.Header{
 						Sender: paymentSender,
+						Note:   ArbitraryString(),
 					},
 					PaymentTxnFields: transactions.PaymentTxnFields{
 						Receiver: paymentReceiver,
@@ -329,6 +341,7 @@ func MakeAppCallWithInnerTxn(appSender, paymentSender, paymentReceiver, assetSen
 					Type: protocol.ApplicationCallTx,
 					Header: transactions.Header{
 						Sender: assetSender,
+						Note:   ArbitraryString(),
 					},
 					ApplicationCallTxnFields: transactions.ApplicationCallTxnFields{
 						ApplicationID:     789,
@@ -349,6 +362,7 @@ func MakeAppCallWithInnerTxn(appSender, paymentSender, paymentReceiver, assetSen
 									Type: protocol.AssetTransferTx,
 									Header: transactions.Header{
 										Sender: assetSender,
+										Note:   ArbitraryString(),
 									},
 									AssetTransferTxnFields: transactions.AssetTransferTxnFields{
 										AssetReceiver: assetReceiver,
@@ -393,6 +407,7 @@ func MakeAppCallWithMultiLogs(appSender basics.Address) transactions.SignedTxnWi
 					Type: protocol.ApplicationCallTx,
 					Header: transactions.Header{
 						Sender: appSender,
+						Note:   ArbitraryString(),
 					},
 					ApplicationCallTxnFields: transactions.ApplicationCallTxnFields{
 						ApplicationID: 789,
@@ -457,6 +472,7 @@ func MakeAppCallWithInnerAppCall(appSender basics.Address) transactions.SignedTx
 					Type: protocol.ApplicationCallTx,
 					Header: transactions.Header{
 						Sender: appSender,
+						Note:   ArbitraryString(),
 					},
 					ApplicationCallTxnFields: transactions.ApplicationCallTxnFields{
 						ApplicationID: 789,
@@ -478,6 +494,7 @@ func MakeAppCallWithInnerAppCall(appSender basics.Address) transactions.SignedTx
 									Type: protocol.ApplicationCallTx,
 									Header: transactions.Header{
 										Sender: appSender,
+										Note:   ArbitraryString(),
 									},
 									ApplicationCallTxnFields: transactions.ApplicationCallTxnFields{
 										ApplicationID: 789,
@@ -494,6 +511,7 @@ func MakeAppCallWithInnerAppCall(appSender basics.Address) transactions.SignedTx
 									Header: transactions.Header{
 										Sender:      appSender,
 										GenesisHash: GenesisHash,
+										Note:        ArbitraryString(),
 									},
 									ApplicationCallTxnFields: transactions.ApplicationCallTxnFields{
 										ApprovalProgram:   []byte{0x02, 0x20, 0x01, 0x01, 0x22},
@@ -601,4 +619,12 @@ func MakeGenesisBlock() bookkeeping.Block {
 		return bookkeeping.Block{}
 	}
 	return genesisBlock
+}
+
+// ArbitraryString should be used to generate a pseudo-random string to put in the Note field of a Txn Header.
+// This is necessary to ensure the hash of any two txns used in tests are never the same.
+func ArbitraryString() []byte {
+	arb := make([]byte, config.MaxTxnNoteBytes)
+	rand.Read(arb)
+	return arb
 }


### PR DESCRIPTION


## Summary

A new field in Teal has shown up in the e2e test files which means that we need to update the submodule. However, because the submodule update also pulls in the 320 round changes, there are some test failures showing up.

The root cause/fix for these is that each transaction submitted to a ledger needs to have a different checksum. In order to accomplish this I've put a "random" byte array into the notes field of each transaction created, and have re-created transactions instead of reusing them in our tests.

I've also added a new LedgerForEvaluator method since that was added the upstream interface as well. It is a very simple wrapper method.

## Test Plan

CI
