### PR TITLE
Conduit init subcommand

### DIFF
--- a/cmd/conduit/conduit.yml.example
+++ b/cmd/conduit/conduit.yml.example
@@ -1,0 +1,20 @@
+# Generated conduit configuration file.
+
+# The importer is typically an algod archival instance.
+Importer:
+    Name: algod
+    Config:
+      - netaddr: "your algod address here"
+        token: "your algod token here"
+
+# One or more processors may be defined to manipulate what data
+# reaches the exporter.
+Processors:
+
+# An exporter is defined to do something with the data.
+# Here the filewriter is defined which writes the raw block
+# data to files.
+Exporter:
+    Name: filewriter
+    Config:
+      - block-dir: "path where data should be written"

--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -152,8 +152,7 @@ func runConduitInit(path string) error {
 		return fmt.Errorf("runConduitInit(): failed to write sample config: %w", err)
 	}
 
-	fmt.Printf("A data directory has been created\n")
-	fmt.Printf("%s\n", location)
+	fmt.Printf("A data directory has been created %s.\n", location)
 	fmt.Printf("\nBefore it can be used, the config file needs to be updated\n")
 	fmt.Printf("by setting the algod address/token and the block-dir path where\n")
 	fmt.Printf("Conduit should write the block files.\n")

--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -22,11 +22,11 @@ import (
 )
 
 var (
-	logger *log.Logger
+	logger               *log.Logger
+	conduitCmd           = makeConduitCmd()
+	initCmd              = makeInitCmd()
+	defaultDataDirectory = "data"
 )
-
-var conduitCmd = makeConduitCmd()
-var initCmd = makeInitCmd()
 
 // init() function for main package
 func init() {
@@ -130,7 +130,7 @@ var sampleConfig string
 func runConduitInit(path string) error {
 	var location string
 	if path == "" {
-		path = "data"
+		path = defaultDataDirectory
 		location = "in the current working directory"
 	} else {
 		location = fmt.Sprintf("at '%s'", path)
@@ -164,19 +164,19 @@ func runConduitInit(path string) error {
 
 // makeInitCmd creates a sample data directory.
 func makeInitCmd() *cobra.Command {
-	var path string
+	var data string
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "initializes a sample data directory",
 		Long:  "initializes a Conduit data directory and conduit.yml file configured with the file_writer plugin. The config file needs to be modified slightly to include an algod address and token. Once ready, launch conduit with './conduit -d /path/to/data'.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runConduitInit(path)
+			return runConduitInit(data)
 		},
 		SilenceUsage: true,
 	}
 
-	cmd.Flags().StringVar(&path, "path", "", "Full path to new data directory. If not set, a directory named 'data' will be created in the current directory.")
+	cmd.Flags().StringVarP(&data, "data", "d", "", "Full path to new data directory. If not set, a directory named 'data' will be created in the current directory.")
 
 	return cmd
 }

--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -118,7 +118,7 @@ func makeConduitCmd() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	cfg.Flags = cmd.PersistentFlags()
+	cfg.Flags = cmd.Flags()
 	cfg.Flags.StringVarP(&cfg.ConduitDataDir, "data-dir", "d", "", "set the data directory for the conduit binary")
 
 	return cmd

--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -23,6 +25,9 @@ var (
 	logger *log.Logger
 )
 
+var conduitCmd = makeConduitCmd()
+var initCmd = makeInitCmd()
+
 // init() function for main package
 func init() {
 
@@ -39,6 +44,8 @@ func init() {
 
 	logger.SetFormatter(&formatter)
 	logger.SetOutput(os.Stdout)
+
+	conduitCmd.AddCommand(initCmd)
 }
 
 // runConduitCmdWithConfig run the main logic with a supplied conduit config
@@ -97,10 +104,10 @@ func runConduitCmdWithConfig(cfg *conduit.Config) error {
 	return pipeline.Error()
 }
 
-// conduitCmd creates the main cobra command, initializes flags, and viper aliases
-func conduitCmd() *cobra.Command {
+// makeConduitCmd creates the main cobra command, initializes flags, and viper aliases
+func makeConduitCmd() *cobra.Command {
 	cfg := &conduit.Config{}
-	conduitCmd := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "conduit",
 		Short: "run the conduit framework",
 		Long:  "run the conduit framework",
@@ -111,14 +118,71 @@ func conduitCmd() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	cfg.Flags = conduitCmd.PersistentFlags()
+	cfg.Flags = cmd.PersistentFlags()
 	cfg.Flags.StringVarP(&cfg.ConduitDataDir, "data-dir", "d", "", "set the data directory for the conduit binary")
 
-	return conduitCmd
+	return cmd
+}
+
+//go:embed conduit.yml.example
+var sampleConfig string
+
+func runConduitInit(path string) error {
+	var location string
+	if path == "" {
+		path = "data"
+		location = "in the current working directory"
+	} else {
+		location = fmt.Sprintf("at '%s'", path)
+	}
+
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return err
+	}
+
+	configFilePath := filepath.Join(path, conduit.DefaultConfigName)
+	f, err := os.Create(configFilePath)
+	if err != nil {
+		return fmt.Errorf("runConduitInit(): failed to create %s", configFilePath)
+	}
+	defer f.Close()
+
+	f.WriteString(sampleConfig)
+	if err != nil {
+		return fmt.Errorf("runConduitInit(): failed to write sample config: %w", err)
+	}
+
+	fmt.Printf("A data directory has been created\n")
+	fmt.Printf("%s\n", location)
+	fmt.Printf("\nBefore it can be used, the config file needs to be updated\n")
+	fmt.Printf("by setting the algod address/token and the block-dir path where\n")
+	fmt.Printf("Conduit should write the block files.\n")
+	fmt.Printf("\nOnce the config file is updated, start Conduit with:\n")
+	fmt.Printf("  ./conduit -d %s\n", path)
+	return nil
+}
+
+// makeInitCmd creates a sample data directory.
+func makeInitCmd() *cobra.Command {
+	var path string
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "initializes a sample data directory",
+		Long:  "initializes a Conduit data directory and conduit.yml file configured with the file_writer plugin. The config file needs to be modified slightly to include an algod address and token. Once ready, launch conduit with './conduit -d /path/to/data'.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConduitInit(path)
+		},
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "Full path to new data directory. If not set, a directory named 'data' will be created in the current directory.")
+
+	return cmd
 }
 
 func main() {
-	if err := conduitCmd().Execute(); err != nil {
+	if err := conduitCmd.Execute(); err != nil {
 		log.Errorf("%v", err)
 		os.Exit(1)
 	}

--- a/cmd/conduit/main_test.go
+++ b/cmd/conduit/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitDataDirectory(t *testing.T) {
+	verifyFile := func(file string) {
+		require.FileExists(t, file)
+		data, err := os.ReadFile(file)
+		require.NoError(t, err)
+		require.Equal(t, sampleConfig, string(data))
+	}
+
+	// avoid clobbering an existing data directory
+	defaultDataDirectory = "override"
+	require.NoDirExists(t, defaultDataDirectory)
+
+	runConduitInit("")
+	verifyFile(fmt.Sprintf("%s/conduit.yml", defaultDataDirectory))
+
+	runConduitInit(fmt.Sprintf("%s/provided_directory", defaultDataDirectory))
+	verifyFile(fmt.Sprintf("%s/provided_directory/conduit.yml", defaultDataDirectory))
+
+	os.RemoveAll(defaultDataDirectory)
+}

--- a/conduit/config.go
+++ b/conduit/config.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 )
 
-// Config configuration for conduit running
+const DefaultConfigName = "conduit.yml"
+
+// Config configuration for conduit running.
+// This is needed to support a CONDUIT_DATA_DIR environment variable.
 type Config struct {
 	Flags          *pflag.FlagSet
 	ConduitDataDir string `yaml:"data-dir"`

--- a/conduit/config.go
+++ b/conduit/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+// DefaultConfigName is the default conduit configuration filename.
 const DefaultConfigName = "conduit.yml"
 
 // Config configuration for conduit running.

--- a/conduit/pipeline.go
+++ b/conduit/pipeline.go
@@ -27,8 +27,6 @@ func init() {
 	viper.SetConfigType("yaml")
 }
 
-const autoLoadParameterConfigName = "conduit.yml"
-
 // NameConfigPair is a generic structure used across plugin configuration ser/de
 type NameConfigPair struct {
 	Name   string                 `yaml:"Name"`
@@ -84,13 +82,13 @@ func MakePipelineConfig(logger *log.Logger, cfg *Config) (*PipelineConfig, error
 	pCfg := PipelineConfig{PipelineLogLevel: logger.Level.String(), ConduitConfig: cfg}
 
 	// Search for pipeline configuration in data directory
-	autoloadParamConfigPath := filepath.Join(cfg.ConduitDataDir, autoLoadParameterConfigName)
+	autoloadParamConfigPath := filepath.Join(cfg.ConduitDataDir, DefaultConfigName)
 
 	_, err := os.Stat(autoloadParamConfigPath)
 	paramConfigFound := err == nil
 
 	if !paramConfigFound {
-		return nil, fmt.Errorf("MakePipelineConfig(): could not find %s in data directory (%s)", autoLoadParameterConfigName, cfg.ConduitDataDir)
+		return nil, fmt.Errorf("MakePipelineConfig(): could not find %s in data directory (%s)", DefaultConfigName, cfg.ConduitDataDir)
 	}
 
 	logger.Infof("Auto-loading Conduit Configuration: %s", autoloadParamConfigPath)

--- a/conduit/pipeline_test.go
+++ b/conduit/pipeline_test.go
@@ -106,7 +106,7 @@ Exporter:
   Config:
     connectionstring: ""`
 
-	err = os.WriteFile(filepath.Join(dataDir, autoLoadParameterConfigName), []byte(validConfigFile), 0777)
+	err = os.WriteFile(filepath.Join(dataDir, DefaultConfigName), []byte(validConfigFile), 0777)
 	assert.Nil(t, err)
 
 	cfg := &Config{ConduitDataDir: dataDir}
@@ -131,7 +131,7 @@ Exporter:
 	cfgBad := &Config{ConduitDataDir: invalidDataDir}
 	_, err = MakePipelineConfig(l, cfgBad)
 	assert.Equal(t, err,
-		fmt.Errorf("MakePipelineConfig(): could not find %s in data directory (%s)", autoLoadParameterConfigName, cfgBad.ConduitDataDir))
+		fmt.Errorf("MakePipelineConfig(): could not find %s in data directory (%s)", DefaultConfigName, cfgBad.ConduitDataDir))
 
 }
 

--- a/exporters/filewriter/file_exporter.go
+++ b/exporters/filewriter/file_exporter.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/bookkeeping"
+
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/exporters"
 	"github.com/algorand/indexer/plugins"

--- a/exporters/filewriter/file_exporter.go
+++ b/exporters/filewriter/file_exporter.go
@@ -10,11 +10,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
-	sdkJson "github.com/algorand/go-algorand-sdk/encoding/json"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/bookkeeping"
-	"github.com/algorand/go-codec/codec"
-
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/exporters"
 	"github.com/algorand/indexer/plugins"
@@ -151,8 +148,7 @@ func (exp *fileExporter) Receive(exportData data.BlockData) error {
 		return fmt.Errorf("Receive(): error opening file %s: %w", blockFile, err)
 	}
 	defer file.Close()
-	enc := codec.NewEncoder(file, sdkJson.CodecHandle)
-	err = enc.Encode(exportData)
+	err = json.NewEncoder(file).Encode(exportData)
 	if err != nil {
 		return fmt.Errorf("Receive(): error encoding exportData: %w", err)
 	}

--- a/exporters/filewriter/file_exporter.go
+++ b/exporters/filewriter/file_exporter.go
@@ -10,8 +10,10 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
+	sdkJson "github.com/algorand/go-algorand-sdk/encoding/json"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-codec/codec"
 
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/exporters"
@@ -149,7 +151,8 @@ func (exp *fileExporter) Receive(exportData data.BlockData) error {
 		return fmt.Errorf("Receive(): error opening file %s: %w", blockFile, err)
 	}
 	defer file.Close()
-	err = json.NewEncoder(file).Encode(exportData)
+	enc := codec.NewEncoder(file, sdkJson.CodecHandle)
+	err = enc.Encode(exportData)
 	if err != nil {
 		return fmt.Errorf("Receive(): error encoding exportData: %w", err)
 	}


### PR DESCRIPTION
## Summary

Note: this is building ontop of #1232 so there are some unrelated changes in the diff.

Thinking out loud a little with this PR. I wanted to try out Conduit and getting the basic configuration setup was a little tricky.

Run `./conduit init` or `./conduit init -d /path/to/data/directory` and a new directory is created along with some instructions:

```
~$ ./conduit init -d data/conduit_data
A data directory has been created at 'data/conduit_data'.

Before it can be used, the config file needs to be updated
by setting the algod address/token and the block-dir path where
Conduit should write the block files.

Once the config file is updated, start Conduit with:
  ./conduit -d data/conduit_data
```

## Test Plan

New unit test and manual testing.
