### PR TITLE
Use config to control noop exporter round start

### DIFF
--- a/exporters/noop/noop_exporter_config.go
+++ b/exporters/noop/noop_exporter_config.go
@@ -1,0 +1,7 @@
+package noop
+
+// ExporterConfig specific to the noop exporter
+type ExporterConfig struct {
+	// Optionally specify the round to start on
+	Round uint64 `yaml:"round"`
+}

--- a/exporters/noop/noop_exporter_test.go
+++ b/exporters/noop/noop_exporter_test.go
@@ -30,7 +30,7 @@ func TestExporterMetadata(t *testing.T) {
 	assert.Equal(t, noopExporterMetadata.ExpDeprecated, meta.Deprecated())
 }
 
-func TestExporterConnect(t *testing.T) {
+func TestExporterInit(t *testing.T) {
 	assert.NoError(t, ne.Init("", nil))
 }
 
@@ -38,12 +38,20 @@ func TestExporterConfig(t *testing.T) {
 	assert.Equal(t, plugins.PluginConfig(""), ne.Config())
 }
 
-func TestExporterDisconnect(t *testing.T) {
+func TestExporterClose(t *testing.T) {
 	assert.NoError(t, ne.Close())
 }
 
 func TestExporterHandleGenesis(t *testing.T) {
 	assert.NoError(t, ne.HandleGenesis(bookkeeping.Genesis{}))
+}
+
+func TestExporterStartRound(t *testing.T) {
+	assert.NoError(t, ne.Init("", nil))
+	assert.Equal(t, uint64(0), ne.Round())
+	assert.NoError(t, ne.Init("round: 55", nil))
+	assert.Equal(t, uint64(55), ne.Round())
+
 }
 
 func TestExporterRoundReceive(t *testing.T) {

--- a/exporters/noop/noop_exporter_test.go
+++ b/exporters/noop/noop_exporter_test.go
@@ -67,7 +67,6 @@ func TestExporterRoundReceive(t *testing.T) {
 			Round: 5,
 		},
 	}
-	assert.Equal(t, uint64(0), ne.Round())
 	assert.NoError(t, ne.Receive(eData))
 	assert.Equal(t, uint64(6), ne.Round())
 }

--- a/exporters/noop/noop_exporter_test.go
+++ b/exporters/noop/noop_exporter_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/algorand/indexer/plugins"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 	"testing"
 )
 
@@ -35,7 +36,13 @@ func TestExporterInit(t *testing.T) {
 }
 
 func TestExporterConfig(t *testing.T) {
-	assert.Equal(t, plugins.PluginConfig(""), ne.Config())
+	defaultConfig := &ExporterConfig{}
+	expected, err := yaml.Marshal(defaultConfig)
+	if err != nil {
+		t.Fatalf("unable to Marshal default noop.ExporterConfig: %v", err)
+	}
+	assert.NoError(t, ne.Init("", nil))
+	assert.Equal(t, plugins.PluginConfig(expected), ne.Config())
 }
 
 func TestExporterClose(t *testing.T) {


### PR DESCRIPTION
## Summary

Allows the user to set the round to start on for the noop exporter. This will be important because the Exporter's provided round will be used initially to determine which round the entire conduit pipeline should start on.

## Test Plan

Added Unit test.
