### PR TITLE
Conduit: AlgodImporter fetcher integration

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -225,6 +225,9 @@ func (bot *fetcherImpl) mainLoop(ctx context.Context) error {
 
 // Run is part of the Fetcher interface
 func (bot *fetcherImpl) Run(ctx context.Context) error {
+	if bot.algodImp == nil {
+		bot.algodImp = algodimporter.New()
+	}
 	bot.algodImp.Init(ctx, bot.cfg, bot.log)
 
 	bot.blockQueue = make(chan *rpcs.EncodedBlockCert)
@@ -283,7 +286,7 @@ func ForNetAndToken(netaddr, token string, log *log.Logger) (bot Fetcher, err er
 	if err != nil {
 		return
 	}
-	cfg := plugins.PluginConfig("netaddr: " + netaddr + "\n" + "token: " + token)
+	cfg := plugins.PluginConfig("netaddr: " + netaddr + "\ntoken: " + token)
 	bot = &fetcherImpl{aclient: client, log: log, algodImp: algodimporter.New(), cfg: cfg}
 	return
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary
This PR updates the current fetcher to utilize `algodimporter` plugin as a block importer (to fetch blocks). This is the first step towards enabling users to choose a specific importer plugin to import blocks, adhering to the general `Importer` interface.
