### PR TITLE
Conduit: Exporter daemon integration

### DIFF
--- a/cmd/algorand-indexer/daemon_test.go
+++ b/cmd/algorand-indexer/daemon_test.go
@@ -49,11 +49,7 @@ func TestImportRetryAndCancel(t *testing.T) {
 	l, err := itest.MakeTestLedger(ledgerLogger)
 	assert.NoError(t, err)
 	defer l.Close()
-<<<<<<< HEAD
-	proc, err := blockprocessor.MakeProcessorWithLedger(logger, l, nil)
-=======
-	proc, err := blockprocessor.MakeProcessorWithLedger(l, imp.ImportBlock)
->>>>>>> 97e3a69 (Integrate postgresql exporter w/ daemon)
+	proc, err := blockprocessor.MakeProcessorWithLedger(logger, l, imp.ImportBlock)
 	assert.Nil(t, err)
 	handler := blockHandler(proc, 50*time.Millisecond)
 	var wg sync.WaitGroup

--- a/cmd/algorand-indexer/daemon_test.go
+++ b/cmd/algorand-indexer/daemon_test.go
@@ -49,9 +49,12 @@ func TestImportRetryAndCancel(t *testing.T) {
 	l, err := itest.MakeTestLedger(ledgerLogger)
 	assert.NoError(t, err)
 	defer l.Close()
+<<<<<<< HEAD
 	proc, err := blockprocessor.MakeProcessorWithLedger(logger, l, nil)
+=======
+	proc, err := blockprocessor.MakeProcessorWithLedger(l, imp.ImportBlock)
+>>>>>>> 97e3a69 (Integrate postgresql exporter w/ daemon)
 	assert.Nil(t, err)
-	proc.SetHandler(imp.ImportBlock)
 	handler := blockHandler(proc, 50*time.Millisecond)
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/exporters/noop/noop_exporter.go
+++ b/exporters/noop/noop_exporter.go
@@ -17,7 +17,8 @@ type noopExporter struct {
 	cfg   plugins.PluginConfig
 }
 
-var noopExporterMetadata exporters.ExporterMetadata = exporters.ExporterMetadata{
+// Metadata for the noop Exporter
+var Metadata exporters.ExporterMetadata = exporters.ExporterMetadata{
 	ExpName:        "noop",
 	ExpDescription: "noop exporter",
 	ExpDeprecated:  false,
@@ -35,7 +36,7 @@ func (c *Constructor) New() exporters.Exporter {
 }
 
 func (exp *noopExporter) Metadata() exporters.ExporterMetadata {
-	return noopExporterMetadata
+	return Metadata
 }
 
 func (exp *noopExporter) Init(_ plugins.PluginConfig, _ *logrus.Logger) error {
@@ -64,5 +65,5 @@ func (exp *noopExporter) Round() uint64 {
 }
 
 func init() {
-	exporters.RegisterExporter(noopExporterMetadata.ExpName, &Constructor{})
+	exporters.RegisterExporter(Metadata.ExpName, &Constructor{})
 }

--- a/exporters/noop/noop_exporter_test.go
+++ b/exporters/noop/noop_exporter_test.go
@@ -16,8 +16,8 @@ var ne = nc.New()
 
 func TestExporterByName(t *testing.T) {
 	logger, _ := test.NewNullLogger()
-	exporters.RegisterExporter(noopExporterMetadata.ExpName, nc)
-	ne, err := exporters.ExporterByName(noopExporterMetadata.ExpName, "", logger)
+	exporters.RegisterExporter(Metadata.ExpName, nc)
+	ne, err := exporters.ExporterByName(Metadata.ExpName, "", logger)
 	assert.NoError(t, err)
 	assert.Implements(t, (*exporters.Exporter)(nil), ne)
 }
@@ -25,9 +25,9 @@ func TestExporterByName(t *testing.T) {
 func TestExporterMetadata(t *testing.T) {
 	meta := ne.Metadata()
 	assert.Equal(t, plugins.PluginType(plugins.Exporter), meta.Type())
-	assert.Equal(t, noopExporterMetadata.ExpName, meta.Name())
-	assert.Equal(t, noopExporterMetadata.ExpDescription, meta.Description())
-	assert.Equal(t, noopExporterMetadata.ExpDeprecated, meta.Deprecated())
+	assert.Equal(t, Metadata.ExpName, meta.Name())
+	assert.Equal(t, Metadata.ExpDescription, meta.Description())
+	assert.Equal(t, Metadata.ExpDeprecated, meta.Deprecated())
 }
 
 func TestExporterConnect(t *testing.T) {

--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -13,7 +13,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const exporterName = "postgresql"
+// ExporterName constant for the postgresql Exporter module
+const ExporterName = "postgresql"
 
 type postgresqlExporter struct {
 	round  uint64
@@ -22,8 +23,9 @@ type postgresqlExporter struct {
 	logger *logrus.Logger
 }
 
-var postgresqlExporterMetadata = exporters.ExporterMetadata{
-	ExpName:        exporterName,
+// Metadata for the postgresql Exporter
+var Metadata = exporters.ExporterMetadata{
+	ExpName:        ExporterName,
 	ExpDescription: "Exporter for writing data to a postgresql instance.",
 	ExpDeprecated:  false,
 }
@@ -39,7 +41,7 @@ func (c *Constructor) New() exporters.Exporter {
 }
 
 func (exp *postgresqlExporter) Metadata() exporters.ExporterMetadata {
-	return postgresqlExporterMetadata
+	return Metadata
 }
 
 func (exp *postgresqlExporter) Init(cfg plugins.PluginConfig, logger *logrus.Logger) error {
@@ -61,6 +63,11 @@ func (exp *postgresqlExporter) Init(cfg plugins.PluginConfig, logger *logrus.Log
 	}
 	exp.db = db
 	<-ready
+	round, err := exp.db.GetNextRoundToAccount()
+	if err != nil {
+		return err
+	}
+	exp.round = round
 	return err
 }
 
@@ -118,5 +125,5 @@ func (exp *postgresqlExporter) unmarhshalConfig(cfg string) error {
 }
 
 func init() {
-	exporters.RegisterExporter(exporterName, &Constructor{})
+	exporters.RegisterExporter(ExporterName, &Constructor{})
 }

--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -64,11 +64,12 @@ func (exp *postgresqlExporter) Init(cfg plugins.PluginConfig, logger *logrus.Log
 	exp.db = db
 	<-ready
 	round, err := exp.db.GetNextRoundToAccount()
-	if err != nil {
+	// Returns idb.ErrorNotInitialized if the genesis has not been loaded
+	if err != nil && err != idb.ErrorNotInitialized {
 		return err
 	}
 	exp.round = round
-	return err
+	return nil
 }
 
 func (exp *postgresqlExporter) Config() plugins.PluginConfig {

--- a/exporters/postgresql/postgresql_exporter_test.go
+++ b/exporters/postgresql/postgresql_exporter_test.go
@@ -29,9 +29,9 @@ func TestExporterMetadata(t *testing.T) {
 	pgsqlExp := pgsqlConstructor.New()
 	meta := pgsqlExp.Metadata()
 	assert.Equal(t, plugins.PluginType(plugins.Exporter), meta.Type())
-	assert.Equal(t, postgresqlExporterMetadata.ExpName, meta.Name())
-	assert.Equal(t, postgresqlExporterMetadata.ExpDescription, meta.Description())
-	assert.Equal(t, postgresqlExporterMetadata.ExpDeprecated, meta.Deprecated())
+	assert.Equal(t, Metadata.ExpName, meta.Name())
+	assert.Equal(t, Metadata.ExpDescription, meta.Description())
+	assert.Equal(t, Metadata.ExpDeprecated, meta.Deprecated())
 }
 
 func TestConnectDisconnectSuccess(t *testing.T) {

--- a/plugins/config.go
+++ b/plugins/config.go
@@ -11,14 +11,19 @@ import (
 // PluginConfig is a generic string which can be deserialized by each individual Plugin
 type PluginConfig string
 
+// PluginConfigPath returns the fs path where the plugin's config should be located
+func PluginConfigPath(indexerDataDir string, meta PluginMetadata) string {
+	resolvedConfigFileName := meta.Name() + "." + config.FileType
+	return filepath.Join(indexerDataDir, resolvedConfigFileName)
+}
+
 // LoadConfig attempts to retrieve plugin configuration from the expected filesystem path.
 // Failure to load a config file will _NOT_ cause an error (since some plugins don't require
 // additional config values.
 // Unexpected errors such as permissions errors on existing config files will be logged as warnings.
 func LoadConfig(log *logrus.Logger, indexerDataDir string, meta PluginMetadata) PluginConfig {
 	var configs PluginConfig
-	resolvedConfigFileName := meta.Name() + "." + config.FileType
-	resolvedConfigPath := filepath.Join(indexerDataDir, resolvedConfigFileName)
+	resolvedConfigPath := PluginConfigPath(indexerDataDir, meta)
 	if !util.FileExists(resolvedConfigPath) {
 		log.Infof("Did not find config file for %s plugin. Continuing with empty config.", meta.Name())
 		return configs

--- a/plugins/config_test.go
+++ b/plugins/config_test.go
@@ -70,3 +70,9 @@ func TestLoadConfigDoesNotRead(t *testing.T) {
 	logMessage := fmt.Sprintf("Found config file %s, but failed to read it into memory.", configFile)
 	assert.Equal(t, logMessage, hook.LastEntry().Message)
 }
+
+func TestPluginConfigPath(t *testing.T) {
+	indexerDataDir := "foo"
+	expectedPath := filepath.Join(indexerDataDir, "baz.yml")
+	assert.Equal(t, expectedPath, PluginConfigPath(indexerDataDir, &mockMetadata{}))
+}

--- a/processor/blockprocessor/block_processor.go
+++ b/processor/blockprocessor/block_processor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/algorand/indexer/util"
 )
 
+// MakeProcessorWithLedger creates a Processor with a given ledger
 func MakeProcessorWithLedger(logger *log.Logger, l *ledger.Ledger, genericHandler interface{}) (processor.Processor, error) {
 	if l == nil {
 		return nil, fmt.Errorf("MakeProcessorWithLedger() err: local ledger not initialized")

--- a/processor/blockprocessor/block_processor.go
+++ b/processor/blockprocessor/block_processor.go
@@ -3,17 +3,15 @@ package blockprocessor
 import (
 	"context"
 	"fmt"
+	"github.com/algorand/indexer/exporters"
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
-	"github.com/algorand/go-algorand/rpcs"
-
 	"github.com/algorand/indexer/accounting"
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/processor"
@@ -21,128 +19,45 @@ import (
 	"github.com/algorand/indexer/util"
 )
 
-type blockProcessor struct {
-	handler func(block *ledgercore.ValidatedBlock) error
-	ledger  *ledger.Ledger
-	logger  *log.Logger
-}
-
-// MakeProcessorWithLedger creates a block processor with a given ledger
-func MakeProcessorWithLedger(logger *log.Logger, l *ledger.Ledger, handler func(block *ledgercore.ValidatedBlock) error) (processor.Processor, error) {
+func MakeProcessorWithLedger(logger *log.Logger, l *ledger.Ledger, genericHandler interface{}) (processor.Processor, error) {
 	if l == nil {
 		return nil, fmt.Errorf("MakeProcessorWithLedger() err: local ledger not initialized")
 	}
-	err := addGenesisBlock(l, handler)
+	var proc processor.Processor
+	if exp, ok := genericHandler.(exporters.Exporter); ok {
+		proc = &ledgerExporterProcessor{logger: logger, ledger: l, exporter: exp}
+	} else if handler, ok := genericHandler.(func(block *ledgercore.ValidatedBlock) error); ok {
+		proc = &blockProcessor{logger: logger, ledger: l, handler: handler}
+	} else {
+		return nil, fmt.Errorf("MakeProcessorWithLedger was unable to determine the type of block handler: %v", genericHandler)
+	}
+	err := proc.AddGenesisBlock()
 	if err != nil {
 		return nil, fmt.Errorf("MakeProcessorWithLedger() err: %w", err)
 	}
-	return &blockProcessor{logger: logger, ledger: l, handler: handler}, nil
+	return proc, nil
 }
 
 // MakeProcessorWithLedgerInit creates a block processor and initializes the ledger.
-func MakeProcessorWithLedgerInit(ctx context.Context, logger *log.Logger, catchpoint string, genesis *bookkeeping.Genesis, nextDBRound uint64, opts idb.IndexerDbOptions, handler func(block *ledgercore.ValidatedBlock) error) (processor.Processor, error) {
+func MakeProcessorWithLedgerInit(ctx context.Context, logger *log.Logger, catchpoint string, genesis *bookkeeping.Genesis, nextDBRound uint64, opts idb.IndexerDbOptions, genericHandler interface{}) (processor.Processor, error) {
 	err := InitializeLedger(ctx, logger, catchpoint, nextDBRound, *genesis, &opts)
 	if err != nil {
 		return nil, fmt.Errorf("MakeProcessorWithLedgerInit() err: %w", err)
 	}
-	return MakeProcessor(logger, genesis, nextDBRound, opts.IndexerDatadir, handler)
+	return MakeProcessor(logger, genesis, nextDBRound, opts.IndexerDatadir, genericHandler)
 }
 
 // MakeProcessor creates a block processor
-func MakeProcessor(logger *log.Logger, genesis *bookkeeping.Genesis, dbRound uint64, datadir string, handler func(block *ledgercore.ValidatedBlock) error) (processor.Processor, error) {
+func MakeProcessor(logger *log.Logger, genesis *bookkeeping.Genesis, dbRound uint64, datadir string, genericHandler interface{}) (processor.Processor, error) {
 	l, err := util.MakeLedger(logger, false, genesis, datadir)
 	if err != nil {
 		return nil, fmt.Errorf("MakeProcessor() err: %w", err)
 	}
 	if uint64(l.Latest()) > dbRound {
+		logger.Fatalf("ledger round: %v, db round: %v", l.Latest(), dbRound)
 		return nil, fmt.Errorf("MakeProcessor() err: the ledger cache is ahead of the required round and must be re-initialized")
 	}
-	return MakeProcessorWithLedger(logger, l, handler)
-}
-
-func addGenesisBlock(l *ledger.Ledger, handler func(block *ledgercore.ValidatedBlock) error) error {
-	if handler != nil && l != nil && l.Latest() == 0 {
-		blk, err := l.Block(0)
-		if err != nil {
-			return fmt.Errorf("addGenesisBlock() err: %w", err)
-		}
-		vb := ledgercore.MakeValidatedBlock(blk, ledgercore.StateDelta{})
-		err = handler(&vb)
-		if err != nil {
-			return fmt.Errorf("addGenesisBlock() handler err: %w", err)
-		}
-	}
-	return nil
-}
-
-// Process a raw algod block
-func (proc *blockProcessor) Process(blockCert *rpcs.EncodedBlockCert) error {
-
-	if blockCert == nil {
-		return fmt.Errorf("Process(): cannot process a nil block")
-	}
-	if blockCert.Block.Round() != (proc.ledger.Latest() + 1) {
-		return fmt.Errorf("Process() invalid round blockCert.Block.Round(): %d nextRoundToProcess: %d", blockCert.Block.Round(), uint64(proc.ledger.Latest())+1)
-	}
-
-	// Make sure "AssetCloseAmount" is enabled. If it isn't, override the
-	// protocol and update the blocks to include transactions with modified
-	// apply data.
-	proto, ok := config.Consensus[blockCert.Block.BlockHeader.CurrentProtocol]
-	if !ok {
-		return fmt.Errorf(
-			"Process() cannot find proto version %s", blockCert.Block.BlockHeader.CurrentProtocol)
-	}
-	protoChanged := !proto.EnableAssetCloseAmount
-	proto.EnableAssetCloseAmount = true
-
-	ledgerForEval := indexerledger.MakeLedgerForEvaluator(proc.ledger)
-
-	resources, err := prepareEvalResources(&ledgerForEval, &blockCert.Block)
-	if err != nil {
-		proc.logger.Panicf("Process() resources err: %v", err)
-	}
-
-	delta, modifiedTxns, err :=
-		ledger.EvalForIndexer(ledgerForEval, &blockCert.Block, proto, resources)
-	if err != nil {
-		return fmt.Errorf("Process() eval err: %w", err)
-	}
-	// validated block
-	var vb ledgercore.ValidatedBlock
-	if protoChanged {
-		block := bookkeeping.Block{
-			BlockHeader: blockCert.Block.BlockHeader,
-			Payset:      modifiedTxns,
-		}
-		vb = ledgercore.MakeValidatedBlock(block, delta)
-	} else {
-		vb = ledgercore.MakeValidatedBlock(blockCert.Block, delta)
-	}
-
-	// execute handler before writing to local ledger
-	if proc.handler != nil {
-		err = proc.handler(&vb)
-		if err != nil {
-			return fmt.Errorf("Process() handler err: %w", err)
-		}
-	}
-	// write to ledger
-	err = proc.ledger.AddValidatedBlock(vb, blockCert.Certificate)
-	if err != nil {
-		return fmt.Errorf("Process() add validated block err: %w", err)
-	}
-	// wait for commit to disk
-	proc.ledger.WaitForCommit(blockCert.Block.Round())
-	return nil
-}
-
-func (proc *blockProcessor) SetHandler(handler func(block *ledgercore.ValidatedBlock) error) {
-	proc.handler = handler
-}
-
-func (proc *blockProcessor) NextRoundToProcess() uint64 {
-	return uint64(proc.ledger.Latest()) + 1
+	return MakeProcessorWithLedger(logger, l, genericHandler)
 }
 
 // Preload all resources (account data, account resources, asset/app creators) for the

--- a/processor/blockprocessor/block_processor.go
+++ b/processor/blockprocessor/block_processor.go
@@ -28,6 +28,8 @@ func MakeProcessorWithLedger(logger *log.Logger, l *ledger.Ledger, genericHandle
 		proc = &ledgerExporterProcessor{logger: logger, ledger: l, exporter: exp}
 	} else if handler, ok := genericHandler.(func(block *ledgercore.ValidatedBlock) error); ok {
 		proc = &blockProcessor{logger: logger, ledger: l, handler: handler}
+	} else if genericHandler == nil {
+		proc = &blockProcessor{logger: logger, ledger: l, handler: handler}
 	} else {
 		return nil, fmt.Errorf("MakeProcessorWithLedger was unable to determine the type of block handler: %v", genericHandler)
 	}

--- a/processor/blockprocessor/block_processor_test.go
+++ b/processor/blockprocessor/block_processor_test.go
@@ -24,6 +24,13 @@ var noopHandler = func(block *ledgercore.ValidatedBlock) error {
 	return nil
 }
 
+var genesisHandler = func(block *ledgercore.ValidatedBlock) error {
+	if block.Block().Round() != 0 {
+		return fmt.Errorf("handler error")
+	}
+	return nil
+}
+
 func TestProcess(t *testing.T) {
 	logger, _ := test2.NewNullLogger()
 	l, err := test.MakeTestLedger(logger)
@@ -111,11 +118,10 @@ func TestFailedProcess(t *testing.T) {
 	}
 	_, err = blockprocessor.MakeProcessorWithLedger(logger, l, handler)
 	assert.Contains(t, err.Error(), "handler error")
-	pr, _ = blockprocessor.MakeProcessorWithLedger(logger, l, nil)
+	pr, _ = blockprocessor.MakeProcessorWithLedger(logger, l, genesisHandler)
 	txn = test.MakePaymentTxn(0, 10, 0, 1, 1, 0, test.AccountA, test.AccountA, basics.Address{}, basics.Address{})
 	block, err = test.MakeBlockForTxns(genesisBlock.BlockHeader, &txn)
 	assert.Nil(t, err)
-	pr.SetHandler(handler)
 	rawBlock = rpcs.EncodedBlockCert{Block: block, Certificate: agreement.Certificate{}}
 	err = pr.Process(&rawBlock)
 	assert.Contains(t, err.Error(), "Process() handler err")

--- a/processor/blockprocessor/exporter_processor.go
+++ b/processor/blockprocessor/exporter_processor.go
@@ -90,7 +90,7 @@ func (proc *ledgerExporterProcessor) Process(blockCert *rpcs.EncodedBlockCert) e
 	if proc.exporter != nil {
 		err = proc.exporter.Receive(blkData)
 		if err != nil {
-			return fmt.Errorf("Process() handler err: %w", err)
+			return fmt.Errorf("Process() exporter err: %w", err)
 		}
 	}
 	// write to ledger

--- a/processor/blockprocessor/exporter_processor.go
+++ b/processor/blockprocessor/exporter_processor.go
@@ -1,0 +1,108 @@
+package blockprocessor
+
+import (
+	"fmt"
+	"github.com/algorand/go-algorand/agreement"
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/ledger"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
+	"github.com/algorand/go-algorand/rpcs"
+	"github.com/algorand/indexer/data"
+	"github.com/algorand/indexer/exporters"
+	indexerledger "github.com/algorand/indexer/processor/eval"
+	"github.com/sirupsen/logrus"
+)
+
+type ledgerExporterProcessor struct {
+	exporter exporters.Exporter
+	ledger   *ledger.Ledger
+	logger   *logrus.Logger
+}
+
+func (proc *ledgerExporterProcessor) AddGenesisBlock() error {
+	if proc.exporter != nil && uint64(proc.ledger.Latest()) == 0 {
+		blk, err := proc.ledger.Block(0)
+		if err != nil {
+			return fmt.Errorf("addGenesisBlock() err: %w", err)
+		}
+		err = proc.exporter.Receive(data.BlockData{
+			Block:       &blk,
+			Delta:       &ledgercore.StateDelta{},
+			Certificate: &agreement.Certificate{},
+		})
+		if err != nil {
+			return fmt.Errorf("addGenesisBlock() handler err: %w", err)
+		}
+	}
+	return nil
+}
+
+// Process a raw algod block
+func (proc *ledgerExporterProcessor) Process(blockCert *rpcs.EncodedBlockCert) error {
+
+	if blockCert == nil {
+		return fmt.Errorf("Process(): cannot process a nil block")
+	}
+	if uint64(blockCert.Block.Round()) != uint64(proc.ledger.Latest())+1 {
+		return fmt.Errorf("Process() invalid round blockCert.Block.Round(): %d nextRoundToProcess: %d", blockCert.Block.Round(), uint64(proc.ledger.Latest())+1)
+	}
+
+	proto, ok := config.Consensus[blockCert.Block.BlockHeader.CurrentProtocol]
+	if !ok {
+		return fmt.Errorf(
+			"Process() cannot find proto version %s", blockCert.Block.BlockHeader.CurrentProtocol)
+	}
+	protoChanged := !proto.EnableAssetCloseAmount
+	proto.EnableAssetCloseAmount = true
+
+	ledgerForEval := indexerledger.MakeLedgerForEvaluator(proc.ledger)
+
+	resources, err := prepareEvalResources(&ledgerForEval, &blockCert.Block)
+	if err != nil {
+		proc.logger.Panicf("Process() resources err: %v", err)
+	}
+
+	delta, modifiedTxns, err :=
+		ledger.EvalForIndexer(ledgerForEval, &blockCert.Block, proto, resources)
+	if err != nil {
+		return fmt.Errorf("Process() eval err: %w", err)
+	}
+	// validated block
+	var vb ledgercore.ValidatedBlock
+	// BlockData
+	var blkData = data.BlockData{
+		Block:       &blockCert.Block,
+		Delta:       &delta,
+		Certificate: &blockCert.Certificate,
+	}
+	vb = ledgercore.MakeValidatedBlock(blockCert.Block, delta)
+	if protoChanged {
+		block := bookkeeping.Block{
+			BlockHeader: blockCert.Block.BlockHeader,
+			Payset:      modifiedTxns,
+		}
+		vb = ledgercore.MakeValidatedBlock(block, delta)
+		blkData.Block = &block
+	}
+
+	// execute Exporter before writing to local ledger
+	if proc.exporter != nil {
+		err = proc.exporter.Receive(blkData)
+		if err != nil {
+			return fmt.Errorf("Process() handler err: %w", err)
+		}
+	}
+	// write to ledger
+	err = proc.ledger.AddValidatedBlock(vb, blockCert.Certificate)
+	if err != nil {
+		return fmt.Errorf("Process() add validated block err: %w", err)
+	}
+	// wait for commit to disk
+	proc.ledger.WaitForCommit(blockCert.Block.Round())
+	return nil
+}
+
+func (proc *ledgerExporterProcessor) NextRoundToProcess() uint64 {
+	return uint64(proc.ledger.Latest()) + 1
+}

--- a/processor/blockprocessor/exporter_processor.go
+++ b/processor/blockprocessor/exporter_processor.go
@@ -27,7 +27,8 @@ func (proc *ledgerExporterProcessor) AddGenesisBlock() error {
 			return fmt.Errorf("addGenesisBlock() err: %w", err)
 		}
 		err = proc.exporter.Receive(data.BlockData{
-			Block:       &blk,
+			BlockHeader: blk.BlockHeader,
+			Payset:      blk.Payset,
 			Delta:       &ledgercore.StateDelta{},
 			Certificate: &agreement.Certificate{},
 		})
@@ -72,7 +73,8 @@ func (proc *ledgerExporterProcessor) Process(blockCert *rpcs.EncodedBlockCert) e
 	var vb ledgercore.ValidatedBlock
 	// BlockData
 	var blkData = data.BlockData{
-		Block:       &blockCert.Block,
+		BlockHeader: blockCert.Block.BlockHeader,
+		Payset:      blockCert.Block.Payset,
 		Delta:       &delta,
 		Certificate: &blockCert.Certificate,
 	}
@@ -83,7 +85,8 @@ func (proc *ledgerExporterProcessor) Process(blockCert *rpcs.EncodedBlockCert) e
 			Payset:      modifiedTxns,
 		}
 		vb = ledgercore.MakeValidatedBlock(block, delta)
-		blkData.Block = &block
+		blkData.BlockHeader = blockCert.Block.BlockHeader
+		blkData.Payset = modifiedTxns
 	}
 
 	// execute Exporter before writing to local ledger

--- a/processor/blockprocessor/exporter_processor_test.go
+++ b/processor/blockprocessor/exporter_processor_test.go
@@ -1,0 +1,245 @@
+package blockprocessor
+
+import (
+	"fmt"
+	"github.com/algorand/go-algorand/agreement"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/rpcs"
+	"github.com/algorand/indexer/data"
+	"github.com/algorand/indexer/exporters"
+	"github.com/algorand/indexer/exporters/noop"
+	"github.com/algorand/indexer/processor"
+	"github.com/algorand/indexer/util/test"
+	test2 "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var logger, _ = test2.NewNullLogger()
+var nc = noop.Constructor{}
+
+type errExp struct {
+	exporters.Exporter
+}
+
+func (exp *errExp) Receive(_ data.BlockData) error {
+	return fmt.Errorf("foobar")
+}
+
+func processTxnForRound(t *testing.T, round uint64, prevHeader bookkeeping.BlockHeader, pr processor.Processor) {
+	txn := test.MakePaymentTxn(0, uint64(round), 0, 1, 1, 0, test.AccountA, test.AccountA, basics.Address{}, basics.Address{})
+	block, err := test.MakeBlockForTxns(prevHeader, &txn)
+	assert.NoError(t, err)
+	rawBlock := rpcs.EncodedBlockCert{Block: block, Certificate: agreement.Certificate{}}
+	err = pr.Process(&rawBlock)
+	assert.NoError(t, err)
+}
+
+func TestAddGenesisBlockNoop(t *testing.T) {
+	proc := &ledgerExporterProcessor{
+		exporter: nil,
+		ledger:   nil,
+		logger:   nil,
+	}
+	assert.NoError(t, proc.AddGenesisBlock())
+}
+
+func TestAddGenesisBlockSuccess(t *testing.T) {
+	exp := nc.New()
+	l, err := test.MakeTestLedger(logger)
+	defer l.Close()
+	require.NoError(t, err)
+	proc := &ledgerExporterProcessor{
+		exporter: exp,
+		ledger:   l,
+		logger:   logger,
+	}
+
+	err = proc.AddGenesisBlock()
+	assert.NoError(t, err)
+}
+
+func TestAddGenesisBlockExporterFailure(t *testing.T) {
+	l, err := test.MakeTestLedger(logger)
+	defer l.Close()
+	require.NoError(t, err)
+	proc := &ledgerExporterProcessor{
+		exporter: &errExp{},
+		ledger:   l,
+		logger:   logger,
+	}
+
+	err = proc.AddGenesisBlock()
+	assert.Errorf(t, err, "foobar")
+}
+
+func TestNextRoundToProcess(t *testing.T) {
+	l, err := test.MakeTestLedger(logger)
+	defer l.Close()
+	require.NoError(t, err)
+	proc := &ledgerExporterProcessor{
+		exporter: nc.New(),
+		ledger:   l,
+		logger:   logger,
+	}
+
+	assert.Equal(t, uint64(1), proc.NextRoundToProcess())
+}
+
+func TestProcessRound(t *testing.T) {
+	l, err := test.MakeTestLedger(logger)
+	defer l.Close()
+	require.NoError(t, err)
+	proc := &ledgerExporterProcessor{
+		exporter: nc.New(),
+		ledger:   l,
+		logger:   logger,
+	}
+
+	genesisBlock, err := l.Block(basics.Round(0))
+	assert.NoError(t, err)
+	prevHeader := genesisBlock.BlockHeader
+	processTxnForRound(t, uint64(1), prevHeader, proc)
+	assert.Equal(t, uint64(2), proc.NextRoundToProcess())
+}
+
+func TestProcessNilBlock(t *testing.T) {
+	proc := &ledgerExporterProcessor{
+		exporter: nc.New(),
+		ledger:   nil,
+		logger:   logger,
+	}
+	err := proc.Process(nil)
+	assert.Errorf(t, err, "Process(): cannot process a nil block")
+}
+
+func TestProcessInvalidRound(t *testing.T) {
+	l, err := test.MakeTestLedger(logger)
+	defer l.Close()
+	require.NoError(t, err)
+	proc := &ledgerExporterProcessor{
+		exporter: nc.New(),
+		ledger:   l,
+		logger:   logger,
+	}
+
+	rawBlock := rpcs.EncodedBlockCert{Block: bookkeeping.Block{
+		BlockHeader: bookkeeping.BlockHeader{
+			Round: 2,
+		},
+	}, Certificate: agreement.Certificate{}}
+	err = proc.Process(&rawBlock)
+	assert.Errorf(t, err, "Process() invalid round blockCert.Block.Round(): %d nextRoundToProcess: %d", 2, 1)
+}
+
+func TestProcessInvalidConsensus(t *testing.T) {
+	l, err := test.MakeTestLedger(logger)
+	defer l.Close()
+	require.NoError(t, err)
+	proc := &ledgerExporterProcessor{
+		exporter: nc.New(),
+		ledger:   l,
+		logger:   logger,
+	}
+
+	rawBlock := rpcs.EncodedBlockCert{Block: bookkeeping.Block{
+		BlockHeader: bookkeeping.BlockHeader{
+			Round: 1,
+			UpgradeState: bookkeeping.UpgradeState{
+				CurrentProtocol: protocol.ConsensusVersion("foobar_not_real"),
+			},
+		},
+	}, Certificate: agreement.Certificate{}}
+	err = proc.Process(&rawBlock)
+	assert.Errorf(t, err, "Process() cannot find proto version %s", "foobar_not_real")
+}
+
+func TestProcessEvalAssetDoesNotExistError(t *testing.T) {
+	l, err := test.MakeTestLedger(logger)
+	defer l.Close()
+	require.NoError(t, err)
+	proc := &ledgerExporterProcessor{
+		exporter: nc.New(),
+		ledger:   l,
+		logger:   logger,
+	}
+	genesisBlock, err := l.Block(basics.Round(0))
+	assert.NoError(t, err)
+	prevHeader := genesisBlock.BlockHeader
+	addr, _ := basics.UnmarshalChecksumAddress("J5YDZLPOHWB5O6MVRHNFGY4JXIQAYYM6NUJWPBSYBBIXH5ENQ4Z5LTJELU")
+	txn := transactions.SignedTxnWithAD{
+		SignedTxn: transactions.SignedTxn{
+			Txn: transactions.Transaction{
+				AssetConfigTxnFields: transactions.AssetConfigTxnFields{
+					ConfigAsset: 99999,
+				},
+				Header: transactions.Header{
+					Sender:      addr,
+					GenesisHash: test.GenesisHash,
+				},
+				Type: protocol.AssetConfigTx,
+			},
+		},
+		ApplyData: transactions.ApplyData{
+			ConfigAsset: basics.AssetIndex(99999999),
+		},
+	}
+	block, err := test.MakeBlockForTxns(prevHeader, &txn)
+	assert.NoError(t, err)
+	rawBlock := rpcs.EncodedBlockCert{Block: block, Certificate: agreement.Certificate{}}
+
+	err = proc.Process(&rawBlock)
+	assert.Errorf(t, err, "Process() eval err: ProcessBlockForIndexer() err: transaction BXIPBW544ZQ7YHBQGR3VAFKJFQZ6W67YQIDABJZU3EB4OCK376LA: asset 99999 does not exist or has been deleted")
+}
+
+func TestProcessProtoChanged(t *testing.T) {
+	l, err := test.MakeTestLedger(logger)
+	defer l.Close()
+	require.NoError(t, err)
+	proc := &ledgerExporterProcessor{
+		exporter: nc.New(),
+		ledger:   l,
+		logger:   logger,
+	}
+
+	rawBlock := rpcs.EncodedBlockCert{Block: bookkeeping.Block{
+		BlockHeader: bookkeeping.BlockHeader{
+			GenesisHash: test.GenesisHash,
+			Round:       1,
+			UpgradeState: bookkeeping.UpgradeState{
+				CurrentProtocol: protocol.ConsensusV24,
+			},
+		},
+		Payset: []transactions.SignedTxnInBlock{},
+	}, Certificate: agreement.Certificate{}}
+	err = proc.Process(&rawBlock)
+	assert.NoError(t, err)
+}
+
+func TestProcessExporterError(t *testing.T) {
+	l, err := test.MakeTestLedger(logger)
+	defer l.Close()
+	require.NoError(t, err)
+	proc := &ledgerExporterProcessor{
+		exporter: &errExp{},
+		ledger:   l,
+		logger:   logger,
+	}
+
+	rawBlock := rpcs.EncodedBlockCert{Block: bookkeeping.Block{
+		BlockHeader: bookkeeping.BlockHeader{
+			GenesisHash: test.GenesisHash,
+			Round:       1,
+			UpgradeState: bookkeeping.UpgradeState{
+				CurrentProtocol: protocol.ConsensusV24,
+			},
+		},
+		Payset: []transactions.SignedTxnInBlock{},
+	}, Certificate: agreement.Certificate{}}
+	err = proc.Process(&rawBlock)
+	assert.Errorf(t, err, "Process() exporter err: foobar")
+}

--- a/processor/blockprocessor/handler_processor.go
+++ b/processor/blockprocessor/handler_processor.go
@@ -1,0 +1,95 @@
+package blockprocessor
+
+import (
+	"fmt"
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/ledger"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
+	"github.com/algorand/go-algorand/rpcs"
+	indexerledger "github.com/algorand/indexer/processor/eval"
+	"github.com/sirupsen/logrus"
+)
+
+type blockProcessor struct {
+	handler func(block *ledgercore.ValidatedBlock) error
+	ledger  *ledger.Ledger
+	logger  *logrus.Logger
+}
+
+func (proc *blockProcessor) AddGenesisBlock() error {
+	if proc.handler != nil && uint64(proc.ledger.Latest()) == 0 {
+		blk, err := proc.ledger.Block(0)
+		if err != nil {
+			return fmt.Errorf("addGenesisBlock() err: %w", err)
+		}
+		vb := ledgercore.MakeValidatedBlock(blk, ledgercore.StateDelta{})
+		err = proc.handler(&vb)
+		if err != nil {
+			return fmt.Errorf("addGenesisBlock() handler err: %w", err)
+		}
+	}
+	return nil
+}
+
+// Process a raw algod block
+func (proc *blockProcessor) Process(blockCert *rpcs.EncodedBlockCert) error {
+
+	if blockCert == nil {
+		return fmt.Errorf("Process(): cannot process a nil block")
+	}
+	if uint64(blockCert.Block.Round()) != uint64(proc.ledger.Latest())+1 {
+		return fmt.Errorf("Process() invalid round blockCert.Block.Round(): %d nextRoundToProcess: %d", blockCert.Block.Round(), uint64(proc.ledger.Latest())+1)
+	}
+
+	proto, ok := config.Consensus[blockCert.Block.BlockHeader.CurrentProtocol]
+	if !ok {
+		return fmt.Errorf(
+			"Process() cannot find proto version %s", blockCert.Block.BlockHeader.CurrentProtocol)
+	}
+	protoChanged := !proto.EnableAssetCloseAmount
+	proto.EnableAssetCloseAmount = true
+
+	ledgerForEval := indexerledger.MakeLedgerForEvaluator(proc.ledger)
+
+	resources, err := prepareEvalResources(&ledgerForEval, &blockCert.Block)
+	if err != nil {
+		proc.logger.Panicf("Process() resources err: %v", err)
+	}
+
+	delta, modifiedTxns, err :=
+		ledger.EvalForIndexer(ledgerForEval, &blockCert.Block, proto, resources)
+	if err != nil {
+		return fmt.Errorf("Process() eval err: %w", err)
+	}
+	// validated block
+	var vb ledgercore.ValidatedBlock
+	vb = ledgercore.MakeValidatedBlock(blockCert.Block, delta)
+	if protoChanged {
+		block := bookkeeping.Block{
+			BlockHeader: blockCert.Block.BlockHeader,
+			Payset:      modifiedTxns,
+		}
+		vb = ledgercore.MakeValidatedBlock(block, delta)
+	}
+
+	// execute handler before writing to local ledger
+	if proc.handler != nil {
+		err = proc.handler(&vb)
+		if err != nil {
+			return fmt.Errorf("Process() handler err: %w", err)
+		}
+	}
+	// write to ledger
+	err = proc.ledger.AddValidatedBlock(vb, blockCert.Certificate)
+	if err != nil {
+		return fmt.Errorf("Process() add validated block err: %w", err)
+	}
+	// wait for commit to disk
+	proc.ledger.WaitForCommit(blockCert.Block.Round())
+	return nil
+}
+
+func (proc *blockProcessor) NextRoundToProcess() uint64 {
+	return uint64(proc.ledger.Latest()) + 1
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1,13 +1,12 @@
 package processor
 
 import (
-	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/rpcs"
 )
 
 // Processor is the block processor interface
 type Processor interface {
 	Process(cert *rpcs.EncodedBlockCert) error
-	SetHandler(handler func(block *ledgercore.ValidatedBlock) error)
 	NextRoundToProcess() uint64
+	AddGenesisBlock() error
 }


### PR DESCRIPTION
## Summary

The goal of this PR is to integrate the new Exporter code with the existing Indexer daemon. In this way we can enable users to create and plug new data destinations into the existing Indexer framework.
 
Replaces #1134 since there have been a lot of changes which are easier to just branch off of instead of merge into the old PR.

## Test Plan

Added tests to cover new code.
