### PR TITLE
Bug-Fix: Revert to Eric's Original BlockHdrCached implementation + miscellany

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ coverage.txt
 
 # mac OS
 .DS_store
+
+# asdf
+.tool-versions

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SRCPATH		:= $(shell pwd)
 VERSION		:= $(shell $(SRCPATH)/mule/scripts/compute_build_number.sh)
 OS_TYPE		?= $(shell $(SRCPATH)/mule/scripts/ostype.sh)
-ARCH			?= $(shell $(SRCPATH)/mule/scripts/archtype.sh)
+ARCH		?= $(shell $(SRCPATH)/mule/scripts/archtype.sh)
 PKG_DIR		= $(SRCPATH)/tmp/node_pkgs/$(OS_TYPE)/$(ARCH)/$(VERSION)
 ifeq ($(OS_TYPE), darwin)
 ifeq ($(ARCH), arm64)

--- a/misc/Dockerfile
+++ b/misc/Dockerfile
@@ -23,4 +23,4 @@ RUN pip3 install -r misc/requirements.txt
 
 ENV INDEXER_DATA="${HOME}/indexer/"
 # Run test script
-ENTRYPOINT ["/bin/bash", "-c", "sleep 5 && python3 misc/e2elive.py --connection-string \"$CONNECTION_STRING\" --indexer-bin /opt/go/indexer/cmd/algorand-indexer/algorand-indexer --indexer-port 9890"]
+ENTRYPOINT ["/bin/bash", "-c", "sleep 5 && python3 misc/e2elive.py --connection-string \"$CONNECTION_STRING\" --s3-source-net \"$CI_E2E_FILENAME\" --indexer-bin /opt/go/indexer/cmd/algorand-indexer/algorand-indexer --indexer-port 9890"]

--- a/misc/docker-compose.yml
+++ b/misc/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: ./misc/Dockerfile    
     environment:
       CONNECTION_STRING: "host=e2e-db port=5432 user=algorand password=algorand dbname=indexer_db sslmode=disable"
-      CI_E2E_FILENAME: "feature-stateproofs"
+      CI_E2E_FILENAME: "net_done"
 
   e2e-db:
     image: "postgres:13-alpine"

--- a/misc/docker-compose.yml
+++ b/misc/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: ./misc/Dockerfile    
     environment:
       CONNECTION_STRING: "host=e2e-db port=5432 user=algorand password=algorand dbname=indexer_db sslmode=disable"
+      CI_E2E_FILENAME: "feature-stateproofs"
 
   e2e-db:
     image: "postgres:13-alpine"

--- a/misc/docker-compose.yml
+++ b/misc/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: ./misc/Dockerfile    
     environment:
       CONNECTION_STRING: "host=e2e-db port=5432 user=algorand password=algorand dbname=indexer_db sslmode=disable"
-      CI_E2E_FILENAME: "net_done"
+      CI_E2E_FILENAME: "rel-nightly"
 
   e2e-db:
     image: "postgres:13-alpine"

--- a/misc/e2elive.py
+++ b/misc/e2elive.py
@@ -48,6 +48,10 @@ def main():
         "--source-net",
         help="Path to test network directory containing Primary and other nodes. May be a tar file.",
     )
+    ap.add_argument(
+        "--s3-source-net",
+        help="AWS S3 key suffix to test network tarball containing Primary and other nodes. Must be a tar bz2 file.",
+    )
     ap.add_argument("--verbose", default=False, action="store_true")
     args = ap.parse_args()
     if args.verbose:
@@ -68,6 +72,11 @@ def main():
     else:
         logger.info("leaving temp dir %r", tempdir)
     if not (source_is_tar or (sourcenet and os.path.isdir(sourcenet))):
+        tarname = args.s3_source_net
+        if not tarname:
+            raise Exception("Must provide either local or s3 network to run test against")
+        tarname = f"{tarname}.tar.bz2"
+
         # fetch test data from S3
         bucket = "algorand-testdata"
         import boto3
@@ -75,7 +84,6 @@ def main():
         from botocore import UNSIGNED
 
         s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
-        tarname = "net_done.tar.bz2"
         tarpath = os.path.join(tempdir, tarname)
         prefix = "indexer/e2e4"
         success = firstFromS3Prefix(s3, bucket, prefix, tarname, outpath=tarpath)
@@ -94,7 +102,6 @@ def main():
         os.path.join(tempdir, "net", "Primary", "*", "*.block.sqlite")
     )
     lastblock = countblocks(blockfiles[0])
-    # subprocess.run(['find', tempnet, '-type', 'f'])
     try:
         xrun(["goal", "network", "start", "-r", tempnet])
     except Exception:

--- a/processor/eval/ledger_for_evaluator.go
+++ b/processor/eval/ledger_for_evaluator.go
@@ -151,5 +151,5 @@ func (l LedgerForEvaluator) LatestTotals() (ledgercore.AccountTotals, error) {
 
 // BlockHdrCached is part of go-algorand's indexerLedgerForEval interface.
 func (l LedgerForEvaluator) BlockHdrCached(round basics.Round) (bookkeeping.BlockHeader, error) {
-	panic("not implemented")
+	return l.Ledger.BlockHdrCached(round)
 }


### PR DESCRIPTION
## Summary

* Implementing `indexerLedgerForEvaluator.BlockHdrCached(round)` in `processor/eval/ledger_for_evaluator.go`
  * this is required for processing blocks with the new [block op code](https://github.com/algorand/go-algorand/blob/2473026a696d0b24bbd98ab033369c44d25bae27/data/transactions/logic/eval.go#L5013) needed for randomness
*  Rename and bubble up the end-to-end test network tar ball's **filename**. In particular:
  * Set this name in `misc/docker-compose.yml` to `rel-nightly`
  * Using the same environment variable naming convention `CI_E2E_FILENAME ` for the S3 network artifact as in [go-algorand](https://github.com/algorand/go-algorand/blob/cdd4aa1305fd3d99c83c7a629f2202ffe0f3964e/test/scripts/e2e.sh#L184) 
  * Pass that env-var as an argument to the Dockerfile's exec command
  * Pass it to the `main()` function in `misc/e2elive.py` via the new argument `--s3-source-net`
* Unrelated NOOP and non-urgent changes to `.gitignore` and `Makefile`

## Some comments originally on #1067 

## Why **was** CI failing? (as of August 2)
Recently, an update to the go-algorand submodule brought in changes for [handling randomness](https://github.com/algorand/go-algorand/pull/3900). In particular, the function [BlockHeaderCached()](https://github.com/algorand/indexer/blob/0598f73678efe8753198ffafef78ffdecdb61496/processor/eval/ledger_for_evaluator.go#L160) is [failing in the E2E test with a `panic("not implemented")`](https://app.circleci.com/pipelines/github/algorand/indexer/1964/workflows/bc0a706b-8083-4057-b576-9eb103fafff0/jobs/3178?invite=true#step-122-978). Interestingly, I plead guilty for requesting this change to panic for this method in the @Eric-Warehime 's [recent PR](https://github.com/algorand/indexer/pull/1144#discussion_r929289900). Likely, the randomness E2E test wasn't yet in place to hit this piece of code when #1144 was merged.

### How the test was fixed: re-introduced Eric's [original implementation](https://github.com/algorand/indexer/blob/6daeb2028764f651592f28684cca617dd21a4926/processor/eval/ledger_for_evaluator.go#L159-L161).


## Test Plan

CI is good 'nuf because:
* it [ran against the downloaded rel_nightly](https://app.circleci.com/pipelines/github/algorand/indexer/1981/workflows/17d845c6-ee09-4a79-874c-4782da42fedb/jobs/3199?invite=true#step-122-904) network
* ...which was generated by August 2nd's rel nightly job
* ...which included the [test/scripts/e2e_subs/hdr-access.py ](https://github.com/jannotti/go-algorand/blob/31a5cb727e16c6bee1f13bc61b1fe8d5a4e097b8/test/scripts/e2e_subs/hdr-access.py#L42) end-to-end test
* ...which includes the [block opcode](https://github.com/jannotti/go-algorand/blob/31a5cb727e16c6bee1f13bc61b1fe8d5a4e097b8/test/scripts/e2e_subs/hdr-access.py#L42)
