### PR TITLE
Set pgsql exporter round from db on init

### DIFF
--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -61,6 +61,9 @@ func (exp *postgresqlExporter) Init(cfg plugins.PluginConfig, logger *logrus.Log
 	}
 	exp.db = db
 	<-ready
+	if rnd, err := exp.db.GetNextRoundToAccount(); err == nil {
+		exp.round = rnd
+	}
 	return err
 }
 


### PR DESCRIPTION

## Summary

Same change that was made for the noop exporter in #1176 

We want to set the exporter's round based on the expected state so that the pipeline knows which round to start on.

## Test Plan

Dummy Db always returns round 0, so there's not a great way to unit test this built in currently. 