### PR TITLE
Enhancement: More information about S3 keys searched for and Dockerfile that uses submodule instead of channel

### DIFF
--- a/misc/Dockerfile
+++ b/misc/Dockerfile
@@ -8,21 +8,17 @@ ENV HOME /opt
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y apt-utils curl git git-core bsdmainutils python3 python3-pip make bash libtool libboost-math-dev libffi-dev
 
-# Install algod nightly binaries to the path
-RUN mkdir -p /opt/algorand/{bin,data}
-ADD https://github.com/algorand/go-algorand/raw/1e1474216421da27008726c44ebe0a5ba2fb6a08/cmd/updater/update.sh /opt/algorand/bin/update.sh
-RUN chmod 755 /opt/algorand/bin/update.sh
-WORKDIR /opt/algorand/bin
-RUN ./update.sh -i -c nightly -p /opt/algorand/bin -d /opt/algorand/data -n
-RUN find /opt/algorand
-ENV PATH="/opt/algorand/bin:${PATH}"
-
 # Setup files for test
 RUN mkdir -p /opt/go/indexer
 COPY . /opt/go/indexer
 WORKDIR /opt/go/indexer
+RUN rm -f $HOME/go/bin/algod
 RUN rm /opt/go/indexer/cmd/algorand-indexer/algorand-indexer
+WORKDIR /opt/go/indexer/third_party/go-algorand
+RUN make install
+WORKDIR /opt/go/indexer
 RUN make
+ENV PATH="${HOME}/go/bin/:${PATH}"
 RUN pip3 install -r misc/requirements.txt
 
 ENV INDEXER_DATA="${HOME}/indexer/"

--- a/misc/e2elive.py
+++ b/misc/e2elive.py
@@ -77,12 +77,11 @@ def main():
         s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
         tarname = "net_done.tar.bz2"
         tarpath = os.path.join(tempdir, tarname)
-        success = firstFromS3Prefix(
-            s3, bucket, "indexer/e2e4", tarname, outpath=tarpath
-        )
+        prefix = "indexer/e2e4"
+        success = firstFromS3Prefix(s3, bucket, prefix, tarname, outpath=tarpath)
         if not success:
             raise Exception(
-                f"failed to locate tarname={tarname} from AWS S3 path {bucket}/indexer/e2e4"
+                f"failed to locate tarname={tarname} from AWS S3 path {bucket}/{prefix}"
             )
         source_is_tar = True
         sourcenet = tarpath

--- a/misc/e2elive.py
+++ b/misc/e2elive.py
@@ -22,16 +22,33 @@ from util import xrun, atexitrun, find_indexer, ensure_test_db, firstFromS3Prefi
 
 logger = logging.getLogger(__name__)
 
+
 def main():
     start = time.time()
     import argparse
+
     ap = argparse.ArgumentParser()
-    ap.add_argument('--keep-temps', default=False, action='store_true')
-    ap.add_argument('--indexer-bin', default=None, help='path to algorand-indexer binary, otherwise search PATH')
-    ap.add_argument('--indexer-port', default=None, type=int, help='port to run indexer on. defaults to random in [4000,30000]')
-    ap.add_argument('--connection-string', help='Use this connection string instead of attempting to manage a local database.')
-    ap.add_argument('--source-net', help='Path to test network directory containing Primary and other nodes. May be a tar file.')
-    ap.add_argument('--verbose', default=False, action='store_true')
+    ap.add_argument("--keep-temps", default=False, action="store_true")
+    ap.add_argument(
+        "--indexer-bin",
+        default=None,
+        help="path to algorand-indexer binary, otherwise search PATH",
+    )
+    ap.add_argument(
+        "--indexer-port",
+        default=None,
+        type=int,
+        help="port to run indexer on. defaults to random in [4000,30000]",
+    )
+    ap.add_argument(
+        "--connection-string",
+        help="Use this connection string instead of attempting to manage a local database.",
+    )
+    ap.add_argument(
+        "--source-net",
+        help="Path to test network directory containing Primary and other nodes. May be a tar file.",
+    )
+    ap.add_argument("--verbose", default=False, action="store_true")
     args = ap.parse_args()
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
@@ -41,9 +58,9 @@ def main():
     sourcenet = args.source_net
     source_is_tar = False
     if not sourcenet:
-        e2edata = os.getenv('E2EDATA')
-        sourcenet = e2edata and os.path.join(e2edata, 'net')
-    if sourcenet and hassuffix(sourcenet, '.tar', '.tar.gz', '.tar.bz2', '.tar.xz'):
+        e2edata = os.getenv("E2EDATA")
+        sourcenet = e2edata and os.path.join(e2edata, "net")
+    if sourcenet and hassuffix(sourcenet, ".tar", ".tar.gz", ".tar.bz2", ".tar.xz"):
         source_is_tar = True
     tempdir = tempfile.mkdtemp()
     if not args.keep_temps:
@@ -52,67 +69,105 @@ def main():
         logger.info("leaving temp dir %r", tempdir)
     if not (source_is_tar or (sourcenet and os.path.isdir(sourcenet))):
         # fetch test data from S3
-        bucket = 'algorand-testdata'
+        bucket = "algorand-testdata"
         import boto3
         from botocore.config import Config
         from botocore import UNSIGNED
-        s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))
-        tarname = 'net_done.tar.bz2'
+
+        s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
+        tarname = "net_done.tar.bz2"
         tarpath = os.path.join(tempdir, tarname)
-        firstFromS3Prefix(s3, bucket, 'indexer/e2e4', tarname, outpath=tarpath)
+        success = firstFromS3Prefix(
+            s3, bucket, "indexer/e2e4", tarname, outpath=tarpath
+        )
+        if not success:
+            raise Exception(
+                f"failed to locate tarname={tarname} from AWS S3 path {bucket}/indexer/e2e4"
+            )
         source_is_tar = True
         sourcenet = tarpath
-    tempnet = os.path.join(tempdir, 'net')
+    tempnet = os.path.join(tempdir, "net")
     if source_is_tar:
-        xrun(['tar', '-C', tempdir, '-x', '-f', sourcenet])
+        xrun(["tar", "-C", tempdir, "-x", "-f", sourcenet])
     else:
-        xrun(['rsync', '-a', sourcenet + '/', tempnet + '/'])
-    blockfiles = glob.glob(os.path.join(tempdir, 'net', 'Primary', '*', '*.block.sqlite'))
+        xrun(["rsync", "-a", sourcenet + "/", tempnet + "/"])
+    blockfiles = glob.glob(
+        os.path.join(tempdir, "net", "Primary", "*", "*.block.sqlite")
+    )
     lastblock = countblocks(blockfiles[0])
-    #subprocess.run(['find', tempnet, '-type', 'f'])
+    # subprocess.run(['find', tempnet, '-type', 'f'])
     try:
-        xrun(['goal', 'network', 'start', '-r', tempnet])
+        xrun(["goal", "network", "start", "-r", tempnet])
     except Exception:
-        logger.error('failed to start private network, looking for node.log')
+        logger.error("failed to start private network, looking for node.log")
         for root, dirs, files in os.walk(tempnet):
             for f in files:
-                if f == 'node.log':
+                if f == "node.log":
                     p = os.path.join(root, f)
-                    logger.error('found node.log: {}'.format(p))
+                    logger.error("found node.log: {}".format(p))
                     with open(p) as nf:
                         for line in nf:
-                            logger.error('   {}'.format(line))
+                            logger.error("   {}".format(line))
         raise
 
-    atexitrun(['goal', 'network', 'stop', '-r', tempnet])
+    atexitrun(["goal", "network", "stop", "-r", tempnet])
 
     psqlstring = ensure_test_db(args.connection_string, args.keep_temps)
-    algoddir = os.path.join(tempnet, 'Primary')
-    aiport = args.indexer_port or random.randint(4000,30000)
-    cmd = [indexer_bin, 'daemon', '--data-dir', '/tmp', '-P', psqlstring, '--dev-mode', '--algod', algoddir, '--server', ':{}'.format(aiport)]
-    logger.debug("%s", ' '.join(map(repr,cmd)))
+    algoddir = os.path.join(tempnet, "Primary")
+    aiport = args.indexer_port or random.randint(4000, 30000)
+    cmd = [
+        indexer_bin,
+        "daemon",
+        "--data-dir",
+        "/tmp",
+        "-P",
+        psqlstring,
+        "--dev-mode",
+        "--algod",
+        algoddir,
+        "--server",
+        ":{}".format(aiport),
+    ]
+    logger.debug("%s", " ".join(map(repr, cmd)))
     indexerdp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     indexerout = subslurp(indexerdp.stdout)
     indexerout.start()
     atexit.register(indexerdp.kill)
     time.sleep(0.2)
 
-    indexerurl = 'http://localhost:{}/'.format(aiport)
-    healthurl = indexerurl + 'health'
+    indexerurl = "http://localhost:{}/".format(aiport)
+    healthurl = indexerurl + "health"
     for attempt in range(20):
         (ok, json) = tryhealthurl(healthurl, args.verbose, waitforround=lastblock)
         if ok:
-            logger.debug('health round={} OK'.format(lastblock))
+            logger.debug("health round={} OK".format(lastblock))
             break
         time.sleep(0.5)
     if not ok:
-        logger.error('could not get indexer health, or did not reach round={}\n{}'.format(lastblock, json))
+        logger.error(
+            "could not get indexer health, or did not reach round={}\n{}".format(
+                lastblock, json
+            )
+        )
         sys.stderr.write(indexerout.dump())
         return 1
     try:
-        logger.info('reached expected round={}'.format(lastblock))
-        xrun(['python3', 'misc/validate_accounting.py', '--verbose', '--algod', algoddir, '--indexer', indexerurl], timeout=20)
-        xrun(['go', 'run', 'cmd/e2equeries/main.go', '-pg', psqlstring, '-q'], timeout=15)
+        logger.info("reached expected round={}".format(lastblock))
+        xrun(
+            [
+                "python3",
+                "misc/validate_accounting.py",
+                "--verbose",
+                "--algod",
+                algoddir,
+                "--indexer",
+                indexerurl,
+            ],
+            timeout=20,
+        )
+        xrun(
+            ["go", "run", "cmd/e2equeries/main.go", "-pg", psqlstring, "-q"], timeout=15
+        )
     except Exception:
         sys.stderr.write(indexerout.dump())
         raise
@@ -121,11 +176,13 @@ def main():
 
     return 0
 
+
 def hassuffix(x, *suffixes):
     for s in suffixes:
         if x.endswith(s):
             return True
     return False
+
 
 def countblocks(path):
     db = sqlite3.connect(path)
@@ -136,49 +193,54 @@ def countblocks(path):
     db.close()
     return row[0]
 
+
 def tryhealthurl(healthurl, verbose=False, waitforround=100):
     try:
         response = urllib.request.urlopen(healthurl)
         if response.code != 200:
             return (False, "")
         raw = response.read()
-        logger.debug('health %r', raw)
+        logger.debug("health %r", raw)
         ob = json.loads(raw)
-        rt = ob.get('message')
+        rt = ob.get("message")
         if not rt:
             return (False, raw)
         return (int(rt) >= waitforround, raw)
     except Exception as e:
         if verbose:
-            logging.warning('GET %s %s', healthurl, e)
+            logging.warning("GET %s %s", healthurl, e)
         return (False, "")
+
 
 class subslurp:
     # asynchronously accumulate stdout or stderr from a subprocess and hold it for debugging if something goes wrong
     def __init__(self, f):
         self.f = f
         self.buf = io.BytesIO()
-        self.gz = gzip.open(self.buf, 'wb')
+        self.gz = gzip.open(self.buf, "wb")
         self.l = threading.Lock()
         self.t = None
+
     def run(self):
         for line in self.f:
             with self.l:
                 if self.gz is None:
                     return
                 self.gz.write(line)
+
     def dump(self):
         with self.l:
             self.gz.close()
             self.gz = None
         self.buf.seek(0)
-        r = gzip.open(self.buf, 'rt')
+        r = gzip.open(self.buf, "rt")
         return r.read()
+
     def start(self):
         self.t = threading.Thread(target=self.run)
         self.t.daemon = True
         self.t.start()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/misc/e2elive.py
+++ b/misc/e2elive.py
@@ -77,7 +77,6 @@ def main():
         s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
         tarname = "net_done.tar.bz2"
         tarpath = os.path.join(tempdir, tarname)
-        tarname = "THIS_DOES_NOT_EXIST"  # temporary change for testing purposes
         success = firstFromS3Prefix(
             s3, bucket, "indexer/e2e4", tarname, outpath=tarpath
         )

--- a/misc/util.py
+++ b/misc/util.py
@@ -14,27 +14,29 @@ logger = logging.getLogger(__name__)
 
 
 def maybedecode(x):
-    if hasattr(x, 'decode'):
+    if hasattr(x, "decode"):
         return x.decode()
     return x
 
+
 def mloads(x):
     return msgpack.loads(x, strict_map_key=False, raw=True)
+
 
 def unmsgpack(ob):
     "convert dict from msgpack.loads() with byte string keys to text string keys"
     if isinstance(ob, dict):
         od = {}
-        for k,v in ob.items():
+        for k, v in ob.items():
             k = maybedecode(k)
             okv = False
-            if (not okv) and (k == 'note'):
+            if (not okv) and (k == "note"):
                 try:
                     v = unmsgpack(mloads(v))
                     okv = True
                 except:
                     pass
-            if (not okv) and k in ('type', 'note'):
+            if (not okv) and k in ("type", "note"):
                 try:
                     v = v.decode()
                     okv = True
@@ -46,9 +48,10 @@ def unmsgpack(ob):
         return od
     if isinstance(ob, list):
         return [unmsgpack(v) for v in ob]
-    #if isinstance(ob, bytes):
+    # if isinstance(ob, bytes):
     #    return base64.b64encode(ob).decode()
     return ob
+
 
 def _getio(p, od, ed):
     if od is not None:
@@ -57,25 +60,26 @@ def _getio(p, od, ed):
         try:
             od = maybedecode(p.stdout.read())
         except:
-            logger.error('subcomand out', exc_info=True)
+            logger.error("subcomand out", exc_info=True)
     if ed is not None:
         ed = maybedecode(ed)
     elif p.stderr:
         try:
             ed = maybedecode(p.stderr.read())
         except:
-            logger.error('subcomand err', exc_info=True)
+            logger.error("subcomand err", exc_info=True)
     return od, ed
 
+
 def xrun(cmd, *args, **kwargs):
-    timeout = kwargs.pop('timeout', None)
-    kwargs['stdout'] = subprocess.PIPE
-    kwargs['stderr'] = subprocess.STDOUT
-    cmdr = ' '.join(map(repr,cmd))
+    timeout = kwargs.pop("timeout", None)
+    kwargs["stdout"] = subprocess.PIPE
+    kwargs["stderr"] = subprocess.STDOUT
+    cmdr = " ".join(map(repr, cmd))
     try:
         p = subprocess.Popen(cmd, *args, **kwargs)
     except Exception as e:
-        logger.error('subprocess failed {}'.format(cmdr), exc_info=True)
+        logger.error("subprocess failed {}".format(cmdr), exc_info=True)
         raise
     stdout_data, stderr_data = None, None
     try:
@@ -84,78 +88,106 @@ def xrun(cmd, *args, **kwargs):
         else:
             stdout_data, stderr_data = p.communicate()
     except subprocess.TimeoutExpired as te:
-        logger.error('subprocess timed out {}'.format(cmdr), exc_info=True)
+        logger.error("subprocess timed out {}".format(cmdr), exc_info=True)
         stdout_data, stderr_data = _getio(p, stdout_data, stderr_data)
         if stdout_data:
-            sys.stderr.write('output from {}:\n{}\n\n'.format(cmdr, stdout_data))
+            sys.stderr.write("output from {}:\n{}\n\n".format(cmdr, stdout_data))
         if stderr_data:
-            sys.stderr.write('stderr from {}:\n{}\n\n'.format(cmdr, stderr_data))
+            sys.stderr.write("stderr from {}:\n{}\n\n".format(cmdr, stderr_data))
         raise
     except Exception as e:
-        logger.error('subprocess exception {}'.format(cmdr), exc_info=True)
+        logger.error("subprocess exception {}".format(cmdr), exc_info=True)
         stdout_data, stderr_data = _getio(p, stdout_data, stderr_data)
         if stdout_data:
-            sys.stderr.write('output from {}:\n{}\n\n'.format(cmdr, stdout_data))
+            sys.stderr.write("output from {}:\n{}\n\n".format(cmdr, stdout_data))
         if stderr_data:
-            sys.stderr.write('stderr from {}:\n{}\n\n'.format(cmdr, stderr_data))
+            sys.stderr.write("stderr from {}:\n{}\n\n".format(cmdr, stderr_data))
         raise
     if p.returncode != 0:
-        logger.error('cmd failed ({}) {}'.format(p.returncode, cmdr))
+        logger.error("cmd failed ({}) {}".format(p.returncode, cmdr))
         stdout_data, stderr_data = _getio(p, stdout_data, stderr_data)
         if stdout_data:
-            sys.stderr.write('output from {}:\n{}\n\n'.format(cmdr, stdout_data))
+            sys.stderr.write("output from {}:\n{}\n\n".format(cmdr, stdout_data))
         if stderr_data:
-            sys.stderr.write('stderr from {}:\n{}\n\n'.format(cmdr, stderr_data))
-        raise Exception('error: cmd failed: {}'.format(cmdr))
+            sys.stderr.write("stderr from {}:\n{}\n\n".format(cmdr, stderr_data))
+        raise Exception("error: cmd failed: {}".format(cmdr))
     if logger.isEnabledFor(logging.DEBUG):
-        logger.debug('cmd success: %s\n%s\n%s\n', cmdr, maybedecode(stdout_data), maybedecode(stderr_data))
+        logger.debug(
+            "cmd success: %s\n%s\n%s\n",
+            cmdr,
+            maybedecode(stdout_data),
+            maybedecode(stderr_data),
+        )
+
 
 def atexitrun(cmd, *args, **kwargs):
-    cargs = [cmd]+list(args)
+    cargs = [cmd] + list(args)
     atexit.register(xrun, *cargs, **kwargs)
+
 
 def find_indexer(indexer_bin, exc=True):
     if indexer_bin:
         return indexer_bin
     # manually search local build and PATH for algorand-indexer
-    path = ['cmd/algorand-indexer'] + os.getenv('PATH').split(':')
+    path = ["cmd/algorand-indexer"] + os.getenv("PATH").split(":")
     for pd in path:
-        ib = os.path.join(pd, 'algorand-indexer')
+        ib = os.path.join(pd, "algorand-indexer")
         if os.path.exists(ib):
             return ib
-    msg = 'could not find algorand-indexer. use --indexer-bin or PATH environment variable.'
+    msg = "could not find algorand-indexer. use --indexer-bin or PATH environment variable."
     if exc:
         raise Exception(msg)
     logger.error(msg)
     return None
+
 
 def ensure_test_db(connection_string, keep_temps=False):
     if connection_string:
         # use the passed db
         return connection_string
     # create a temporary database
-    dbname = 'e2eindex_{}_{}'.format(int(time.time()), random.randrange(1000))
-    xrun(['dropdb', '--if-exists', dbname], timeout=5)
-    xrun(['createdb', dbname], timeout=5)
+    dbname = "e2eindex_{}_{}".format(int(time.time()), random.randrange(1000))
+    xrun(["dropdb", "--if-exists", dbname], timeout=5)
+    xrun(["createdb", dbname], timeout=5)
     if not keep_temps:
-        atexitrun(['dropdb', '--if-exists', dbname], timeout=5)
+        atexitrun(["dropdb", "--if-exists", dbname], timeout=5)
     else:
         logger.info("leaving db %r", dbname)
-    return 'dbname={} sslmode=disable'.format(dbname)
+    return "dbname={} sslmode=disable".format(dbname)
+
 
 # whoever calls this will need to import boto and get the s3 client
-def firstFromS3Prefix(s3, bucket, prefix, desired_filename, outdir=None, outpath=None):
-    response = s3.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=10)
-    if (not response.get('KeyCount')) or ('Contents' not in response):
-        raise Exception('nothing found in s3://{}/{}'.format(bucket, prefix))
-    for x in response['Contents']:
-        path = x['Key']
-        _, fname = path.rsplit('/', 1)
+def firstFromS3Prefix(
+    s3, bucket, prefix, desired_filename, outdir=None, outpath=None
+) -> bool:
+    haystack = []
+    found_needle = False
+
+    def report():
+        print(
+            f"""Hello from firstFromS3Prefix() !!!!
+        I finished searching for the needle {desired_filename} in the AWS S3 path {bucket}/{prefix}.
+        haystack={haystack}
+        found_needle={found_needle}
+"""
+        )
+
+    atexit.register(report)
+
+    response = s3.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=100)
+    if (not response.get("KeyCount")) or ("Contents" not in response):
+        raise Exception("nothing found in s3://{}/{}".format(bucket, prefix))
+    for x in response["Contents"]:
+        path = x["Key"]
+        haystack.append(path)
+        _, fname = path.rsplit("/", 1)
         if fname == desired_filename:
             if outpath is None:
                 if outdir is None:
-                    outdir = '.'
+                    outdir = "."
                 outpath = os.path.join(outdir, desired_filename)
-            logger.info('s3://%s/%s -> %s', bucket, x['Key'], outpath)
-            s3.download_file(bucket, x['Key'], outpath)
-            return
+            logger.info("s3://%s/%s -> %s", bucket, x["Key"], outpath)
+            s3.download_file(bucket, x["Key"], outpath)
+            return True
+
+    return False

--- a/misc/util.py
+++ b/misc/util.py
@@ -188,6 +188,7 @@ def firstFromS3Prefix(
                 outpath = os.path.join(outdir, desired_filename)
             logger.info("s3://%s/%s -> %s", bucket, x["Key"], outpath)
             s3.download_file(bucket, x["Key"], outpath)
-            return True
+            found_needle = True
+            break
 
-    return False
+    return found_needle

--- a/misc/util.py
+++ b/misc/util.py
@@ -168,6 +168,7 @@ def firstFromS3Prefix(
             f"""Hello from firstFromS3Prefix() !!!!
         I finished searching for the needle {desired_filename} in the AWS S3 path {bucket}/{prefix}.
         haystack={haystack}
+        len(haystack)={len(haystack)}
         found_needle={found_needle}
 """
         )


### PR DESCRIPTION
# More info in `e2elive.py` + `Dockerfile` update

## Summary of changes
* [Improved message](https://app.circleci.com/pipelines/github/algorand/indexer/1919/workflows/2c21d2cd-c170-43da-89b8-8db814b0d33b/jobs/3124/parallel-runs/0/steps/0-122) at the end of `make e2e` (see image below)
* `misc/Dockerfile` -  ([cherry picked](https://github.com/algorand/indexer/pull/1002/commits/9d39e43a3bbe7224ce2caecf3cd3e5dfba25d736) out of @Eric-Warehime 's #1002 ) `make e2e` calls out to `docker-compose` which builds and runs this `Dockerfile` to run the end to end tests via `misc/e2elive.py` running inside the container.  In doing so, an `algod` with private network is brought up with `goal nework start -r ${tempnet}`.
  * Previously, the `go-algorand` was retrieved and built from the nightly channel via a [pinned version](https://github.com/algorand/go-algorand/raw/1e1474216421da27008726c44ebe0a5ba2fb6a08/cmd/updater/update.sh) of `go-algorand`'s`cmd/updater/update.sh` and the command `./update.sh -i -c nightly -p /opt/algorand/bin -d /opt/algorand/data -n`. 
  * Going forward, `go-algorand` is being built directly with `make install` under the submodule `third_party/go-algorand`
  * **TLDR;** - we'll be using the commit's go-algorand submodule in end to end tests instead of the external nightly build

### Example Output for `e2elive.py` Failing Due to Missing Tarball
<img width="981" alt="image" src="https://user-images.githubusercontent.com/291133/181831424-f8c892e3-af82-476f-a95c-27ec8f758e68.png">


## Test Plan

CI
