### PR TITLE
Slack demo

### DIFF
--- a/exporters/all/all.go
+++ b/exporters/all/all.go
@@ -5,4 +5,5 @@ import (
 	_ "github.com/algorand/indexer/exporters/filewriter"
 	_ "github.com/algorand/indexer/exporters/noop"
 	_ "github.com/algorand/indexer/exporters/postgresql"
+	_ "github.com/algorand/indexer/exporters/slack"
 )

--- a/exporters/slack/slack_exporter.go
+++ b/exporters/slack/slack_exporter.go
@@ -65,7 +65,6 @@ func (exp *slackExporter) Receive(exportData data.BlockData) error {
 			exp.logger.Infof("Sending txn message to webhook: %v", webhook)
 			err := slack.PostWebhook(webhook, &slack.WebhookMessage{
 				Username: "Conduit Slackbot",
-				IconEmoji: 
 				Text: fmt.Sprintf(
 					"Transaction:\nSender: %v\nReceiver: %v\nAmount: %v\nNote: %v\n",
 					txn.Txn.AssetSender,

--- a/exporters/slack/slack_exporter.go
+++ b/exporters/slack/slack_exporter.go
@@ -1,0 +1,101 @@
+package slack
+
+import (
+	"fmt"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/indexer/data"
+	"github.com/algorand/indexer/exporters"
+	"github.com/algorand/indexer/plugins"
+	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
+	"gopkg.in/yaml.v3"
+)
+
+type slackExporter struct {
+	round  uint64
+	cfg    ExporterConfig
+	logger *logrus.Logger
+}
+
+var slackExporterMetadata exporters.ExporterMetadata = exporters.ExporterMetadata{
+	ExpName:        "slack",
+	ExpDescription: "Sends slack messages with transaction information",
+	ExpDeprecated:  false,
+}
+
+// Constructor is the ExporterConstructor implementation for an Exporter
+type Constructor struct{}
+
+// New initializes an Exporter
+func (c *Constructor) New() exporters.Exporter {
+	return &slackExporter{}
+}
+
+// Metadata returns the Exporter's Metadata object
+func (exp *slackExporter) Metadata() exporters.ExporterMetadata {
+	return slackExporterMetadata
+}
+
+// Init sets up the slack client
+func (exp *slackExporter) Init(cfg plugins.PluginConfig, logger *logrus.Logger) error {
+	exp.logger = logger
+	err := yaml.Unmarshal([]byte(cfg), &exp.cfg)
+	if err != nil {
+		return fmt.Errorf("init failure in unmarshal config: %v", err)
+	}
+	return nil
+}
+
+// Config returns the unmarshaled config object
+func (exp *slackExporter) Config() plugins.PluginConfig {
+	ret, _ := yaml.Marshal(exp.cfg)
+	return plugins.PluginConfig(ret)
+}
+
+// Close terminates connections
+func (exp *slackExporter) Close() error {
+	return nil
+}
+
+// Receive is the main handler function for blocks
+func (exp *slackExporter) Receive(exportData data.BlockData) error {
+	for _, txn := range exportData.Payset {
+		exp.logger.Infof("got %v txns", len(exportData.Payset))
+		for _, webhook := range exp.cfg.Webhooks {
+			exp.logger.Infof("Sending txn message to webhook: %v", webhook)
+			err := slack.PostWebhook(webhook, &slack.WebhookMessage{
+				Username: "Conduit Slackbot",
+				IconEmoji: 
+				Text: fmt.Sprintf(
+					"Transaction:\nSender: %v\nReceiver: %v\nAmount: %v\nNote: %v\n",
+					txn.Txn.AssetSender,
+					txn.Txn.AssetReceiver,
+					txn.Txn.AssetAmount,
+					string(txn.Txn.Note),
+				),
+			})
+			if err != nil {
+				exp.logger.Errorf("failed to send webhook message: %v", err)
+				return err
+			}
+		}
+	}
+	exp.round = exportData.Round() + 1
+	return nil
+}
+
+// HandleGenesis provides the opportunity to store initial chain state
+func (exp *slackExporter) HandleGenesis(_ bookkeeping.Genesis) error {
+	return nil
+}
+
+// Round should return the round number of the next expected round that should be provided to the Exporter
+func (exp *slackExporter) Round() uint64 {
+	return exp.round
+}
+
+func init() {
+	// In order to provide a Constructor to the exporter_factory, we register our Exporter in the init block.
+	// To load this Exporter into the factory, simply import the package.
+	exporters.RegisterExporter(slackExporterMetadata.ExpName, &Constructor{})
+}

--- a/exporters/slack/slack_exporter_config.go
+++ b/exporters/slack/slack_exporter_config.go
@@ -1,0 +1,9 @@
+package slack
+
+type ExporterConfig struct {
+	// A list of webhooks. Each of which will have a POST request sent to it w/ a constructed Slack message
+	// relating to each Transaction sent to the exporter.
+	Webhooks []string `yaml:"webhooks"`
+	// API Token for the Slack Client
+	Token string `yaml:"token"`
+}

--- a/exporters/slack/slack_exporter_test.go
+++ b/exporters/slack/slack_exporter_test.go
@@ -1,0 +1,43 @@
+package slack
+
+import (
+	"github.com/algorand/indexer/plugins"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var exCons = &Constructor{}
+
+var exExp = exCons.New()
+
+func TestExporterMetadata(t *testing.T) {
+	meta := exExp.Metadata()
+	assert.Equal(t, plugins.PluginType(plugins.Exporter), meta.Type())
+	assert.Equal(t, slackExporterMetadata.ExpName, meta.Name())
+	assert.Equal(t, slackExporterMetadata.ExpDescription, meta.Description())
+	assert.Equal(t, slackExporterMetadata.ExpDeprecated, meta.Deprecated())
+}
+
+func TestExporterInit(t *testing.T) {
+	// assert.Panics(t, func() { exExp.Init("", nil) })
+}
+
+func TestExporterConfig(t *testing.T) {
+	// assert.Panics(t, func() { exExp.Config() })
+}
+
+func TestExporterClose(t *testing.T) {
+	// assert.Panics(t, func() { exExp.Close() })
+}
+
+func TestExporterReceive(t *testing.T) {
+	// assert.Panics(t, func() { exExp.Receive(data.BlockData{}) })
+}
+
+func TestExporterHandleGenesis(t *testing.T) {
+	// assert.Panics(t, func() { exExp.HandleGenesis(bookkeeping.Genesis{}) })
+}
+
+func TestExporterRound(t *testing.T) {
+	// assert.Panics(t, func() { exExp.Round() })
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/algorand/go-algorand v0.0.0-20220211161928-53b157beb10f
 	github.com/algorand/go-algorand-sdk v1.9.1
 	github.com/algorand/go-codec/codec v1.1.8
+	github.com/algorand/go-deadlock v0.2.2
 	github.com/algorand/oapi-codegen v1.3.7
 	github.com/davecgh/go-spew v1.1.1
 	github.com/getkin/kin-openapi v0.22.0
@@ -21,6 +22,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.10.0
 	github.com/sirupsen/logrus v1.8.1
+	github.com/slack-go/slack v0.11.3
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.0
@@ -32,7 +34,6 @@ require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/algorand/avm-abi v0.1.0 // indirect
 	github.com/algorand/falcon v0.0.0-20220727072124-02a2a64c4414 // indirect
-	github.com/algorand/go-deadlock v0.2.2 // indirect
 	github.com/algorand/go-sumhash v0.1.0 // indirect
 	github.com/algorand/msgp v1.1.52 // indirect
 	github.com/algorand/websocket v1.4.5 // indirect
@@ -55,6 +56,7 @@ require (
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/gorilla/mux v1.7.4 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,8 @@ github.com/go-redis/redis/v7 v7.2.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRf
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
+github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
 github.com/gobuffalo/depgen v0.1.0/go.mod h1:+ifsuy7fhi15RWncXQQKjWS9JPkdah5sZvtHc2RXGlg=
@@ -351,8 +353,9 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -400,6 +403,8 @@ github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -759,6 +764,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/slack-go/slack v0.11.3 h1:GN7revxEMax4amCc3El9a+9SGnjmBvSUobs0QnO6ZO8=
+github.com/slack-go/slack v0.11.3/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/processors/all/all.go
+++ b/processors/all/all.go
@@ -3,5 +3,6 @@ package all
 import (
 	// Call package wide init function
 	_ "github.com/algorand/indexer/processors/blockprocessor"
+	_ "github.com/algorand/indexer/processors/filterprocessor"
 	_ "github.com/algorand/indexer/processors/noop"
 )


### PR DESCRIPTION

## Summary

Adds a slack exporter which simply posts a message from an asset transfer txn.

## Test Plan

Using conduit running locally, pointing to a testnet algod, providing the most recent round to start at, and a personal account funded by testnet dispenser to trigger transfers.

Here is the local config:


```yml
LogLevel: info
Round: 24261185
Importer:
  Name: "algod"
  Config:
    netaddr: "http://127.0.0.1:8080"
    token: "TOKEN"
Processors:
  - Name: "filter_processor"
    Config:
      filters:
        - any:
          - tag: SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.AssetReceiver
            expression-type: exact
            expression: "ACCOUNT"
          - tag: SignedTxnWithAD.SignedTxn.Txn.AssetReceiver
            expression-type: exact
            expression: "ACCOUNT"
          - tag: SignedTxnWithAD.SignedTxn.Txn.Receiver
            expression-type: exact
            expression: "ACCOUNT"
          - tag: SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Receiver
            expression-type: exact
            expression: "ACCOUNT"
Exporter:
  Name: "slack"
  Config:
    webhooks:
      - "WEBHOOK"
```