### PR TITLE
Bug:  Fix bug in reveals lookup

### DIFF
--- a/api/converter_utils.go
+++ b/api/converter_utils.go
@@ -432,7 +432,7 @@ func signedTxnWithAdToTransaction(stxn *transactions.SignedTxnWithAD, extra rowD
 		}
 		sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
 		reveals := make([]generated.StateProofReveal, len(stxn.Txn.StateProof.Reveals))
-		for _, key := range keys {
+		for i, key := range keys {
 			revToConv := stxn.Txn.StateProof.Reveals[key]
 			commitment := revToConv.Part.PK.Commitment[:]
 			falconSig := []byte(revToConv.SigSlot.Sig.Signature)
@@ -442,7 +442,7 @@ func signedTxnWithAdToTransaction(stxn *transactions.SignedTxnWithAD, extra rowD
 				proofPath[idx] = proofPart
 			}
 
-			reveals[key] = generated.StateProofReveal{
+			reveals[i] = generated.StateProofReveal{
 				Participant: &generated.StateProofParticipant{
 					Verifier: &generated.StateProofVerifier{
 						Commitment:  &commitment,


### PR DESCRIPTION
Based on live debugging with @algoidan, @shiqizng, and @gmalouf, proposes a fix to `reveals` lookup.  

In `api/converter_utils.go`, `reveals` is a locally defined array.  The bug appears to be inadvertent `reveals` _index_ access using a non-index value (`key`).

The proposed fix is to use the _index_ associated with `key` to access `reveals`.  