### PR TITLE
File Exporter: fixes for simple configuration

### DIFF
--- a/exporters/filewriter/file_exporter.go
+++ b/exporters/filewriter/file_exporter.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/bookkeeping"
+
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/exporters"
 	"github.com/algorand/indexer/plugins"

--- a/exporters/filewriter/file_exporter.go
+++ b/exporters/filewriter/file_exporter.go
@@ -10,11 +10,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
-	sdkJson "github.com/algorand/go-algorand-sdk/encoding/json"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/bookkeeping"
-	"github.com/algorand/go-codec/codec"
-
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/exporters"
 	"github.com/algorand/indexer/plugins"
@@ -151,8 +148,7 @@ func (exp *fileExporter) Receive(exportData data.BlockData) error {
 		return fmt.Errorf("Receive(): error opening file %s: %w", blockFile, err)
 	}
 	defer file.Close()
-	enc := codec.NewEncoder(file, sdkJson.CodecHandle)
-	err = enc.Encode(exportData)
+	err = json.NewEncoder(file).Encode(exportData)
 	if err != nil {
 		return fmt.Errorf("Receive(): error encoding exportData: %w", err)
 	}

--- a/exporters/filewriter/file_exporter_test.go
+++ b/exporters/filewriter/file_exporter_test.go
@@ -50,8 +50,17 @@ func TestExporterInit(t *testing.T) {
 	err = fileExp.Init(plugins.PluginConfig(config), logger)
 	assert.NoError(t, err)
 	fileExp.Close()
-
+	// re-initializes empty file
+	path := "/tmp/blocks/metadata.json"
+	assert.NoError(t, os.Remove(path))
+	f, err := os.Create(path)
+	f.Close()
+	assert.NoError(t, err)
+	err = fileExp.Init(plugins.PluginConfig(config), logger)
+	assert.NoError(t, err)
+	fileExp.Close()
 }
+
 func TestExporterHandleGenesis(t *testing.T) {
 	fileExp := fileCons.New()
 	fileExp.Init(plugins.PluginConfig(config), logger)


### PR DESCRIPTION
## Summary

Testing with a simple configuration wasn't working quite right:
```yaml
Importer:
    Name: algod
    Config:
      - netaddr: {mainnet node addr}
        token: {token}
Exporter:
    Name: filewriter
    Config:
      - block-dir: {path}/data2/blocks
```

1) encoding failed when pointed to mainnet.
2) the metadata file was not being updated, leading to re-downloading the same blocks.
