### PR TITLE
Testing: Use tempdir instead of /tmp for e2elive test

### DIFF
--- a/misc/e2elive.py
+++ b/misc/e2elive.py
@@ -89,7 +89,7 @@ def main():
     psqlstring = ensure_test_db(args.connection_string, args.keep_temps)
     algoddir = os.path.join(tempnet, 'Primary')
     aiport = args.indexer_port or random.randint(4000,30000)
-    cmd = [indexer_bin, 'daemon', '--data-dir', '/tmp', '-P', psqlstring, '--dev-mode', '--algod', algoddir, '--server', ':{}'.format(aiport)]
+    cmd = [indexer_bin, 'daemon', '--data-dir', tempdir, '-P', psqlstring, '--dev-mode', '--algod', algoddir, '--server', ':{}'.format(aiport)]
     logger.debug("%s", ' '.join(map(repr,cmd)))
     indexerdp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     indexerout = subslurp(indexerdp.stdout)

--- a/misc/util.py
+++ b/misc/util.py
@@ -159,4 +159,4 @@ def firstFromS3Prefix(s3, bucket, prefix, desired_filename, outdir=None, outpath
             logger.info('s3://%s/%s -> %s', bucket, x['Key'], outpath)
             s3.download_file(bucket, x['Key'], outpath)
             return
-    logger.info('file not found in s3://{}/{}'.format(bucket, prefix))
+    logger.warning('file not found in s3://{}/{}'.format(bucket, prefix))

--- a/misc/util.py
+++ b/misc/util.py
@@ -145,7 +145,7 @@ def ensure_test_db(connection_string, keep_temps=False):
 
 # whoever calls this will need to import boto and get the s3 client
 def firstFromS3Prefix(s3, bucket, prefix, desired_filename, outdir=None, outpath=None):
-    response = s3.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=10)
+    response = s3.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=50)
     if (not response.get('KeyCount')) or ('Contents' not in response):
         raise Exception('nothing found in s3://{}/{}'.format(bucket, prefix))
     for x in response['Contents']:
@@ -159,3 +159,4 @@ def firstFromS3Prefix(s3, bucket, prefix, desired_filename, outdir=None, outpath
             logger.info('s3://%s/%s -> %s', bucket, x['Key'], outpath)
             s3.download_file(bucket, x['Key'], outpath)
             return
+    logger.info('file not found in s3://{}/{}'.format(bucket, prefix))


### PR DESCRIPTION
## Summary

When running locally there were test artifacts left in /tmp which caused errors when running the test more than once.

Additionally, increase the lookback for the e2e archive and print more information when a file was not found in S3.

