### PR TITLE
conduit: pipeline run loop implementation

### DIFF
--- a/conduit/logging.go
+++ b/conduit/logging.go
@@ -18,3 +18,13 @@ func (f PluginLogFormatter) Format(entry *log.Entry) ([]byte, error) {
 	entry.Data["_name"] = f.Name
 	return f.Formatter.Format(entry)
 }
+
+func makePluginLogFormatter(pluginType string, pluginName string) PluginLogFormatter {
+	return PluginLogFormatter{
+		Formatter: &log.JSONFormatter{
+			DisableHTMLEscape: true,
+		},
+		Type: pluginType,
+		Name: pluginName,
+	}
+}

--- a/conduit/pipeline.go
+++ b/conduit/pipeline.go
@@ -203,7 +203,7 @@ func (p *pipelineImpl) Start() error {
 				Name: (*processor).Metadata().Name(),
 			},
 		)
-		jsonEncode = string(json.Encode(p.cfg.Processors[idx]))
+		jsonEncode = string(json.Encode(p.cfg.Processors[idx].Config))
 		err := (*processor).Init(p.ctx, *p.initProvider, plugins.PluginConfig(jsonEncode), processorLogger)
 		processorName := (*processor).Metadata().Name()
 		if err != nil {

--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -2,15 +2,19 @@ package postgresql
 
 import (
 	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
+
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/exporters"
 	"github.com/algorand/indexer/idb"
+	_ "github.com/algorand/indexer/idb/postgres"
 	"github.com/algorand/indexer/importer"
 	"github.com/algorand/indexer/plugins"
-	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 )
 
 const exporterName = "postgresql"

--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/exporters"
 	"github.com/algorand/indexer/idb"
+	// Necessary to ensure the postgres implementation has been registered in the idb factory
 	_ "github.com/algorand/indexer/idb/postgres"
 	"github.com/algorand/indexer/importer"
 	"github.com/algorand/indexer/plugins"

--- a/importers/algod/algod_importer.go
+++ b/importers/algod/algod_importer.go
@@ -2,7 +2,6 @@ package algodimporter
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"net/url"
@@ -84,7 +83,7 @@ func (algodImp *algodImporter) Init(ctx context.Context, cfg plugins.PluginConfi
 
 	genesis := bookkeeping.Genesis{}
 
-	err = json.Unmarshal([]byte(genesisResponse), &genesis)
+	err = protocol.DecodeJSON([]byte(genesisResponse), &genesis)
 	if err != nil {
 		return nil, err
 	}

--- a/processors/blockprocessor/block_processor_test.go
+++ b/processors/blockprocessor/block_processor_test.go
@@ -68,7 +68,7 @@ func TestFailedProcess(t *testing.T) {
 	proc := blockprocessor.MakeBlockProcessorHandlerAdapter(&pr, nil)
 	assert.Nil(t, err)
 	err = proc(nil)
-	assert.Contains(t, err.Error(), "invalid round")
+	assert.Nil(t, err)
 
 	genesisBlock, err := l.Block(basics.Round(0))
 	assert.Nil(t, err)

--- a/processors/noop/noop_processor.go
+++ b/processors/noop/noop_processor.go
@@ -2,6 +2,9 @@ package noop
 
 import (
 	"context"
+
+	"github.com/sirupsen/logrus"
+
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/plugins"
 	"github.com/algorand/indexer/processors"
@@ -36,7 +39,7 @@ func (p *Processor) Config() plugins.PluginConfig {
 }
 
 // Init noop
-func (p *Processor) Init(_ context.Context, _ data.InitProvider, _ plugins.PluginConfig) error {
+func (p *Processor) Init(_ context.Context, _ data.InitProvider, _ plugins.PluginConfig, _ *logrus.Logger) error {
 	return nil
 }
 

--- a/processors/processor.go
+++ b/processors/processor.go
@@ -2,6 +2,9 @@ package processors
 
 import (
 	"context"
+
+	"github.com/sirupsen/logrus"
+
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/plugins"
 )
@@ -18,7 +21,7 @@ type Processor interface {
 	// Typically, used for things like initializing network connections.
 	// The Context passed to Init() will be used for deadlines, cancel signals and other early terminations
 	// The Config passed to Init() will contain the unmarshalled config file specific to this plugin.
-	Init(ctx context.Context, initProvider data.InitProvider, cfg plugins.PluginConfig) error
+	Init(ctx context.Context, initProvider data.InitProvider, cfg plugins.PluginConfig, logger *logrus.Logger) error
 
 	// Close will be called during termination of the Indexer process.
 	Close() error

--- a/processors/processor_factory.go
+++ b/processors/processor_factory.go
@@ -42,7 +42,7 @@ func ProcessorByName(ctx context.Context, name string, dataDir string, initProvi
 	}
 	processor := constructor.New()
 	cfg := plugins.LoadConfig(logger, dataDir, processor.Metadata())
-	if err := processor.Init(ctx, initProvider, cfg); err != nil {
+	if err := processor.Init(ctx, initProvider, cfg, logger); err != nil {
 		return nil, err
 	}
 	return processor, nil

--- a/processors/processor_factory_test.go
+++ b/processors/processor_factory_test.go
@@ -3,16 +3,18 @@ package processors
 import (
 	"context"
 	"fmt"
-	"github.com/algorand/go-algorand/data/basics"
-	"github.com/algorand/go-algorand/data/bookkeeping"
-	"github.com/algorand/indexer/data"
 	"testing"
 
-	"github.com/algorand/indexer/plugins"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+
+	"github.com/algorand/indexer/data"
+	"github.com/algorand/indexer/plugins"
 )
 
 var logger *logrus.Logger
@@ -40,8 +42,8 @@ type mockProcessor struct {
 	Processor
 }
 
-func (m *mockProcessor) Init(ctx context.Context, initProvider data.InitProvider, cfg plugins.PluginConfig) error {
-	args := m.Called(ctx, initProvider, cfg)
+func (m *mockProcessor) Init(ctx context.Context, initProvider data.InitProvider, cfg plugins.PluginConfig, logger *logrus.Logger) error {
+	args := m.Called(ctx, initProvider, cfg, logger)
 	return args.Error(0)
 }
 

--- a/processors/processor_factory_test.go
+++ b/processors/processor_factory_test.go
@@ -61,7 +61,7 @@ func (c *mockProcessorConstructor) New() Processor {
 
 func TestProcessorByNameSuccess(t *testing.T) {
 	me := mockProcessor{}
-	me.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	me.On("Init", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	RegisterProcessor("foobar", &mockProcessorConstructor{&me})
 
 	exp, err := ProcessorByName(context.Background(), "foobar", "", mockProvider{}, logger)
@@ -78,7 +78,7 @@ func TestProcessorByNameNotFound(t *testing.T) {
 func TestProcessorByNameConnectFailure(t *testing.T) {
 	me := mockProcessor{}
 	expectedErr := fmt.Errorf("connect failure")
-	me.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(expectedErr)
+	me.On("Init", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(expectedErr)
 	RegisterProcessor("baz", &mockProcessorConstructor{&me})
 	_, err := ProcessorByName(context.Background(), "baz", "", mockProvider{}, logger)
 	assert.EqualError(t, err, expectedErr.Error())


### PR DESCRIPTION
## Summary

I've gone through the initial implementation of the conduit pipeline run loop, and found/fixed a few bugs along the way.

Bug fixes/changes:
* Configs were being loaded, but empty string were being passed into plugins during init--now we parse and load plugins with proper configs
* The Processor interface was the only plugin interface not taking a logger, so I've added one
* Additionally, I've made sure that all conduit loggers are properly being passed to Inits
* Fixed import order in as many places as I saw
* Rearranged ledger variable assignment in block_processor to avoid a null pointer exception
* algod importer was not properly decoding config data--switched to using the protocol package to fix this issue
* Fixed an issue where importing the genesis file in the ledger initializes the 0 block, but the same is not true for pgsql
  * We now no-op the 0 round in the ledger instead of failing on it.
* Added a run loop for the pipeline--infinitely runs, exiting on any error


I know of a few more bugs that I wasn't able to address here that I will create tickets for.

## Test Plan

This PR runs using local algod importer, (noop/block_processor) processors, and (noop/postgresql) exporters.

