### PR TITLE
conduit bugfix: succeed close calls when init fails

### DIFF
--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -78,7 +78,9 @@ func (exp *postgresqlExporter) Config() plugins.PluginConfig {
 }
 
 func (exp *postgresqlExporter) Close() error {
-	exp.db.Close()
+	if exp.db != nil {
+		exp.db.Close()
+	}
 	return nil
 }
 

--- a/importers/algod/algod_importer.go
+++ b/importers/algod/algod_importer.go
@@ -97,7 +97,9 @@ func (algodImp *algodImporter) Config() plugins.PluginConfig {
 }
 
 func (algodImp *algodImporter) Close() error {
-	algodImp.cancel()
+	if algodImp.cancel != nil {
+		algodImp.cancel()
+	}
 	return nil
 }
 

--- a/processors/blockprocessor/block_processor.go
+++ b/processors/blockprocessor/block_processor.go
@@ -165,7 +165,9 @@ func (proc *blockProcessor) saveLastValidatedInformation(lastValidatedBlock ledg
 }
 
 func (proc *blockProcessor) Close() error {
-	proc.ledger.Close()
+	if proc.ledger != nil {
+		proc.ledger.Close()
+	}
 	return nil
 }
 


### PR DESCRIPTION

## Summary

When running conduit using the indexer setup (alogd, ledger, postgresql), you will get a NPE when your algod fails to connect (traceback included below). This is because the Close function is being called and invoking function calls on objects which were never initialized (ledger, db, cancel func). 

 ```
> ./cmd/conduit/conduit -d ~/.algorand/conduit/
{"__type":"Conduit","_name":"main","level":"info","msg":"Data Directory: /Users/eric/.algorand/conduit/ ","time":"2022-08-26T12:47:57-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Auto-loading Conduit Configuration: /Users/eric/.algorand/conduit/conduit.yml","time":"2022-08-26T12:47:57-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Log level set to: info","time":"2022-08-26T12:47:57-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Conduit configuration is valid","time":"2022-08-26T12:47:57-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Found Importer: algod","time":"2022-08-26T12:47:57-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Found Processor: block_evaluator","time":"2022-08-26T12:47:57-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Found Exporter: postgresql","time":"2022-08-26T12:47:57-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Starting Pipeline Initialization","time":"2022-08-26T12:47:57-07:00"}
{"__type":"Conduit","_name":"main","level":"error","msg":"Pipeline start failure: Pipeline.Start(): could not initialize Exporter (postgresql): connect failure constructing db, postgres: connecting to postgres: failed to connect to `host=localhost user=algorand database=indexer_db`: dial error (dial tcp 127.0.0.1:45432: connect: connection refused)","time":"2022-08-26T12:47:57-07:00"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10357ae04]

goroutine 1 [running]:
github.com/algorand/indexer/importers/algod.(*algodImporter).Close(0x14000141ae0)
	/Users/eric/go/src/github.com/algorand/indexer/importers/algod/algod_importer.go:100 +0x24
github.com/algorand/indexer/conduit.(*pipelineImpl).Stop(0x140001d6c00)
	/Users/eric/go/src/github.com/algorand/indexer/conduit/pipeline.go:196 +0x44
main.runConduitCmdWithConfig.func1({0x103c0f088, 0x140001d6c00})
	/Users/eric/go/src/github.com/algorand/indexer/cmd/conduit/main.go:90 +0x30
main.runConduitCmdWithConfig(0x14000212e40)
	/Users/eric/go/src/github.com/algorand/indexer/cmd/conduit/main.go:100 +0x448
main.conduitCmd.func1(0x140006c3180, {0x1400011f0c0, 0x0, 0x2})
	/Users/eric/go/src/github.com/algorand/indexer/cmd/conduit/main.go:115 +0x28
github.com/spf13/cobra.(*Command).execute(0x140006c3180, {0x140000321c0, 0x2, 0x2})
	/Users/eric/.asdf/installs/golang/1.17.9/packages/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:856 +0x668
github.com/spf13/cobra.(*Command).ExecuteC(0x140006c3180)
	/Users/eric/.asdf/installs/golang/1.17.9/packages/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:974 +0x410
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/eric/.asdf/installs/golang/1.17.9/packages/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:902
main.main()
```

## Test Plan

Failures now properly show error instead of NPE panic.

```
> ./cmd/conduit/conduit -d ~/.algorand/conduit/
{"__type":"Conduit","_name":"main","level":"info","msg":"Data Directory: /Users/eric/.algorand/conduit/ ","time":"2022-08-26T13:19:23-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Auto-loading Conduit Configuration: /Users/eric/.algorand/conduit/conduit.yml","time":"2022-08-26T13:19:23-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Log level set to: info","time":"2022-08-26T13:19:23-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Conduit configuration is valid","time":"2022-08-26T13:19:23-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Found Importer: algod","time":"2022-08-26T13:19:23-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Found Processor: block_evaluator","time":"2022-08-26T13:19:23-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Found Exporter: postgresql","time":"2022-08-26T13:19:23-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Starting Pipeline Initialization","time":"2022-08-26T13:19:23-07:00"}
{"__type":"Conduit","_name":"main","level":"error","msg":"Pipeline start failure: Pipeline.Start(): could not initialize Exporter (postgresql): connect failure constructing db, postgres: connecting to postgres: failed to connect to `host=localhost user=algorand database=indexer_db`: dial error (dial tcp 127.0.0.1:45432: connect: connection refused)","time":"2022-08-26T13:19:23-07:00"}
Error: Pipeline.Start(): could not initialize Exporter (postgresql): connect failure constructing db, postgres: connecting to postgres: failed to connect to `host=localhost user=algorand database=indexer_db`: dial error (dial tcp 127.0.0.1:45432: connect: connection refused)
Usage:
  conduit [flags]

Flags:
  -d, --data-dir string   set the data directory for the conduit binary
  -h, --help              help for conduit

ERRO[0000] Pipeline.Start(): could not initialize Exporter (postgresql): connect failure constructing db, postgres: connecting to postgres: failed to connect to `host=localhost user=algorand database=indexer_db`: dial error (dial tcp 127.0.0.1:45432: connect: connection refused) 
```