### PR TITLE
Conduit: prometheus metrics

### DIFF
--- a/cmd/block-generator/generator/generate.go
+++ b/cmd/block-generator/generator/generate.go
@@ -101,7 +101,7 @@ func MakeGenerator(config GenerationConfig) (Generator, error) {
 		genesisHash:               [32]byte{},
 		genesisID:                 "blockgen-test",
 		prevBlockHash:             "",
-		round:                     1,
+		round:                     0,
 		txnCounter:                0,
 		timestamp:                 0,
 		rewardsLevel:              0,
@@ -159,6 +159,7 @@ type Generator interface {
 	WriteGenesis(output io.Writer) error
 	WriteBlock(output io.Writer, round uint64) error
 	WriteAccount(output io.Writer, accountString string) error
+	WriteStatus(output io.Writer) error
 	Accounts() <-chan basics.Address
 }
 
@@ -244,6 +245,14 @@ func (g *generator) recordData(id TxTypeID, start time.Time) {
 
 func (g *generator) WriteReport(output io.Writer) error {
 	_, err := output.Write(protocol.EncodeJSON(g.reportData))
+	return err
+}
+
+func (g *generator) WriteStatus(output io.Writer) error {
+	response := generated.NodeStatusResponse{
+		LastRound: g.round,
+	}
+	_, err := output.Write(protocol.EncodeJSON(response))
 	return err
 }
 

--- a/cmd/block-generator/generator/server.go
+++ b/cmd/block-generator/generator/server.go
@@ -57,6 +57,7 @@ func MakeServerWithMiddleware(configFile string, addr string, blocksMiddleware B
 	mux.HandleFunc("/v2/accounts/", getAccountHandler(gen))
 	mux.HandleFunc("/genesis", getGenesisHandler(gen))
 	mux.HandleFunc("/report", getReportHandler(gen))
+	mux.HandleFunc("/v2/status/wait-for-block-after/", getStatusWaitHandler(gen))
 
 	return &http.Server{
 		Addr:    addr,
@@ -78,6 +79,12 @@ func maybeWriteError(w http.ResponseWriter, err error) {
 func getReportHandler(gen Generator) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		maybeWriteError(w, gen.WriteReport(w))
+	}
+}
+
+func getStatusWaitHandler(gen Generator) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		maybeWriteError(w, gen.WriteStatus(w))
 	}
 }
 

--- a/cmd/block-generator/runner/run.go
+++ b/cmd/block-generator/runner/run.go
@@ -441,7 +441,7 @@ func startIndexer(dataDir string, logfile string, loglevel string, indexerBinary
 
 	// Ensure that the health endpoint can be queried.
 	// The service should start very quickly because the DB is empty.
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 	resp, err := http.Get(fmt.Sprintf("http://%s/health", indexerNet))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "stdout:\n%s\n", stdout.String())

--- a/importers/algod/algod_importer.go
+++ b/importers/algod/algod_importer.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/indexer/util/metrics"
 	"net/url"
+	"time"
 
 	"github.com/algorand/go-algorand-sdk/client/v2/algod"
 	"github.com/algorand/go-algorand/protocol"
@@ -120,7 +122,10 @@ func (algodImp *algodImporter) GetBlock(rnd uint64) (data.BlockData, error) {
 				"r=%d error getting status %d", retries, rnd)
 			continue
 		}
+		start := time.Now()
 		blockbytes, err = algodImp.aclient.BlockRaw(rnd).Do(algodImp.ctx)
+		dt := time.Since(start)
+		metrics.GetAlgodRawBlockTimeSeconds.Observe(dt.Seconds())
 		if err != nil {
 			return blk, err
 		}


### PR DESCRIPTION
## Summary

Add prometheus metrics to Conduit. These should be fully backwards compatible w/ Indexer's metrics so that we can compare them 1 to 1 in __most__ ways.

## Test Plan

Generating metrics using block-generator.
