### PR TITLE
cicd: add darwin arm64 support to release script

### DIFF
--- a/misc/release.py
+++ b/misc/release.py
@@ -38,6 +38,7 @@ osArchArch = [
     ("linux", "arm", "armhf"),
     ("linux", "arm64", "arm64"),
     ("darwin", "amd64", None),
+    ("darwin", "arm64", None)
 ]
 
 channel = "indexer"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

this adds support for darwin machines running on arm64 architecture (m1) to the `release.py` script. this makes it so that darwin-arm64 builds can be enabled at a later time. 

