### PR TITLE
Add waits/retries to algod importer

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,6 +2,11 @@ codecov:
   require_ci_to_pass: no
   branch: develop
 
+ignore:
+  - "idb/mocks"
+  - "idb/dummy"
+  - "util/test"
+
 coverage:
   precision: 2
   round: down

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -69,7 +69,7 @@ func TestFetcherImplCatchupLoopBlockError(t *testing.T) {
 		// returning an empty block `passingCalls` times before throwing 500s
 		func(path string, w http.ResponseWriter) bool {
 			if strings.Contains(path, "v2/blocks/") {
-				if passingCalls <= 0 {
+				if passingCalls == 0 {
 					w.WriteHeader(http.StatusInternalServerError)
 				} else {
 					var block bookkeeping.Block

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -3,8 +3,9 @@ package fetcher
 import (
 	"context"
 	"fmt"
+	"github.com/algorand/indexer/util/test"
+	"github.com/stretchr/testify/assert"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -12,20 +13,10 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/algorand/go-algorand-sdk/client/v2/algod"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/rpcs"
 )
-
-type AlgodHandler struct {
-	mock.Mock
-}
-
-func (handler *AlgodHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	handler.Called(w, req)
-	return
-}
 
 type BlockHandler struct {
 	mock.Mock
@@ -36,29 +27,23 @@ func (handler *BlockHandler) handlerFunc(ctx context.Context, cert *rpcs.Encoded
 	return args.Error(0)
 }
 
-func mockAClient(t *testing.T, algodHandler *AlgodHandler) *algod.Client {
-	mockServer := httptest.NewServer(algodHandler)
-	aclient, err := algod.MakeClient(mockServer.URL, "")
-	if err != nil {
-		t.FailNow()
-	}
-	return aclient
-}
-
 func TestFetcherImplErrorInitialization(t *testing.T) {
-	aclient := mockAClient(t, &AlgodHandler{})
+	aclient, err := test.MockAClient(test.NewAlgodHandler())
+	assert.NoError(t, err)
 	fetcher := &fetcherImpl{aclient: aclient, log: logrus.New()}
 	require.Equal(t, "", fetcher.Error(), "Initialization of fetcher caused an unexpected error.")
 }
 
 func TestFetcherImplAlgodReturnsClient(t *testing.T) {
-	aclient := mockAClient(t, &AlgodHandler{})
+	aclient, err := test.MockAClient(test.NewAlgodHandler())
+	assert.NoError(t, err)
 	fetcher := &fetcherImpl{aclient: aclient, log: logrus.New()}
 	require.Equal(t, aclient, fetcher.Algod(), "Algod client returned from fetcherImpl does not match expected instance.")
 }
 
 func TestFetcherImplSetError(t *testing.T) {
-	aclient := mockAClient(t, &AlgodHandler{})
+	aclient, err := test.MockAClient(test.NewAlgodHandler())
+	assert.NoError(t, err)
 	fetcher := &fetcherImpl{aclient: aclient, log: logrus.New()}
 	expectedErr := fmt.Errorf("foobar")
 	fetcher.setError(expectedErr)
@@ -66,56 +51,45 @@ func TestFetcherImplSetError(t *testing.T) {
 }
 
 func TestFetcherImplProcessQueueHandlerError(t *testing.T) {
-	mockAlgodHandler := &AlgodHandler{}
-	aclient := mockAClient(t, mockAlgodHandler)
+	aclient, err := test.MockAClient(test.NewAlgodHandler(test.BlockResponder))
+	assert.NoError(t, err)
 	fetcher := &fetcherImpl{aclient: aclient, log: logrus.New()}
 	bHandler := &BlockHandler{}
 	expectedError := fmt.Errorf("handlerError")
 	// The block handler function will immediately return an error on any block passed to it
 	bHandler.On("handlerFunc", mock.Anything, mock.Anything).Return(expectedError)
 	fetcher.SetBlockHandler(bHandler.handlerFunc)
-	// Mock algod server to continually return empty blocks
-	mockAlgodHandler.On("ServeHTTP", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-		respWriter := args.Get(0).(http.ResponseWriter)
-		req := args.Get(1).(*http.Request)
-		path := req.URL.Path
-		if strings.Contains(path, "v2/blocks/") {
-			var block bookkeeping.Block
-			respWriter.Write(protocol.Encode(&block))
-		}
-	})
 	require.ErrorIsf(t, fetcher.Run(context.Background()), expectedError, "FetcherImpl did not return expected error in processQueue handler.")
 }
 
 func TestFetcherImplCatchupLoopBlockError(t *testing.T) {
-	mockAlgodHandler := &AlgodHandler{}
-	aclient := mockAClient(t, mockAlgodHandler)
 	passingCalls := 5
+	aclient, err := test.MockAClient(test.NewAlgodHandler(
+		// Our mock algod client will process /v2/blocks/{round} calls
+		// returning an empty block `passingCalls` times before throwing 500s
+		func(path string, w http.ResponseWriter) bool {
+			if strings.Contains(path, "v2/blocks/") {
+				if passingCalls <= 0 {
+					w.WriteHeader(http.StatusInternalServerError)
+				} else {
+					var block bookkeeping.Block
+					w.WriteHeader(http.StatusOK)
+					w.Write(protocol.Encode(&block))
+					passingCalls--
+				}
+				return true
+			}
+			return false
+		}),
+	)
+	assert.NoError(t, err)
 	// Initializing blockQueue here needs buffer since we have no other goroutines receiving from it
 	fetcher := &fetcherImpl{aclient: aclient, log: logrus.New(), blockQueue: make(chan *rpcs.EncodedBlockCert, 256)}
 	bHandler := &BlockHandler{}
 	// the handler will do nothing here
 	bHandler.On("handlerFunc", mock.Anything, mock.Anything).Return(nil)
 	fetcher.SetBlockHandler(bHandler.handlerFunc)
-
-	// Our mock algod client will process /v2/blocks/{round} calls
-	// returning an empty block `passingCalls` times before throwing 500s
-	mockAlgodHandler.On("ServeHTTP", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-		respWriter := args.Get(0).(http.ResponseWriter)
-		req := args.Get(1).(*http.Request)
-		path := req.URL.Path
-		if strings.Contains(path, "v2/blocks/") {
-			if passingCalls <= 0 {
-				respWriter.WriteHeader(http.StatusInternalServerError)
-			} else {
-				var block bookkeeping.Block
-				respWriter.WriteHeader(http.StatusOK)
-				respWriter.Write(protocol.Encode(&block))
-				passingCalls--
-			}
-		}
-	})
-	err := fetcher.catchupLoop(context.Background())
+	err = fetcher.catchupLoop(context.Background())
 	require.NoError(t, err, "FetcherImpl returned an unexpected error from catchupLoop")
 	require.Equal(t, "", fetcher.Error(), "FetcherImpl set an unexpected error from algod client during catchupLoop")
 }

--- a/importers/algod/algod_importer_test.go
+++ b/importers/algod/algod_importer_test.go
@@ -2,12 +2,13 @@ package algodimporter
 
 import (
 	"context"
-	"github.com/algorand/indexer/util/test"
 	"os"
 	"testing"
 
 	"github.com/algorand/indexer/importers"
 	"github.com/algorand/indexer/plugins"
+	"github.com/algorand/indexer/util/test"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"

--- a/util/test/mock_algod.go
+++ b/util/test/mock_algod.go
@@ -1,0 +1,74 @@
+package test
+
+import (
+	"github.com/algorand/go-algorand-sdk/client/v2/algod"
+	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/rpcs"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strconv"
+	"strings"
+)
+
+type algodHandler struct {
+	responders []func(path string, w http.ResponseWriter) bool
+}
+
+func NewAlgodServer(responders ...func(path string, w http.ResponseWriter) bool) *httptest.Server {
+	return httptest.NewServer(&algodHandler{responders})
+}
+
+func NewAlgodHandler(responders ...func(path string, w http.ResponseWriter) bool) *algodHandler {
+	return &algodHandler{responders}
+}
+
+func (handler *algodHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	for _, responder := range handler.responders {
+		if responder(req.URL.Path, w) {
+			return
+		}
+	}
+	w.WriteHeader(http.StatusBadRequest)
+}
+
+func MockAClient(algodHandler *algodHandler) (*algod.Client, error) {
+	mockServer := httptest.NewServer(algodHandler)
+	return algod.MakeClient(mockServer.URL, "")
+}
+
+func BlockResponder(reqPath string, w http.ResponseWriter) bool {
+	if strings.Contains(reqPath, "v2/blocks/") {
+		rnd, _ := strconv.Atoi(path.Base(reqPath))
+		blk := rpcs.EncodedBlockCert{Block: bookkeeping.Block{BlockHeader: bookkeeping.BlockHeader{Round: basics.Round(rnd)}}}
+		blockbytes := protocol.Encode(&blk)
+		w.WriteHeader(http.StatusOK)
+		w.Write(blockbytes)
+		return true
+	}
+	return false
+}
+
+func GenesisResponder(reqPath string, w http.ResponseWriter) bool {
+	if strings.Contains(reqPath, "/genesis") {
+		w.WriteHeader(http.StatusOK)
+		genesis := &bookkeeping.Genesis{}
+		blockbytes := protocol.EncodeJSON(*genesis)
+		w.Write(blockbytes)
+		return true
+	}
+	return false
+}
+
+func BlockAfterResponder(reqPath string, w http.ResponseWriter) bool {
+	if strings.Contains(reqPath, "/wait-for-block-after") {
+		w.WriteHeader(http.StatusOK)
+		nStatus := models.NodeStatus{}
+		w.Write(protocol.EncodeJSON(nStatus))
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Indexer's fetcher uses the GetBlock API while catching up since it knows the blocks should exist, and adds a WaitForBlock call during follow. 

I've added a wait call for each block fetch so that fetching blocks via the Algod Importer should function properly for both older blocks and new ones.

I've also refactored the mock algod server used in these tests and the fetcher tests to use a common package.

Also added files to the codecov ignore list since they are mocks/tests.

## Test Plan

Added/updated unit tests.