### PR TITLE
Replace `*string` by `ledgercore.ValueDelta{Data:}` in `kvmods`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/algorand/go-algorand v0.0.0-20220211161928-53b157beb10f
 	github.com/algorand/go-algorand-sdk v1.9.1
 	github.com/algorand/go-codec/codec v1.1.8
+	github.com/algorand/go-deadlock v0.2.2
 	github.com/algorand/oapi-codegen v1.3.7
 	github.com/davecgh/go-spew v1.1.1
 	github.com/getkin/kin-openapi v0.22.0
@@ -32,7 +33,6 @@ require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/algorand/avm-abi v0.1.0 // indirect
 	github.com/algorand/falcon v0.0.0-20220727072124-02a2a64c4414 // indirect
-	github.com/algorand/go-deadlock v0.2.2 // indirect
 	github.com/algorand/go-sumhash v0.1.0 // indirect
 	github.com/algorand/msgp v1.1.52 // indirect
 	github.com/algorand/websocket v1.4.5 // indirect

--- a/idb/postgres/internal/writer/writer_test.go
+++ b/idb/postgres/internal/writer/writer_test.go
@@ -1611,14 +1611,14 @@ func TestWriterAppBoxTableInsertMutateDelete(t *testing.T) {
 	k4 := logic.MakeBoxKey(appID, n4)
 	k5 := logic.MakeBoxKey(appID, n5)
 
-	delta.KvMods = map[string]*string{}
-	delta.KvMods[k1] = &v1
-	delta.KvMods[k2] = &v2
-	delta.KvMods[k3] = &v3
-	delta.KvMods[k4] = &v4
-	delta.KvMods[k5] = &v5
+	delta.KvMods = map[string]ledgercore.ValueDelta{}
+	delta.KvMods[k1] = ledgercore.ValueDelta{Data: &v1}
+	delta.KvMods[k2] = ledgercore.ValueDelta{Data: &v2}
+	delta.KvMods[k3] = ledgercore.ValueDelta{Data: &v3}
+	delta.KvMods[k4] = ledgercore.ValueDelta{Data: &v4}
+	delta.KvMods[k5] = ledgercore.ValueDelta{Data: &v5}
 
-	delta2, newKvMods, accts := test.BuildAccountDeltasFromKvsAndMods(t, map[string]*string{}, delta.KvMods)
+	delta2, newKvMods, accts := test.BuildAccountDeltasFromKvsAndMods(t, map[string]ledgercore.ValueDelta{}, delta.KvMods)
 	delta.Accts = delta2.Accts
 
 	err := pgutil.TxWithRetry(db, serializable, addNewBlock, nil)
@@ -1676,12 +1676,12 @@ func TestWriterAppBoxTableInsertMutateDelete(t *testing.T) {
 
 	k6 := logic.MakeBoxKey(appID, n6)
 
-	delta.KvMods = map[string]*string{}
-	delta.KvMods[k2] = &v2
-	delta.KvMods[k3] = nil
-	delta.KvMods[k4] = &v4
-	delta.KvMods[k5] = nil
-	delta.KvMods[k6] = &v6
+	delta.KvMods = map[string]ledgercore.ValueDelta{}
+	delta.KvMods[k2] = ledgercore.ValueDelta{Data: &v2}
+	delta.KvMods[k3] = ledgercore.ValueDelta{Data: nil}
+	delta.KvMods[k4] = ledgercore.ValueDelta{Data: &v4}
+	delta.KvMods[k5] = ledgercore.ValueDelta{Data: nil}
+	delta.KvMods[k6] = ledgercore.ValueDelta{Data: &v6}
 
 	delta2, newKvMods, accts = test.BuildAccountDeltasFromKvsAndMods(t, newKvMods, delta.KvMods)
 	delta.Accts = delta2.Accts
@@ -1703,9 +1703,9 @@ func TestWriterAppBoxTableInsertMutateDelete(t *testing.T) {
 	// v4 is "deleted"
 	v5 = "re-inserted"
 
-	delta.KvMods = map[string]*string{}
-	delta.KvMods[k4] = nil
-	delta.KvMods[k5] = &v5
+	delta.KvMods = map[string]ledgercore.ValueDelta{}
+	delta.KvMods[k4] = ledgercore.ValueDelta{Data: nil}
+	delta.KvMods[k5] = ledgercore.ValueDelta{Data: &v5}
 
 	delta2, newKvMods, accts = test.BuildAccountDeltasFromKvsAndMods(t, newKvMods, delta.KvMods)
 	delta.Accts = delta2.Accts
@@ -1723,7 +1723,7 @@ func TestWriterAppBoxTableInsertMutateDelete(t *testing.T) {
 	validateTotals()
 
 	/*** FOURTH ROUND  - NOOP ***/
-	delta.KvMods = map[string]*string{}
+	delta.KvMods = map[string]ledgercore.ValueDelta{}
 	delta2, _, accts = test.BuildAccountDeltasFromKvsAndMods(t, newKvMods, delta.KvMods)
 	delta.Accts = delta2.Accts
 

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -48,7 +48,7 @@ func OpenPostgres(connection string, opts idb.IndexerDbOptions, log *log.Logger)
 
 	postgresConfig, err := pgxpool.ParseConfig(connection)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Couldn't parse config: %v", err)
+		return nil, nil, fmt.Errorf("couldn't parse config: %v", err)
 	}
 
 	if opts.MaxConn != 0 {

--- a/idb/postgres/postgres_random_box_test.go
+++ b/idb/postgres/postgres_random_box_test.go
@@ -53,7 +53,7 @@ func createBoxesWithDelta(t *testing.T, numApps, maxBoxes int) (map[basics.AppIn
 	appBoxes := make(map[basics.AppIndex]map[string]string)
 
 	delta := ledgercore.StateDelta{
-		KvMods: map[string]*string{},
+		KvMods: map[string]ledgercore.ValueDelta{},
 		Accts:  ledgercore.MakeAccountDeltas(numApps),
 	}
 
@@ -71,7 +71,7 @@ func createBoxesWithDelta(t *testing.T, numApps, maxBoxes int) (map[basics.AppIn
 			require.Equal(t, appIndex, embeddedAppIdx)
 
 			val := string([]byte(value)[:])
-			delta.KvMods[key] = &val
+			delta.KvMods[key] = ledgercore.ValueDelta{Data: &val}
 
 			totalBoxBytes += len(name) + len(value)
 		}
@@ -82,7 +82,7 @@ func createBoxesWithDelta(t *testing.T, numApps, maxBoxes int) (map[basics.AppIn
 
 func mutateSomeBoxesWithDelta(t *testing.T, appBoxes map[basics.AppIndex]map[string]string) ledgercore.StateDelta {
 	var delta ledgercore.StateDelta
-	delta.KvMods = make(map[string]*string)
+	delta.KvMods = make(map[string]ledgercore.ValueDelta)
 
 	for _, boxes := range appBoxes {
 		for key, value := range boxes {
@@ -95,7 +95,7 @@ func mutateSomeBoxesWithDelta(t *testing.T, appBoxes map[basics.AppIndex]map[str
 			boxes[key] = string(valueBytes)
 
 			val := string([]byte(boxes[key])[:])
-			delta.KvMods[key] = &val
+			delta.KvMods[key] = ledgercore.ValueDelta{Data: &val}
 		}
 	}
 
@@ -106,7 +106,7 @@ func deleteSomeBoxesWithDelta(t *testing.T, appBoxes map[basics.AppIndex]map[str
 	deletedBoxes := make(map[basics.AppIndex]map[string]bool, len(appBoxes))
 
 	var delta ledgercore.StateDelta
-	delta.KvMods = make(map[string]*string)
+	delta.KvMods = make(map[string]ledgercore.ValueDelta)
 
 	for appIndex, boxes := range appBoxes {
 		deletedBoxes[appIndex] = map[string]bool{}
@@ -115,7 +115,7 @@ func deleteSomeBoxesWithDelta(t *testing.T, appBoxes map[basics.AppIndex]map[str
 				continue
 			}
 			deletedBoxes[appIndex][key] = true
-			delta.KvMods[key] = nil
+			delta.KvMods[key] = ledgercore.ValueDelta{Data: nil}
 		}
 	}
 

--- a/util/test/box_testutil.go
+++ b/util/test/box_testutil.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getNameAndAccountPointer(t *testing.T, value *string, fullKey string, accts map[basics.Address]*ledgercore.AccountData) (basics.Address, string, *ledgercore.AccountData) {
+func getNameAndAccountPointer(t *testing.T, value ledgercore.ValueDelta, fullKey string, accts map[basics.Address]*ledgercore.AccountData) (basics.Address, string, *ledgercore.AccountData) {
 	require.NotNil(t, value, "cannot handle a nil value for box stats modification")
 	appIdx, name, err := logic.SplitBoxKey(fullKey)
 	account := appIdx.Address()
@@ -27,12 +27,12 @@ func getNameAndAccountPointer(t *testing.T, value *string, fullKey string, accts
 	return account, name, acctData
 }
 
-func addBoxInfoToStats(t *testing.T, fullKey string, value *string,
+func addBoxInfoToStats(t *testing.T, fullKey string, value ledgercore.ValueDelta,
 	accts map[basics.Address]*ledgercore.AccountData, boxTotals map[basics.Address]basics.AccountData) {
 	addr, name, acctData := getNameAndAccountPointer(t, value, fullKey, accts)
 
 	acctData.TotalBoxes++
-	acctData.TotalBoxBytes += uint64(len(name) + len(*value))
+	acctData.TotalBoxBytes += uint64(len(name) + len(*value.Data))
 
 	boxTotals[addr] = basics.AccountData{
 		TotalBoxes:    acctData.TotalBoxes,
@@ -40,11 +40,11 @@ func addBoxInfoToStats(t *testing.T, fullKey string, value *string,
 	}
 }
 
-func subtractBoxInfoToStats(t *testing.T, fullKey string, value *string,
+func subtractBoxInfoToStats(t *testing.T, fullKey string, value ledgercore.ValueDelta,
 	accts map[basics.Address]*ledgercore.AccountData, boxTotals map[basics.Address]basics.AccountData) {
 	addr, name, acctData := getNameAndAccountPointer(t, value, fullKey, accts)
 
-	prevBoxBytes := uint64(len(name) + len(*value))
+	prevBoxBytes := uint64(len(name) + len(*value.Data))
 	require.GreaterOrEqual(t, acctData.TotalBoxes, uint64(0))
 	require.GreaterOrEqual(t, acctData.TotalBoxBytes, prevBoxBytes)
 
@@ -58,9 +58,9 @@ func subtractBoxInfoToStats(t *testing.T, fullKey string, value *string,
 }
 
 // BuildAccountDeltasFromKvsAndMods simulates keeping track of the evolution of the box statistics
-func BuildAccountDeltasFromKvsAndMods(t *testing.T, kvOriginals, kvMods map[string]*string) (
-	ledgercore.StateDelta, map[string]*string, map[basics.Address]basics.AccountData) {
-	kvUpdated := map[string]*string{}
+func BuildAccountDeltasFromKvsAndMods(t *testing.T, kvOriginals, kvMods map[string]ledgercore.ValueDelta) (
+	ledgercore.StateDelta, map[string]ledgercore.ValueDelta, map[basics.Address]basics.AccountData) {
+	kvUpdated := map[string]ledgercore.ValueDelta{}
 	boxTotals := map[basics.Address]basics.AccountData{}
 	accts := map[basics.Address]*ledgercore.AccountData{}
 	/*
@@ -90,14 +90,14 @@ func BuildAccountDeltasFromKvsAndMods(t *testing.T, kvOriginals, kvMods map[stri
 			continue
 		}
 		/* 2B. */
-		if value == nil {
+		if value.Data == nil {
 			/* 2Bi. */
 			subtractBoxInfoToStats(t, fullKey, prevValue, accts, boxTotals)
 			delete(kvUpdated, fullKey)
 			continue
 		}
 		/* 2Bii. */
-		require.Equal(t, len(*prevValue), len(*value))
+		require.Equal(t, len(*prevValue.Data), len(*value.Data))
 		require.Contains(t, kvUpdated, fullKey)
 		kvUpdated[fullKey] = value
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged.

## Test Plan

How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale.
