### PR TITLE
conduit bugfix: silence usage data on error

### DIFF
--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -114,6 +114,7 @@ func conduitCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runConduitCmdWithConfig(cfg)
 		},
+		SilenceUsage: true,
 	}
 
 	cfg.Flags = conduitCmd.PersistentFlags()


### PR DESCRIPTION


## Summary

Cobra prints usage data when the RunE function exits with an error, but that's pretty counterintuitive. If an error returned from conduit is on account of improper usage, the error should contain the proper info.

Cobra has an open issue about the need for docs on this as well. Found this solution there https://github.com/spf13/cobra/issues/914

## Test Plan

After fix (running using changes in #1204 ) 
```
> ./cmd/conduit/conduit -d ~/.algorand/conduit/
{"__type":"Conduit","_name":"main","level":"info","msg":"Data Directory: /Users/eric/.algorand/conduit/ ","time":"2022-08-26T13:40:09-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Auto-loading Conduit Configuration: /Users/eric/.algorand/conduit/conduit.yml","time":"2022-08-26T13:40:09-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Log level set to: info","time":"2022-08-26T13:40:09-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Conduit configuration is valid","time":"2022-08-26T13:40:09-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Found Importer: algod","time":"2022-08-26T13:40:09-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Found Processor: block_evaluator","time":"2022-08-26T13:40:09-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Found Exporter: postgresql","time":"2022-08-26T13:40:09-07:00"}
{"__type":"Conduit","_name":"main","level":"info","msg":"Starting Pipeline Initialization","time":"2022-08-26T13:40:09-07:00"}
{"__type":"Conduit","_name":"main","level":"error","msg":"Pipeline start failure: Pipeline.Start(): could not initialize Exporter (postgresql): connect failure constructing db, postgres: connecting to postgres: failed to connect to `host=localhost user=algorand database=indexer_db`: dial error (dial tcp 127.0.0.1:45432: connect: connection refused)","time":"2022-08-26T13:40:09-07:00"}
Error: Pipeline.Start(): could not initialize Exporter (postgresql): connect failure constructing db, postgres: connecting to postgres: failed to connect to `host=localhost user=algorand database=indexer_db`: dial error (dial tcp 127.0.0.1:45432: connect: connection refused)
ERRO[0000] Pipeline.Start(): could not initialize Exporter (postgresql): connect failure constructing db, postgres: connecting to postgres: failed to connect to `host=localhost user=algorand database=indexer_db`: dial error (dial tcp 127.0.0.1:45432: connect: connection refused) 
```
