### PR TITLE
enhancement: prune historical data

### DIFF
--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -73,11 +73,15 @@ func (exp *postgresqlExporter) Init(cfg plugins.PluginConfig, logger *logrus.Log
 	}
 	// if data pruning is enabled
 	if exp.cfg.Delete.Rounds > 0 {
-		dm := util.MakeDataManager(&cfg, logger)
-		exp.deleteDataChan = make(chan uint64)
-		go dm.Delete(exp.deleteDataChan)
+		dm, err := util.MakeDataManager(&exp.cfg.Delete, dbName, exp.cfg.ConnectionString, logger)
+		if err != nil {
+			logger.Warnf("skipping data pruning. %w", err)
+		} else {
+			logger.Info("exporter running with data pruning mode")
+			exp.deleteDataChan = make(chan uint64)
+			go dm.Delete(exp.deleteDataChan)
+		}
 	}
-
 	return err
 }
 

--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -75,12 +75,12 @@ func (exp *postgresqlExporter) Init(cfg plugins.PluginConfig, logger *logrus.Log
 	}
 	exp.ctx = context.Background()
 	// if data pruning is enabled
-	if exp.cfg.Delete.Rounds > 0 {
-		dm, err := util.MakeDataManager(&exp.cfg.Delete, exp.cfg.ConnectionString, logger)
+	if !exp.cfg.Test && exp.cfg.Delete.Rounds > 0 {
+		dm, err := util.MakeDataManager(&exp.cfg.Delete, dbName, exp.cfg.ConnectionString, logger)
 		if err != nil {
-			logger.Warnf("skipping data pruning. %w", err)
+			logger.Warnf("cannot start data pruning %v", err)
 		} else {
-			logger.Info("exporter running with data pruning mode")
+			logger.Info("exporter running with data pruning ON")
 			exp.deleteDataChan = make(chan uint64)
 			go dm.Delete(exp.ctx, exp.deleteDataChan)
 		}

--- a/exporters/postgresql/postgresql_exporter_config.go
+++ b/exporters/postgresql/postgresql_exporter_config.go
@@ -1,5 +1,7 @@
 package postgresql
 
+import "github.com/algorand/indexer/exporters/util"
+
 // serde for converting an ExporterConfig to/from a PostgresqlExporterConfig
 
 // ExporterConfig specific to the postgresql exporter
@@ -14,4 +16,6 @@ type ExporterConfig struct {
 	// The test flag will replace an actual DB connection being created via the connection string,
 	// with a mock DB for unit testing.
 	Test bool `yaml:"test"`
+	// the configuration for data pruning
+	Delete util.PruneConfigurations `yaml:"delete-task"`
 }

--- a/exporters/postgresql/postgresql_exporter_test.go
+++ b/exporters/postgresql/postgresql_exporter_test.go
@@ -106,15 +106,28 @@ func TestReceiveAddBlockSuccess(t *testing.T) {
 }
 
 func TestUnmarshalConfigsContainingDeleteTask(t *testing.T) {
+	// configured delete task
 	pgsqlExp := postgresqlExporter{}
-	cfg := "test: true\ndelete-task:\n  rounds: 3000\n  interval: 1"
+	cfg := "test: true\ndelete-task:\n  rounds: 3000\n  interval: daily"
 	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
-	assert.Equal(t, 1, int(pgsqlExp.cfg.Delete.Interval))
+	assert.Equal(t, "daily", string(pgsqlExp.cfg.Delete.Interval))
 	assert.Equal(t, uint64(3000), pgsqlExp.cfg.Delete.Rounds)
 
+	// delete task with default rounds
 	pgsqlExp = postgresqlExporter{}
-	cfg = "test: true\ndelete-task:\n  interval: 3"
+	cfg = "test: true\ndelete-task:\n  interval: once"
 	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
-	assert.Equal(t, 3, int(pgsqlExp.cfg.Delete.Interval))
+	assert.Equal(t, "once", string(pgsqlExp.cfg.Delete.Interval))
 	assert.Equal(t, uint64(0), pgsqlExp.cfg.Delete.Rounds)
+
+	// delete task with default interval
+	pgsqlExp = postgresqlExporter{}
+	cfg = "test: true\ndelete-task:\n  rounds: 3000\n"
+	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
+	assert.Equal(t, "", string(pgsqlExp.cfg.Delete.Interval))
+
+	// delete task with negative round
+	pgsqlExp = postgresqlExporter{}
+	cfg = "test: true\ndelete-task:\n  rounds: -1\n  interval: once"
+	assert.ErrorContains(t, pgsqlExp.unmarhshalConfig(cfg), "unmarshal errors")
 }

--- a/exporters/postgresql/postgresql_exporter_test.go
+++ b/exporters/postgresql/postgresql_exporter_test.go
@@ -108,26 +108,28 @@ func TestReceiveAddBlockSuccess(t *testing.T) {
 func TestUnmarshalConfigsContainingDeleteTask(t *testing.T) {
 	// configured delete task
 	pgsqlExp := postgresqlExporter{}
-	cfg := "test: true\ndelete-task:\n  rounds: 3000\n  interval: daily"
+	cfg := "test: true\ndelete-task:\n  rounds: 3000\n  frequency: daily\n  timeout: 5"
 	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
-	assert.Equal(t, "daily", string(pgsqlExp.cfg.Delete.Interval))
+	assert.Equal(t, "daily", string(pgsqlExp.cfg.Delete.Frequency))
 	assert.Equal(t, uint64(3000), pgsqlExp.cfg.Delete.Rounds)
+	assert.Equal(t, uint64(5), pgsqlExp.cfg.Delete.Timeout)
 
-	// delete task with default rounds
+	// delete task with rounds and timeout default to 0
 	pgsqlExp = postgresqlExporter{}
-	cfg = "test: true\ndelete-task:\n  interval: once"
+	cfg = "test: true\ndelete-task:\n  frequency: once"
 	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
-	assert.Equal(t, "once", string(pgsqlExp.cfg.Delete.Interval))
+	assert.Equal(t, "once", string(pgsqlExp.cfg.Delete.Frequency))
 	assert.Equal(t, uint64(0), pgsqlExp.cfg.Delete.Rounds)
+	assert.Equal(t, uint64(0), pgsqlExp.cfg.Delete.Timeout)
 
-	// delete task with default interval
+	// delete task with default frequency
 	pgsqlExp = postgresqlExporter{}
 	cfg = "test: true\ndelete-task:\n  rounds: 3000\n"
 	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
-	assert.Equal(t, "", string(pgsqlExp.cfg.Delete.Interval))
+	assert.Equal(t, "", string(pgsqlExp.cfg.Delete.Frequency))
 
 	// delete task with negative round
 	pgsqlExp = postgresqlExporter{}
-	cfg = "test: true\ndelete-task:\n  rounds: -1\n  interval: once"
+	cfg = "test: true\ndelete-task:\n  rounds: -1\n  frequency: once"
 	assert.ErrorContains(t, pgsqlExp.unmarhshalConfig(cfg), "unmarshal errors")
 }

--- a/exporters/postgresql/postgresql_exporter_test.go
+++ b/exporters/postgresql/postgresql_exporter_test.go
@@ -2,6 +2,8 @@ package postgresql
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -10,7 +12,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"gopkg.in/yaml.v3"
-	"testing"
 
 	_ "github.com/algorand/indexer/idb/dummy"
 	"github.com/algorand/indexer/plugins"
@@ -102,4 +103,18 @@ func TestReceiveAddBlockSuccess(t *testing.T) {
 		Delta:       &ledgercore.StateDelta{},
 	}
 	assert.NoError(t, pgsqlExp.Receive(block))
+}
+
+func TestUnmarshalConfigsContainingDeleteTask(t *testing.T) {
+	pgsqlExp := postgresqlExporter{}
+	cfg := "test: true\ndelete-task:\n  rounds: 3000\n  interval: 1"
+	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
+	assert.Equal(t, 1, int(pgsqlExp.cfg.Delete.Interval))
+	assert.Equal(t, uint64(3000), pgsqlExp.cfg.Delete.Rounds)
+
+	pgsqlExp = postgresqlExporter{}
+	cfg = "test: true\ndelete-task:\n  interval: 3"
+	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
+	assert.Equal(t, 3, int(pgsqlExp.cfg.Delete.Interval))
+	assert.Equal(t, uint64(0), pgsqlExp.cfg.Delete.Rounds)
 }

--- a/exporters/util/prune.go
+++ b/exporters/util/prune.go
@@ -35,7 +35,7 @@ type DataManager interface {
 	Closed() bool
 }
 
-type postgressql struct {
+type postgresql struct {
 	config *PruneConfigurations
 	db     *pgxpool.Pool
 	logger *logrus.Logger
@@ -57,7 +57,7 @@ func MakeDataManager(ctx context.Context, cfg *PruneConfigurations, dbname strin
 		}
 
 		c, cf := context.WithCancel(ctx)
-		dm := postgressql{
+		dm := postgresql{
 			config: cfg,
 			db:     db,
 			logger: logger,
@@ -70,7 +70,7 @@ func MakeDataManager(ctx context.Context, cfg *PruneConfigurations, dbname strin
 }
 
 // Delete removes data from the txn table in Postgres DB
-func (p postgressql) Delete(wg *sync.WaitGroup) {
+func (p postgresql) Delete(wg *sync.WaitGroup) {
 
 	// set up a 24-hour ticker
 	ticker := time.NewTicker(day)
@@ -127,11 +127,11 @@ func (p postgressql) Delete(wg *sync.WaitGroup) {
 }
 
 // Closed indicates whether the process has exited Delete() and closed DB connection.
-func (p postgressql) Closed() bool {
+func (p postgresql) Closed() bool {
 	return p.db.Stat().TotalConns() == 0
 }
 
-func (p postgressql) deleteTransactions() error {
+func (p postgresql) deleteTransactions() error {
 	sec := timeout
 	// allow any timeout value for testing
 	if p.test || p.config.Timeout > 0 {

--- a/exporters/util/prune.go
+++ b/exporters/util/prune.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"github.com/algorand/indexer/idb"
+	"github.com/algorand/indexer/plugins"
+	"github.com/sirupsen/logrus"
+)
+
+type Interval int
+
+const (
+	once Interval = iota
+	daily
+)
+
+// PruneConfigurations a data type
+type PruneConfigurations struct {
+	Interval Interval `yaml:"interval"`
+	Rounds   uint64   `yaml:"rounds"`
+}
+
+type DataManager interface {
+	Delete(<-chan uint64)
+}
+
+type postgresDB struct {
+	configs *PruneConfigurations
+	db      idb.IndexerDb
+	logger  *logrus.Logger
+}
+
+func MakeDataManager(pc *plugins.PluginConfig, logger *logrus.Logger) DataManager {
+	db := postgresDB{
+		configs: nil,
+		db:      nil,
+		logger:  nil,
+	}
+	return db
+}
+func (p postgresDB) Delete(rnd <-chan uint64) {}

--- a/exporters/util/prune.go
+++ b/exporters/util/prune.go
@@ -1,10 +1,12 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"strings"
+	"time"
 
-	"github.com/algorand/indexer/idb"
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/sirupsen/logrus"
 )
 
@@ -22,26 +24,29 @@ type PruneConfigurations struct {
 }
 
 type DataManager interface {
-	Delete(<-chan uint64)
+	Delete(context.Context, <-chan uint64)
 }
 
 type Postgressql struct {
 	Config *PruneConfigurations
-	DB     idb.IndexerDb
+	DB     *pgxpool.Pool
 	Logger *logrus.Logger
 }
 
-func MakeDataManager(cfg *PruneConfigurations, dbname string, dataconnection string, logger *logrus.Logger) (DataManager, error) {
-	datasource := strings.Split(dataconnection, ":")[0]
+func MakeDataManager(cfg *PruneConfigurations, connection string, logger *logrus.Logger) (DataManager, error) {
+	datasource := strings.Split(connection, ":")[0]
 	if datasource == "postgres" {
-		conn, ready, err := idb.IndexerDbByName(dbname, dataconnection, idb.IndexerDbOptions{ReadOnly: false}, logger)
+		postgresConfig, err := pgxpool.ParseConfig(connection)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Couldn't parse config: %v", err)
 		}
-		<-ready
+		db, err := pgxpool.ConnectConfig(context.Background(), postgresConfig)
+		if err != nil {
+			return nil, fmt.Errorf("connecting to postgres: %v", err)
+		}
 		dm := Postgressql{
 			Config: cfg,
-			DB:     conn,
+			DB:     db,
 			Logger: logger,
 		}
 		return dm, nil
@@ -49,6 +54,54 @@ func MakeDataManager(cfg *PruneConfigurations, dbname string, dataconnection str
 		return nil, fmt.Errorf("data source %s is not supported", datasource)
 	}
 }
-func (p Postgressql) Delete(rnd <-chan uint64) {
-	fmt.Println("TO BE IMPLEMENTED")
+func (p Postgressql) Delete(ctx context.Context, rnd <-chan uint64) {
+	select {
+	case round := <-rnd:
+		p.Logger.Infof("received round %d", round)
+		p.deleteTransactions(round)
+	case <-ctx.Done():
+		p.Logger.Info("exporter closed")
+		p.DB.Close()
+	}
+}
+
+func (p Postgressql) deleteTransactions(round uint64) {
+	keep := round - p.Config.Rounds
+	prune := true
+	dbctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if p.Config.Interval != once {
+		currentTime := time.Now()
+		query := "SELECT last_pruned from metastate"
+		result, err := p.DB.Query(dbctx, query)
+		if err != nil {
+			p.Logger.Warnf("err %v", err)
+		}
+		var last_pruned time.Time
+		err = result.Scan(last_pruned)
+		if err != nil {
+			p.Logger.Warnf("err %v", err)
+		}
+		diff := currentTime.Sub(last_pruned)
+		if diff.Hours() < 24 {
+			prune = false
+		}
+	}
+	if keep > 0 && prune {
+		//	sql: DELETE FROM txn WHERE round < keep;
+		query := "DELETE FROM txn WHERE round < keep"
+		cmd, err := p.DB.Exec(dbctx, query)
+		if err != nil {
+			p.Logger.Warnf("err %v", err)
+		} else {
+			p.Logger.Infof("%d transactions deleted", cmd.RowsAffected())
+			// sql: update last_pruned
+			metastate := fmt.Sprintf("{last_pruned: %s}", time.Now())
+			query = "INSERT INTO metastate (k,v) VALUES('prune',$1) ON CONFLICT(k) DO UPDATE SET v=EXCLUDED.v"
+			_, err = p.DB.Exec(dbctx, query, metastate)
+			if err != nil {
+				p.Logger.Warnf("err %v", err)
+			}
+		}
+	}
 }

--- a/exporters/util/prune.go
+++ b/exporters/util/prune.go
@@ -2,10 +2,11 @@ package util
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/sirupsen/logrus"
 )
@@ -33,16 +34,15 @@ type Postgressql struct {
 	Logger *logrus.Logger
 }
 
-func MakeDataManager(cfg *PruneConfigurations, connection string, logger *logrus.Logger) (DataManager, error) {
-	datasource := strings.Split(connection, ":")[0]
-	if datasource == "postgres" {
+func MakeDataManager(cfg *PruneConfigurations, dbname string, connection string, logger *logrus.Logger) (DataManager, error) {
+	if dbname == "postgres" {
 		postgresConfig, err := pgxpool.ParseConfig(connection)
 		if err != nil {
 			return nil, fmt.Errorf("Couldn't parse config: %v", err)
 		}
 		db, err := pgxpool.ConnectConfig(context.Background(), postgresConfig)
 		if err != nil {
-			return nil, fmt.Errorf("connecting to postgres: %v", err)
+			return nil, fmt.Errorf("connecting to postgres: %w", err)
 		}
 		dm := Postgressql{
 			Config: cfg,
@@ -51,13 +51,13 @@ func MakeDataManager(cfg *PruneConfigurations, connection string, logger *logrus
 		}
 		return dm, nil
 	} else {
-		return nil, fmt.Errorf("data source %s is not supported", datasource)
+		return nil, fmt.Errorf("data source %s is not supported", dbname)
 	}
 }
 func (p Postgressql) Delete(ctx context.Context, rnd <-chan uint64) {
 	select {
 	case round := <-rnd:
-		p.Logger.Infof("received round %d", round)
+		p.Logger.Infof("received exporter round %d", round)
 		p.deleteTransactions(round)
 	case <-ctx.Done():
 		p.Logger.Info("exporter closed")
@@ -66,42 +66,85 @@ func (p Postgressql) Delete(ctx context.Context, rnd <-chan uint64) {
 }
 
 func (p Postgressql) deleteTransactions(round uint64) {
-	keep := round - p.Config.Rounds
-	prune := true
-	dbctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if p.Config.Interval != once {
-		currentTime := time.Now()
-		query := "SELECT last_pruned from metastate"
-		result, err := p.DB.Query(dbctx, query)
-		if err != nil {
-			p.Logger.Warnf("err %v", err)
-		}
-		var last_pruned time.Time
-		err = result.Scan(last_pruned)
-		if err != nil {
-			p.Logger.Warnf("err %v", err)
-		}
-		diff := currentTime.Sub(last_pruned)
-		if diff.Hours() < 24 {
-			prune = false
-		}
+	// current exporter round < desired number of rounds to keep
+	if round < p.Config.Rounds {
+		// no data to remove
+		return
 	}
-	if keep > 0 && prune {
-		//	sql: DELETE FROM txn WHERE round < keep;
-		query := "DELETE FROM txn WHERE round < keep"
-		cmd, err := p.DB.Exec(dbctx, query)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// oldest round to keep
+	keep := round - p.Config.Rounds
+
+	// delete old txns and update metastate
+	deleteTxns := func() {
+		// start a transaction
+		tx, err := p.DB.BeginTx(ctx, pgx.TxOptions{})
 		if err != nil {
-			p.Logger.Warnf("err %v", err)
+			p.Logger.Warnf("delete transactions: %v", err)
+			return
+		}
+		defer tx.Rollback(ctx)
+		p.Logger.Infof("keeping round %d and later", keep)
+		query := "DELETE FROM txn WHERE round < $1"
+		cmd, err := tx.Exec(ctx, query, keep)
+		t := time.Now()
+		if err != nil {
+			p.Logger.Warnf("transaction delete err %v", err)
+			return
 		} else {
-			p.Logger.Infof("%d transactions deleted", cmd.RowsAffected())
-			// sql: update last_pruned
-			metastate := fmt.Sprintf("{last_pruned: %s}", time.Now())
-			query = "INSERT INTO metastate (k,v) VALUES('prune',$1) ON CONFLICT(k) DO UPDATE SET v=EXCLUDED.v"
-			_, err = p.DB.Exec(dbctx, query, metastate)
+			// format time, "2006-01-02T15:04:05Z07:00"
+			ft := t.Format(time.RFC3339)
+			p.Logger.Infof("%d transactions deleted, last pruned at %s", cmd.RowsAffected(), ft)
+			// update last_pruned
+			metastate := fmt.Sprintf("{last_pruned: %s}", ft)
+			encoded, err := json.Marshal(metastate)
 			if err != nil {
-				p.Logger.Warnf("err %v", err)
+				p.Logger.Warnf("transaction delete err %v", err)
+				return
+			}
+			query = "INSERT INTO metastate (k,v) VALUES('prune',$1) ON CONFLICT(k) DO UPDATE SET v=EXCLUDED.v"
+			_, err = tx.Exec(ctx, query, string(encoded))
+			if err != nil {
+				p.Logger.Warnf("metastate update err %v", err)
+				return
 			}
 		}
+		// Commit the transaction.
+		if err = tx.Commit(ctx); err != nil {
+			p.Logger.Warnf("delete transactions: %v", err)
+		}
 	}
+
+	if p.Config.Interval == once {
+		deleteTxns()
+	} else if p.Config.Interval == daily {
+		prune := false
+		var lastPruned time.Time
+		query := "SELECT last_pruned from metastate"
+		result, err := p.DB.Query(ctx, query)
+		if err != nil {
+			p.Logger.Warnf("err %v", err)
+		}
+		err = result.Scan(lastPruned)
+		if err == pgx.ErrNoRows {
+			// first prune
+			prune = true
+		} else if err != nil {
+			p.Logger.Warnf("err %v", err)
+		} else {
+			currentTime := time.Now()
+			diff := currentTime.Sub(lastPruned)
+			if diff.Hours() >= 24 {
+				prune = true
+			}
+		}
+		if prune {
+			deleteTxns()
+		}
+	} else {
+		p.Logger.Warnf("%s pruning interval is not supported", p.Config.Interval)
+	}
+
 }

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -1,0 +1,41 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/algorand/indexer/exporters/util"
+	"github.com/algorand/indexer/idb"
+	"github.com/algorand/indexer/idb/postgres"
+	pgtest "github.com/algorand/indexer/idb/postgres/testing"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+var logger *logrus.Logger
+
+func init() {
+	logger, _ = test.NewNullLogger()
+}
+func TestDataPruning(t *testing.T) {
+	_, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
+
+	db, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+	defer db.Close()
+	dm := makeMockedDataManager(db)
+	ch := make(chan uint64)
+	dm.Delete(ch)
+}
+
+func makeMockedDataManager(db *postgres.IndexerDb) util.DataManager {
+	return util.Postgressql{
+		Config: &util.PruneConfigurations{
+			Interval: "once",
+			Rounds:   10,
+		},
+		DB:     db,
+		Logger: nil,
+	}
+}

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -1,4 +1,4 @@
-package util_test
+package util
 
 import (
 	"context"
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/algorand/indexer/exporters/util"
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/idb/postgres"
 	pgtest "github.com/algorand/indexer/idb/postgres/testing"
@@ -24,33 +23,45 @@ func init() {
 	logger, _ = test.NewNullLogger()
 }
 
+var config = PruneConfigurations{
+	Frequency: "once",
+	Rounds:    10,
+}
+
 func TestMakeDataManager(t *testing.T) {
-	config := util.PruneConfigurations{
-		Interval: "once",
-		Rounds:   10,
-	}
 	_, connStr, shutdownFunc := pgtest.SetupPostgres(t)
 	defer shutdownFunc()
 
-	dm, err := util.MakeDataManager(&config, "postgres", connStr, logger)
+	dm, err := MakeDataManager(context.Background(), &config, "postgres", connStr, logger)
 	assert.NoError(t, err)
 	assert.NotNil(t, dm)
 }
 
-func TestDataPruning(t *testing.T) {
-	_, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+func TestDeleteEmptyTxnTable(t *testing.T) {
+	logger.SetOutput(os.Stdout)
+	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
 	defer shutdownFunc()
 
-	db, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	// init the tables
+	idb, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
-	defer db.Close()
+	idb.Close()
 
-	dm := makeMockedDataManager(nil)
-	ch := make(chan uint64)
-	ctx := context.Background()
-	dm.Delete(ctx, ch)
+	// empty txn table
+	err = populateTxnTable(db, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, rowsInTxnTable(db))
+
+	// data manager
+	dm, err := MakeDataManager(context.Background(), &config, "postgres", connStr, logger)
+	assert.NoError(t, err)
+	go dm.Delete()
+	// wait
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, 0, rowsInTxnTable(db))
 }
-func TestDelete(t *testing.T) {
+
+func TestDeleteTxns(t *testing.T) {
 	logger.SetOutput(os.Stdout)
 	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
 	defer shutdownFunc()
@@ -61,51 +72,188 @@ func TestDelete(t *testing.T) {
 	idb.Close()
 
 	// add 20 records to txn table
-	err = populateTxnTable(db)
+	err = populateTxnTable(db, 20)
 	assert.NoError(t, err)
 	assert.Equal(t, 20, rowsInTxnTable(db))
 
-	config := util.PruneConfigurations{
-		Interval: "once",
-		Rounds:   10,
-	}
 	// data manager
-	dm, err := util.MakeDataManager(&config, "postgres", connStr, logger)
+	dm, err := MakeDataManager(context.Background(), &config, "postgres", connStr, logger)
 	assert.NoError(t, err)
-	ch := make(chan uint64)
-	go dm.Delete(context.Background(), ch)
-	// ch empty, nothing happens
-	assert.Equal(t, 20, rowsInTxnTable(db))
-	// send current round
-	ch <- 20
+	go dm.Delete()
 	// wait
 	time.Sleep(1 * time.Second)
 	// 10 rounds removed
 	assert.Equal(t, 10, rowsInTxnTable(db))
 	// check remaining rounds are correct
 	assert.True(t, validateTxnTable(db, 10, 20))
-	// todo: test rollback
-	// todo: test context closed.
-	// todo: test daily
-	// todo: test timeout
-	// todo: test round < p.Config.Rounds
-	// todo: test round == p.Config.Rounds
-	close(ch)
-}
-func makeMockedDataManager(db *pgxpool.Pool) util.DataManager {
-	return util.Postgressql{
-		Config: &util.PruneConfigurations{
-			Interval: "once",
-			Rounds:   10,
-		},
-		DB:     db,
-		Logger: nil,
-	}
+	//	processor ended
+	assert.True(t, dm.Closed())
+
 }
 
-func populateTxnTable(db *pgxpool.Pool) error {
+func TestDeleteConfigs(t *testing.T) {
+	logger.SetOutput(os.Stdout)
+	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
+
+	// init the tables
+	idb, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+	idb.Close()
+
+	// add 3 record to txn table
+	err = populateTxnTable(db, 3)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, rowsInTxnTable(db))
+
+	// config.Rounds > rounds in DB
+	config = PruneConfigurations{
+		Frequency: "once",
+		Rounds:    5,
+	}
+	dm, err := MakeDataManager(context.Background(), &config, "postgres", connStr, logger)
+	assert.NoError(t, err)
+	go dm.Delete()
+	// wait
+	time.Sleep(1 * time.Second)
+	// delete didn't happen
+	assert.Equal(t, 3, rowsInTxnTable(db))
+
+	// config.Rounds == rounds in DB
+	config.Rounds = 3
+	dm, err = MakeDataManager(context.Background(), &config, "postgres", connStr, logger)
+	assert.NoError(t, err)
+	go dm.Delete()
+	// wait
+	time.Sleep(1 * time.Second)
+	// delete didn't happen
+	assert.Equal(t, 3, rowsInTxnTable(db))
+	//	processor ended
+	assert.True(t, dm.Closed())
+}
+
+func TestDeleteDaily(t *testing.T) {
+	logger.SetOutput(os.Stdout)
+	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
+
+	// init the tables
+	idb, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+	idb.Close()
+
+	// add 20 record to txn table
+	err = populateTxnTable(db, 20)
+	assert.NoError(t, err)
+	assert.Equal(t, 20, rowsInTxnTable(db))
+
+	config = PruneConfigurations{
+		Frequency: "daily",
+		Rounds:    15,
+	}
+	ctx, cf := context.WithCancel(context.Background())
+	dm, err := MakeDataManager(ctx, &config, "postgres", connStr, logger)
+	assert.NoError(t, err)
+	go dm.Delete()
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, 15, rowsInTxnTable(db))
+	// database connection stays open
+	assert.False(t, dm.Closed())
+	// cancel
+	cf()
+	// database connection should be closed
+	time.Sleep(1 * time.Second)
+	assert.True(t, dm.Closed())
+
+	//	reconnect
+	config = PruneConfigurations{
+		Frequency: "daily",
+		Rounds:    10,
+	}
+	dm, err = MakeDataManager(context.Background(), &config, "postgres", connStr, logger)
+	assert.NoError(t, err)
+	go dm.Delete()
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, 10, rowsInTxnTable(db))
+}
+
+func TestDeleteRollback(t *testing.T) {
+	logger.SetOutput(os.Stdout)
+	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
+
+	// init the tables
+	idb, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+	idb.Close()
+
+	// remove metastate table
+	_, err = db.Exec(context.Background(), "DROP TABLE metastate")
+	assert.NoError(t, err)
+
+	// add 10 record to txn table
+	err = populateTxnTable(db, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, rowsInTxnTable(db))
+
+	config = PruneConfigurations{
+		Frequency: "once",
+		Rounds:    5,
+	}
+	postgres := Postgressql{
+		Config: &config,
+		DB:     db,
+		Logger: logger,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = postgres.deleteTransactions(ctx)
+	// delete didn't happen
+	assert.Equal(t, 10, rowsInTxnTable(db))
+	// metastate update failed
+	assert.Contains(t, err.Error(), "\"metastate\" does not exist")
+
+}
+
+func TestDeleteTimeout(t *testing.T) {
+	logger.SetOutput(os.Stdout)
+	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
+
+	// init the tables
+	idb, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+	idb.Close()
+
+	// add 10 record to txn table
+	err = populateTxnTable(db, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, rowsInTxnTable(db))
+
+	config = PruneConfigurations{
+		Frequency: "once",
+		Rounds:    5,
+		Timeout:   0,
+	}
+	postgres := Postgressql{
+		Config: &config,
+		DB:     db,
+		Logger: logger,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	defer cancel()
+	err = postgres.deleteTransactions(ctx)
+	// delete didn't happen
+	assert.Equal(t, 10, rowsInTxnTable(db))
+	// context deadline exceeded
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+}
+
+func populateTxnTable(db *pgxpool.Pool, n int) error {
 	batch := &pgx.Batch{}
-	for i := 0; i < 20; i++ {
+	for i := 0; i < n; i++ {
 		query := "INSERT INTO txn(round, intra, typeenum,asset,txn,extra) VALUES ($1,$2,$3,$4,$5,$6)"
 		batch.Queue(query, i, i, 1, 0, "{}", "{}")
 	}

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -236,7 +236,7 @@ func TestDeleteRollback(t *testing.T) {
 		Frequency: "once",
 		Rounds:    5,
 	}
-	postgres := postgressql{
+	postgres := postgresql{
 		config: &config,
 		db:     db,
 		logger: logger,
@@ -274,7 +274,7 @@ func TestDeleteTimeout(t *testing.T) {
 		Rounds:    5,
 		Timeout:   0,
 	}
-	postgres := postgressql{
+	postgres := postgresql{
 		config: &config,
 		db:     db,
 		logger: logger,

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -1,12 +1,14 @@
 package util_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/algorand/indexer/exporters/util"
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/idb/postgres"
 	pgtest "github.com/algorand/indexer/idb/postgres/testing"
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -24,12 +26,13 @@ func TestDataPruning(t *testing.T) {
 	db, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 	defer db.Close()
-	dm := makeMockedDataManager(db)
+	dm := makeMockedDataManager(nil)
 	ch := make(chan uint64)
-	dm.Delete(ch)
+	ctx := context.Background()
+	dm.Delete(ctx, ch)
 }
 
-func makeMockedDataManager(db *postgres.IndexerDb) util.DataManager {
+func makeMockedDataManager(db *pgxpool.Pool) util.DataManager {
 	return util.Postgressql{
 		Config: &util.PruneConfigurations{
 			Interval: "once",

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -84,7 +84,12 @@ func TestDelete(t *testing.T) {
 	assert.Equal(t, 10, rowsInTxnTable(db))
 	// check remaining rounds are correct
 	assert.True(t, validateTxnTable(db, 10, 20))
-
+	// todo: test rollback
+	// todo: test context closed.
+	// todo: test daily
+	// todo: test timeout
+	// todo: test round < p.Config.Rounds
+	// todo: test round == p.Config.Rounds
 	close(ch)
 }
 func makeMockedDataManager(db *pgxpool.Pool) util.DataManager {

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -2,12 +2,16 @@ package util_test
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/algorand/indexer/exporters/util"
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/idb/postgres"
 	pgtest "github.com/algorand/indexer/idb/postgres/testing"
+	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -19,6 +23,20 @@ var logger *logrus.Logger
 func init() {
 	logger, _ = test.NewNullLogger()
 }
+
+func TestMakeDataManager(t *testing.T) {
+	config := util.PruneConfigurations{
+		Interval: "once",
+		Rounds:   10,
+	}
+	_, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
+
+	dm, err := util.MakeDataManager(&config, "postgres", connStr, logger)
+	assert.NoError(t, err)
+	assert.NotNil(t, dm)
+}
+
 func TestDataPruning(t *testing.T) {
 	_, connStr, shutdownFunc := pgtest.SetupPostgres(t)
 	defer shutdownFunc()
@@ -26,12 +44,49 @@ func TestDataPruning(t *testing.T) {
 	db, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 	defer db.Close()
+
 	dm := makeMockedDataManager(nil)
 	ch := make(chan uint64)
 	ctx := context.Background()
 	dm.Delete(ctx, ch)
 }
+func TestDelete(t *testing.T) {
+	logger.SetOutput(os.Stdout)
+	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
 
+	// init the tables
+	idb, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+	idb.Close()
+
+	// add 20 records to txn table
+	err = populateTxnTable(db)
+	assert.NoError(t, err)
+	assert.Equal(t, 20, rowsInTxnTable(db))
+
+	config := util.PruneConfigurations{
+		Interval: "once",
+		Rounds:   10,
+	}
+	// data manager
+	dm, err := util.MakeDataManager(&config, "postgres", connStr, logger)
+	assert.NoError(t, err)
+	ch := make(chan uint64)
+	go dm.Delete(context.Background(), ch)
+	// ch empty, nothing happens
+	assert.Equal(t, 20, rowsInTxnTable(db))
+	// send current round
+	ch <- 20
+	// wait
+	time.Sleep(1 * time.Second)
+	// 10 rounds removed
+	assert.Equal(t, 10, rowsInTxnTable(db))
+	// check remaining rounds are correct
+	assert.True(t, validateTxnTable(db, 10, 20))
+
+	close(ch)
+}
 func makeMockedDataManager(db *pgxpool.Pool) util.DataManager {
 	return util.Postgressql{
 		Config: &util.PruneConfigurations{
@@ -41,4 +96,58 @@ func makeMockedDataManager(db *pgxpool.Pool) util.DataManager {
 		DB:     db,
 		Logger: nil,
 	}
+}
+
+func populateTxnTable(db *pgxpool.Pool) error {
+	batch := &pgx.Batch{}
+	for i := 0; i < 20; i++ {
+		query := "INSERT INTO txn(round, intra, typeenum,asset,txn,extra) VALUES ($1,$2,$3,$4,$5,$6)"
+		batch.Queue(query, i, i, 1, 0, "{}", "{}")
+	}
+	results := db.SendBatch(context.Background(), batch)
+	defer results.Close()
+	for i := 0; i < batch.Len(); i++ {
+		_, err := results.Exec()
+		if err != nil {
+			return fmt.Errorf("populateTxnTable() exec err: %w", err)
+		}
+	}
+	return nil
+}
+
+func rowsInTxnTable(db *pgxpool.Pool) int {
+	var rows int
+	r, err := db.Query(context.Background(), "SELECT count(*) FROM txn")
+	if err != nil {
+		return 0
+	}
+	defer r.Close()
+	for r.Next() {
+		err = r.Scan(&rows)
+		if err != nil {
+			return 0
+		}
+	}
+	return rows
+}
+
+func validateTxnTable(db *pgxpool.Pool, first, last uint64) bool {
+	res, err := db.Query(context.Background(), "SELECT round FROM txn")
+	if err != nil {
+		return false
+	}
+	defer res.Close()
+	var round uint64
+	// expected round
+	expected := first
+	next := first + 1
+	for res.Next() {
+		err = res.Scan(&round)
+		if err != nil || round != expected {
+			return false
+		}
+		expected = next
+		next++
+	}
+	return expected == last
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Adding an option for postgresql exporter to discard old transaction data by round.

## Test Plan

Adding new tests, run indexer for multiple days to validate data are removed correctly for the recurring option.

