### PR TITLE
Conduit: Network importer implementation

### DIFF
--- a/importers/all/all.go
+++ b/importers/all/all.go
@@ -3,4 +3,5 @@ package all
 import (
 	// Call package wide init function
 	_ "github.com/algorand/indexer/importers/algod"
+	_ "github.com/algorand/indexer/importers/network"
 )

--- a/importers/network/network_importer.go
+++ b/importers/network/network_importer.go
@@ -1,0 +1,124 @@
+package networkimporter
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/algorand/go-algorand/catchup"
+	"github.com/algorand/go-algorand/config"
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/logging"
+	"github.com/algorand/go-algorand/network"
+
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/indexer/data"
+	"github.com/algorand/indexer/importers"
+	"github.com/algorand/indexer/plugins"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+const importerName = "network"
+
+type networkImporter struct {
+	logger         *logrus.Logger
+	cfg            ImporterConfig
+	ctx            context.Context
+	cancel         context.CancelFunc
+	networkFetcher *catchup.NetworkFetcher
+}
+
+var networkImporterMetadata = importers.ImporterMetadata{
+	ImpName:        importerName,
+	ImpDescription: "Importer for fetching blocks directly from the network.",
+	ImpDeprecated:  false,
+}
+
+// New initializes an network importer
+func New() importers.Importer {
+	return &networkImporter{}
+}
+
+// Constructor is the Constructor implementation for the "network" importer
+type Constructor struct{}
+
+// New initializes a blockProcessorConstructor
+func (c *Constructor) New() importers.Importer {
+	return &networkImporter{}
+}
+
+func (networkImp *networkImporter) Metadata() importers.ImporterMetadata {
+	return networkImporterMetadata
+}
+
+// package-wide init function
+func init() {
+	importers.RegisterImporter(importerName, &Constructor{})
+}
+
+func (networkImp *networkImporter) Init(ctx context.Context, cfg plugins.PluginConfig, logger *logrus.Logger) (*bookkeeping.Genesis, error) {
+	networkImp.ctx, networkImp.cancel = context.WithCancel(ctx)
+	networkImp.logger = logger
+	if err := networkImp.unmarhshalConfig(string(cfg)); err != nil {
+		return nil, fmt.Errorf("connect failure in unmarshalConfig: %v", err)
+	}
+
+	genesisText, err := ioutil.ReadFile(networkImp.cfg.GenesisPath)
+	if err != nil {
+		return nil, err
+	}
+	var genesis bookkeeping.Genesis
+	err = protocol.DecodeJSON(genesisText, &genesis)
+	if err != nil {
+		return nil, err
+	}
+
+	localCfg, err := config.LoadConfigFromDisk(networkImp.cfg.ConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	// disabling cert authentication
+	localCfg.CatchupBlockValidateMode = 1
+
+	// start a node
+	net, err := network.NewWebsocketNetwork(logging.NewWrappedLogger(logger), localCfg, nil, genesis.ID(), genesis.Network, nil)
+	if err != nil {
+		return nil, err
+	}
+	net.Start()
+	localCfg.NetAddress, _ = net.Address()
+	net.RequestConnectOutgoing(false, ctx.Done())
+
+	// create fetcher to fetch blocks from network
+	networkImp.networkFetcher = catchup.MakeNetworkFetcher(logging.NewWrappedLogger(logger), net, localCfg, nil, false)
+
+	return &genesis, err
+}
+
+func (networkImp *networkImporter) Config() plugins.PluginConfig {
+	s, _ := yaml.Marshal(networkImp.cfg)
+	return plugins.PluginConfig(s)
+}
+
+func (networkImp *networkImporter) Close() error {
+	networkImp.cancel()
+	return nil
+}
+
+func (networkImp *networkImporter) GetBlock(rnd uint64) (data.BlockData, error) {
+	var blk data.BlockData
+	block, cert, _, err := networkImp.networkFetcher.FetchBlock(networkImp.ctx, basics.Round(rnd))
+	if err != nil {
+		return blk, err
+	}
+	blk.BlockHeader = block.BlockHeader
+	blk.Payset = block.Payset
+	blk.Certificate = cert
+	return blk, nil
+}
+
+func (networkImp *networkImporter) unmarhshalConfig(cfg string) error {
+	return yaml.Unmarshal([]byte(cfg), &networkImp.cfg)
+}

--- a/importers/network/network_importer_config.go
+++ b/importers/network/network_importer_config.go
@@ -1,0 +1,9 @@
+package networkimporter
+
+// ImporterConfig specific to the network importer
+type ImporterConfig struct {
+	// Path to genesis file
+	GenesisPath string `yaml:"genesis-path"`
+	// Path to config file
+	ConfigPath string `yaml:"config-path"`
+}

--- a/importers/network/network_importer_test.go
+++ b/importers/network/network_importer_test.go
@@ -1,0 +1,118 @@
+package networkimporter
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/algorand/indexer/importers"
+	"github.com/algorand/indexer/plugins"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	logger       *logrus.Logger
+	ctx          context.Context
+	cancel       context.CancelFunc
+	testImporter importers.Importer
+)
+
+func init() {
+	logger = logrus.New()
+	logger.SetOutput(os.Stdout)
+	logger.SetLevel(logrus.InfoLevel)
+	ctx, cancel = context.WithCancel(context.Background())
+}
+
+func TestImporterorterMetadata(t *testing.T) {
+	testImporter = New()
+	metadata := testImporter.Metadata()
+	assert.Equal(t, metadata.Type(), networkImporterMetadata.Type())
+	assert.Equal(t, metadata.Name(), networkImporterMetadata.Name())
+	assert.Equal(t, metadata.Description(), networkImporterMetadata.Description())
+	assert.Equal(t, metadata.Deprecated(), networkImporterMetadata.Deprecated())
+}
+
+func TestCloseSuccess(t *testing.T) {
+	testImporter = New()
+	_, err := testImporter.Init(ctx, plugins.PluginConfig(
+		"genesis-path: /Users/ganesh/go-algorand/installer/genesis/mainnet/genesis.json"+
+			"\nconfig-path: /Users/ganesh/go-algorand/installer/"), logger)
+	assert.NoError(t, err)
+	err = testImporter.Close()
+	assert.NoError(t, err)
+}
+
+func TestInitSuccess(t *testing.T) {
+	testImporter = New()
+	_, err := testImporter.Init(ctx, plugins.PluginConfig(
+		"genesis-path: /Users/ganesh/go-algorand/installer/genesis/mainnet/genesis.json"+
+			"\nconfig-path: /Users/ganesh/go-algorand/installer/"), logger)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testImporter, nil)
+	testImporter.Close()
+}
+
+func TestInitUnmarshalFailure(t *testing.T) {
+	testImporter = New()
+	_, err := testImporter.Init(ctx, "`", logger)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "connect failure in unmarshalConfig")
+	testImporter.Close()
+}
+
+func TestConfigDefault(t *testing.T) {
+	testImporter = New()
+	expected, err := yaml.Marshal(&ImporterConfig{})
+	if err != nil {
+		t.Fatalf("unable to Marshal default networkImporter.ImporterConfig: %v", err)
+	}
+	assert.Equal(t, plugins.PluginConfig(expected), testImporter.Config())
+}
+
+func TestGetBlockSuccess(t *testing.T) {
+	ctx, cancel = context.WithCancel(context.Background())
+	testImporter = New()
+	_, err := testImporter.Init(ctx, plugins.PluginConfig(
+		"genesis-path: /Users/ganesh/go-algorand/installer/genesis/mainnet/genesis.json"+
+			"\nconfig-path: /Users/ganesh/go-algorand/installer/"), logger)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testImporter, nil)
+
+	downloadedBlk, err := testImporter.GetBlock(uint64(20000000))
+	assert.NoError(t, err)
+	assert.Equal(t, downloadedBlk.Round(), uint64(20000000))
+	cancel()
+}
+
+func TestGetBlockNoBlockFound(t *testing.T) {
+	ctx, cancel = context.WithCancel(context.Background())
+	testImporter = New()
+	_, err := testImporter.Init(ctx, plugins.PluginConfig(
+		"genesis-path: /Users/ganesh/go-algorand/installer/genesis/mainnet/genesis.json"+
+			"\nconfig-path: /Users/ganesh/go-algorand/installer/lessRetries/"), logger)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testImporter, nil)
+
+	_, err = testImporter.GetBlock(uint64(23000000000))
+	require.Contains(t, err.Error(), "FetchBlock failed after multiple blocks download attempts")
+	cancel()
+}
+
+func TestGetBlockContextCancelled(t *testing.T) {
+	ctx, cancel = context.WithCancel(context.Background())
+	testImporter = New()
+	_, err := testImporter.Init(ctx, plugins.PluginConfig(
+		"genesis-path: /Users/ganesh/go-algorand/installer/genesis/mainnet/genesis.json"+
+			"\nconfig-path: /Users/ganesh/go-algorand/installer/"), logger)
+	assert.NoError(t, err)
+	assert.NotEqual(t, testImporter, nil)
+
+	cancel()
+	_, err = testImporter.GetBlock(uint64(10))
+	assert.Error(t, err)
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary
This PR introduces a new importer plugin, `network-importer`, that allows users to fetch block directly from the network.
Config file provided to the plugin must contain paths to `genesis` and `config` files.
