### PR TITLE
enhancement: prune historical data 

### DIFF
--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -81,7 +81,7 @@ func (exp *postgresqlExporter) Init(cfg plugins.PluginConfig, logger *logrus.Log
 	if !exp.cfg.Test && exp.cfg.Delete.Rounds > 0 {
 		exp.wg.Add(1)
 		exp.dm = util.MakeDataManager(exp.ctx, &exp.cfg.Delete, exp.db, logger)
-		go exp.dm.Delete(&exp.wg)
+		go exp.dm.Delete(&exp.wg, nil)
 	}
 	return err
 }

--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -73,11 +73,15 @@ func (exp *postgresqlExporter) Init(cfg plugins.PluginConfig, logger *logrus.Log
 	}
 	// if data pruning is enabled
 	if exp.cfg.Delete.Rounds > 0 {
-		dm := util.MakeDataManager(&cfg, logger)
-		exp.deleteDataChan = make(chan uint64)
-		go dm.Delete(exp.deleteDataChan)
+		dm, err := util.MakeDataManager(&exp.cfg.Delete, dbName, exp.cfg.ConnectionString, logger)
+		if err != nil {
+			logger.Warnf("skipping data pruning. %w", err)
+		} else {
+			logger.Info("exporter running with data pruning mode")
+			exp.deleteDataChan = make(chan uint64)
+			go dm.Delete(exp.deleteDataChan)
+		}
 	}
-
 	return err
 }
 

--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -80,13 +80,8 @@ func (exp *postgresqlExporter) Init(cfg plugins.PluginConfig, logger *logrus.Log
 	// if data pruning is enabled
 	if !exp.cfg.Test && exp.cfg.Delete.Rounds > 0 {
 		exp.wg.Add(1)
-		exp.dm, err = util.MakeDataManager(exp.ctx, &exp.cfg.Delete, dbName, exp.cfg.ConnectionString, logger)
-		if err != nil {
-			logger.Warnf("cannot start data pruning %v", err)
-		} else {
-			logger.Info("exporter running with data pruning ON")
-			go exp.dm.Delete(&exp.wg)
-		}
+		exp.dm = util.MakeDataManager(exp.ctx, &exp.cfg.Delete, exp.db, logger)
+		go exp.dm.Delete(&exp.wg)
 	}
 	return err
 }

--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -81,7 +81,7 @@ func (exp *postgresqlExporter) Init(cfg plugins.PluginConfig, logger *logrus.Log
 	if !exp.cfg.Test && exp.cfg.Delete.Rounds > 0 {
 		exp.wg.Add(1)
 		exp.dm = util.MakeDataManager(exp.ctx, &exp.cfg.Delete, exp.db, logger)
-		go exp.dm.Delete(&exp.wg, nil)
+		go exp.dm.Delete(&exp.wg)
 	}
 	return err
 }

--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -75,12 +75,12 @@ func (exp *postgresqlExporter) Init(cfg plugins.PluginConfig, logger *logrus.Log
 	}
 	exp.ctx = context.Background()
 	// if data pruning is enabled
-	if exp.cfg.Delete.Rounds > 0 {
-		dm, err := util.MakeDataManager(&exp.cfg.Delete, exp.cfg.ConnectionString, logger)
+	if !exp.cfg.Test && exp.cfg.Delete.Rounds > 0 {
+		dm, err := util.MakeDataManager(&exp.cfg.Delete, dbName, exp.cfg.ConnectionString, logger)
 		if err != nil {
-			logger.Warnf("skipping data pruning. %w", err)
+			logger.Warnf("cannot start data pruning %v", err)
 		} else {
-			logger.Info("exporter running with data pruning mode")
+			logger.Info("exporter running with data pruning ON")
 			exp.deleteDataChan = make(chan uint64)
 			go dm.Delete(exp.ctx, exp.deleteDataChan)
 		}

--- a/exporters/postgresql/postgresql_exporter_config.go
+++ b/exporters/postgresql/postgresql_exporter_config.go
@@ -1,5 +1,7 @@
 package postgresql
 
+import "github.com/algorand/indexer/exporters/util"
+
 // serde for converting an ExporterConfig to/from a PostgresqlExporterConfig
 
 // ExporterConfig specific to the postgresql exporter
@@ -14,4 +16,6 @@ type ExporterConfig struct {
 	// The test flag will replace an actual DB connection being created via the connection string,
 	// with a mock DB for unit testing.
 	Test bool `yaml:"test"`
+	// the configuration for data pruning
+	Delete util.PruneConfigurations `yaml:"delete-task"`
 }

--- a/exporters/postgresql/postgresql_exporter_test.go
+++ b/exporters/postgresql/postgresql_exporter_test.go
@@ -106,15 +106,28 @@ func TestReceiveAddBlockSuccess(t *testing.T) {
 }
 
 func TestUnmarshalConfigsContainingDeleteTask(t *testing.T) {
+	// configured delete task
 	pgsqlExp := postgresqlExporter{}
-	cfg := "test: true\ndelete-task:\n  rounds: 3000\n  interval: 1"
+	cfg := "test: true\ndelete-task:\n  rounds: 3000\n  interval: daily"
 	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
-	assert.Equal(t, 1, int(pgsqlExp.cfg.Delete.Interval))
+	assert.Equal(t, "daily", string(pgsqlExp.cfg.Delete.Interval))
 	assert.Equal(t, uint64(3000), pgsqlExp.cfg.Delete.Rounds)
 
+	// delete task with default rounds
 	pgsqlExp = postgresqlExporter{}
-	cfg = "test: true\ndelete-task:\n  interval: 3"
+	cfg = "test: true\ndelete-task:\n  interval: once"
 	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
-	assert.Equal(t, 3, int(pgsqlExp.cfg.Delete.Interval))
+	assert.Equal(t, "once", string(pgsqlExp.cfg.Delete.Interval))
 	assert.Equal(t, uint64(0), pgsqlExp.cfg.Delete.Rounds)
+
+	// delete task with default interval
+	pgsqlExp = postgresqlExporter{}
+	cfg = "test: true\ndelete-task:\n  rounds: 3000\n"
+	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
+	assert.Equal(t, "", string(pgsqlExp.cfg.Delete.Interval))
+
+	// delete task with negative round
+	pgsqlExp = postgresqlExporter{}
+	cfg = "test: true\ndelete-task:\n  rounds: -1\n  interval: once"
+	assert.ErrorContains(t, pgsqlExp.unmarhshalConfig(cfg), "unmarshal errors")
 }

--- a/exporters/postgresql/postgresql_exporter_test.go
+++ b/exporters/postgresql/postgresql_exporter_test.go
@@ -108,26 +108,28 @@ func TestReceiveAddBlockSuccess(t *testing.T) {
 func TestUnmarshalConfigsContainingDeleteTask(t *testing.T) {
 	// configured delete task
 	pgsqlExp := postgresqlExporter{}
-	cfg := "test: true\ndelete-task:\n  rounds: 3000\n  interval: daily"
+	cfg := "test: true\ndelete-task:\n  rounds: 3000\n  frequency: daily\n  timeout: 5"
 	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
-	assert.Equal(t, "daily", string(pgsqlExp.cfg.Delete.Interval))
+	assert.Equal(t, "daily", string(pgsqlExp.cfg.Delete.Frequency))
 	assert.Equal(t, uint64(3000), pgsqlExp.cfg.Delete.Rounds)
+	assert.Equal(t, uint64(5), pgsqlExp.cfg.Delete.Timeout)
 
-	// delete task with default rounds
+	// delete task with rounds and timeout default to 0
 	pgsqlExp = postgresqlExporter{}
-	cfg = "test: true\ndelete-task:\n  interval: once"
+	cfg = "test: true\ndelete-task:\n  frequency: once"
 	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
-	assert.Equal(t, "once", string(pgsqlExp.cfg.Delete.Interval))
+	assert.Equal(t, "once", string(pgsqlExp.cfg.Delete.Frequency))
 	assert.Equal(t, uint64(0), pgsqlExp.cfg.Delete.Rounds)
+	assert.Equal(t, uint64(0), pgsqlExp.cfg.Delete.Timeout)
 
-	// delete task with default interval
+	// delete task with default frequency
 	pgsqlExp = postgresqlExporter{}
 	cfg = "test: true\ndelete-task:\n  rounds: 3000\n"
 	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
-	assert.Equal(t, "", string(pgsqlExp.cfg.Delete.Interval))
+	assert.Equal(t, "", string(pgsqlExp.cfg.Delete.Frequency))
 
 	// delete task with negative round
 	pgsqlExp = postgresqlExporter{}
-	cfg = "test: true\ndelete-task:\n  rounds: -1\n  interval: once"
+	cfg = "test: true\ndelete-task:\n  rounds: -1\n  frequency: once"
 	assert.ErrorContains(t, pgsqlExp.unmarhshalConfig(cfg), "unmarshal errors")
 }

--- a/exporters/postgresql/postgresql_exporter_test.go
+++ b/exporters/postgresql/postgresql_exporter_test.go
@@ -2,6 +2,8 @@ package postgresql
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -10,7 +12,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"gopkg.in/yaml.v3"
-	"testing"
 
 	_ "github.com/algorand/indexer/idb/dummy"
 	"github.com/algorand/indexer/plugins"
@@ -102,4 +103,18 @@ func TestReceiveAddBlockSuccess(t *testing.T) {
 		Delta:       &ledgercore.StateDelta{},
 	}
 	assert.NoError(t, pgsqlExp.Receive(block))
+}
+
+func TestUnmarshalConfigsContainingDeleteTask(t *testing.T) {
+	pgsqlExp := postgresqlExporter{}
+	cfg := "test: true\ndelete-task:\n  rounds: 3000\n  interval: 1"
+	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
+	assert.Equal(t, 1, int(pgsqlExp.cfg.Delete.Interval))
+	assert.Equal(t, uint64(3000), pgsqlExp.cfg.Delete.Rounds)
+
+	pgsqlExp = postgresqlExporter{}
+	cfg = "test: true\ndelete-task:\n  interval: 3"
+	assert.NoError(t, pgsqlExp.unmarhshalConfig(cfg))
+	assert.Equal(t, 3, int(pgsqlExp.cfg.Delete.Interval))
+	assert.Equal(t, uint64(0), pgsqlExp.cfg.Delete.Rounds)
 }

--- a/exporters/util/prune.go
+++ b/exporters/util/prune.go
@@ -2,13 +2,10 @@ package util
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"sync"
 	"time"
 
-	"github.com/jackc/pgx/v4"
-	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/algorand/indexer/idb"
 	"github.com/sirupsen/logrus"
 )
 
@@ -16,10 +13,10 @@ import (
 type Frequency string
 
 const (
-	once    Frequency = "once"
-	daily   Frequency = "daily"
-	timeout uint64    = 5
-	day               = 24 * time.Hour
+	once           Frequency = "once"
+	daily          Frequency = "daily"
+	day                      = 24 * time.Hour
+	defaultTimeout uint64    = 5
 )
 
 // PruneConfigurations contains the configurations for data pruning
@@ -32,12 +29,11 @@ type PruneConfigurations struct {
 // DataManager is a data pruning interface
 type DataManager interface {
 	Delete(*sync.WaitGroup)
-	Closed() bool
 }
 
 type postgresql struct {
 	config *PruneConfigurations
-	db     *pgxpool.Pool
+	db     idb.IndexerDb
 	logger *logrus.Logger
 	ctx    context.Context
 	cf     context.CancelFunc
@@ -45,163 +41,58 @@ type postgresql struct {
 }
 
 // MakeDataManager initializes resources need for removing data from data source
-func MakeDataManager(ctx context.Context, cfg *PruneConfigurations, dbname string, connection string, logger *logrus.Logger) (DataManager, error) {
-	if dbname == "postgres" {
-		postgresConfig, err := pgxpool.ParseConfig(connection)
-		if err != nil {
-			return nil, fmt.Errorf("Couldn't parse config: %v", err)
-		}
-		db, err := pgxpool.ConnectConfig(context.Background(), postgresConfig)
-		if err != nil {
-			return nil, fmt.Errorf("connecting to postgres: %w", err)
-		}
-
-		c, cf := context.WithCancel(ctx)
-		dm := postgresql{
-			config: cfg,
-			db:     db,
-			logger: logger,
-			ctx:    c,
-			cf:     cf,
-		}
-		return dm, nil
+func MakeDataManager(ctx context.Context, cfg *PruneConfigurations, db idb.IndexerDb, logger *logrus.Logger) DataManager {
+	c, cf := context.WithCancel(ctx)
+	dm := postgresql{
+		config: cfg,
+		db:     db,
+		logger: logger,
+		ctx:    c,
+		cf:     cf,
 	}
-	return nil, fmt.Errorf("data source %s is not supported", dbname)
+	return dm
 }
 
 // Delete removes data from the txn table in Postgres DB
 func (p postgresql) Delete(wg *sync.WaitGroup) {
+	defer wg.Done()
+	timeout := defaultTimeout
+	if p.config.Timeout > 0 {
+		timeout = p.config.Timeout
+	}
+	// exec pruning job base on configured interval
+	p.logger.Info("start data pruning")
+	if p.config.Frequency == once {
+		_, err := p.db.DeleteTransactions(p.ctx, p.config.Rounds, time.Duration(timeout)*time.Second)
+		if err != nil {
+			p.logger.Warnf("exec: data pruning err: %v", err)
+		}
+		return
+	} else if p.config.Frequency == daily {
+		// set up a 24-hour ticker
+		ticker := time.NewTicker(day)
 
-	// set up a 24-hour ticker
-	ticker := time.NewTicker(day)
-
-	// close resources
-	defer func() {
-		ticker.Stop()
-		p.db.Close()
-		wg.Done()
-	}()
-
-	exec := make(chan bool)
-	done := make(chan bool)
-
-	// execute delete
-	go func() {
+		// execute recurring delete
+		exec := make(chan bool, 1)
+		exec <- true
 		for {
 			select {
+			case <-p.ctx.Done():
+				ticker.Stop()
+				return
 			case <-ticker.C:
 				exec <- true
 			case <-exec:
-				p.logger.Info("start data pruning")
-				err := p.deleteTransactions()
+				_, err := p.db.DeleteTransactions(p.ctx, p.config.Rounds, time.Duration(timeout)*time.Second)
 				if err != nil {
 					p.logger.Warnf("exec: data pruning err: %v", err)
 				}
 				ticker.Reset(day)
-				done <- true
 			}
 		}
-	}()
 
-	// exec pruning job base on configured interval
-	if p.config.Frequency == once {
-		exec <- true
-		<-done
-		return
-	} else if p.config.Frequency == daily {
-		// query last pruned time
-		var prunedms map[string]time.Time
-		query := "SELECT k from metastate WHERE k='pruned'"
-		err := p.db.QueryRow(p.ctx, query).Scan(&prunedms)
-		if err != nil && err != pgx.ErrNoRows {
-			p.logger.Warnf(" Delete() metastate: %v", err)
-			return
-		}
-
-		// prune data
-		exec <- true
-		<-p.ctx.Done()
 	} else {
 		p.logger.Warnf("%s pruning interval is not supported", p.config.Frequency)
 	}
-}
 
-// Closed indicates whether the process has exited Delete() and closed DB connection.
-func (p postgresql) Closed() bool {
-	return p.db.Stat().TotalConns() == 0
-}
-
-func (p postgresql) deleteTransactions() error {
-	sec := timeout
-	// allow any timeout value for testing
-	if p.test || p.config.Timeout > 0 {
-		sec = p.config.Timeout
-	}
-
-	ctx, cancel := context.WithTimeout(p.ctx, time.Duration(sec)*time.Second)
-	defer cancel()
-
-	// get latest txn round
-	var latestRound uint64
-	query := "SELECT round FROM txn ORDER BY round DESC LIMIT 1"
-	err := p.db.QueryRow(ctx, query).Scan(&latestRound)
-	if err != nil {
-		return fmt.Errorf("deleteTransactions: %v", err)
-	}
-	p.logger.Infof("last round in database %d", latestRound)
-	// latest round < desired number of rounds to keep
-	if latestRound < p.config.Rounds {
-		// no data to remove
-		return nil
-	}
-
-	// oldest round to keep
-	keep := latestRound - p.config.Rounds + 1
-
-	// atomic txn: delete old transactions and update metastate
-	deleteTxns := func() error {
-		// start a transaction
-		tx, err2 := p.db.BeginTx(ctx, pgx.TxOptions{})
-		if err2 != nil {
-			return fmt.Errorf("delete transactions: %w", err2)
-		}
-		defer tx.Rollback(ctx)
-
-		p.logger.Infof("keeping round %d and later", keep)
-		// delete query
-		query = "DELETE FROM txn WHERE round < $1"
-		cmd, err2 := tx.Exec(ctx, query, keep)
-		if err2 != nil {
-			return fmt.Errorf("transaction delete err %w", err2)
-		}
-		t := time.Now()
-		// update last_pruned in metastate
-		// format time, "2006-01-02T15:04:05Z07:00"
-		ft := t.Format(time.RFC3339)
-		metastate := fmt.Sprintf("{last_pruned: %s}", ft)
-		encoded, err2 := json.Marshal(metastate)
-		if err2 != nil {
-			return fmt.Errorf("transaction delete err %w", err2)
-		}
-		query = "INSERT INTO metastate (k,v) VALUES('prune',$1) ON CONFLICT(k) DO UPDATE SET v=EXCLUDED.v"
-		_, err2 = tx.Exec(ctx, query, string(encoded))
-		if err2 != nil {
-			return fmt.Errorf("metastate update err %w", err2)
-		}
-		// Commit the transaction.
-		if err = tx.Commit(ctx); err2 != nil {
-			return fmt.Errorf("delete transactions: %w", err2)
-		}
-		p.logger.Infof("%d transactions deleted, last pruned at %s", cmd.RowsAffected(), ft)
-		return nil
-	}
-	// retry
-	for i := 1; i <= 3; i++ {
-		err = deleteTxns()
-		if err == nil {
-			return nil
-		}
-		p.logger.Infof("data pruning retry %d", i)
-	}
-	return err
 }

--- a/exporters/util/prune.go
+++ b/exporters/util/prune.go
@@ -35,7 +35,7 @@ type DataManager interface {
 	Closed() bool
 }
 
-type postgressql struct {
+type postgresql struct {
 	config *PruneConfigurations
 	db     *pgxpool.Pool
 	logger *logrus.Logger
@@ -57,7 +57,7 @@ func MakeDataManager(ctx context.Context, cfg *PruneConfigurations, dbname strin
 		}
 
 		c, cf := context.WithCancel(ctx)
-		dm := postgressql{
+		dm := postgresql{
 			config: cfg,
 			db:     db,
 			logger: logger,
@@ -70,7 +70,7 @@ func MakeDataManager(ctx context.Context, cfg *PruneConfigurations, dbname strin
 }
 
 // Delete removes data from the txn table in Postgres DB
-func (p postgressql) Delete(wg *sync.WaitGroup) {
+func (p postgresql) Delete(wg *sync.WaitGroup) {
 
 	// set up a 24-hour ticker
 	ticker := time.NewTicker(day)
@@ -127,11 +127,11 @@ func (p postgressql) Delete(wg *sync.WaitGroup) {
 }
 
 // Closed indicates whether the process has exited Delete() and closed DB connection.
-func (p postgressql) Closed() bool {
+func (p postgresql) Closed() bool {
 	return p.db.Stat().TotalConns() == 0
 }
 
-func (p postgressql) deleteTransactions() error {
+func (p postgresql) deleteTransactions() error {
 	sec := timeout
 	// allow any timeout value for testing
 	if p.test || p.config.Timeout > 0 {

--- a/exporters/util/prune.go
+++ b/exporters/util/prune.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"github.com/algorand/indexer/idb"
+	"github.com/algorand/indexer/plugins"
+	"github.com/sirupsen/logrus"
+)
+
+type Interval int
+
+const (
+	once Interval = iota
+	daily
+)
+
+// PruneConfigurations a data type
+type PruneConfigurations struct {
+	Interval Interval `yaml:"interval"`
+	Rounds   uint64   `yaml:"rounds"`
+}
+
+type DataManager interface {
+	Delete(<-chan uint64)
+}
+
+type postgresDB struct {
+	configs *PruneConfigurations
+	db      idb.IndexerDb
+	logger  *logrus.Logger
+}
+
+func MakeDataManager(pc *plugins.PluginConfig, logger *logrus.Logger) DataManager {
+	db := postgresDB{
+		configs: nil,
+		db:      nil,
+		logger:  nil,
+	}
+	return db
+}
+func (p postgresDB) Delete(rnd <-chan uint64) {}

--- a/exporters/util/prune.go
+++ b/exporters/util/prune.go
@@ -1,10 +1,12 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"strings"
+	"time"
 
-	"github.com/algorand/indexer/idb"
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/sirupsen/logrus"
 )
 
@@ -22,26 +24,29 @@ type PruneConfigurations struct {
 }
 
 type DataManager interface {
-	Delete(<-chan uint64)
+	Delete(context.Context, <-chan uint64)
 }
 
 type Postgressql struct {
 	Config *PruneConfigurations
-	DB     idb.IndexerDb
+	DB     *pgxpool.Pool
 	Logger *logrus.Logger
 }
 
-func MakeDataManager(cfg *PruneConfigurations, dbname string, dataconnection string, logger *logrus.Logger) (DataManager, error) {
-	datasource := strings.Split(dataconnection, ":")[0]
+func MakeDataManager(cfg *PruneConfigurations, connection string, logger *logrus.Logger) (DataManager, error) {
+	datasource := strings.Split(connection, ":")[0]
 	if datasource == "postgres" {
-		conn, ready, err := idb.IndexerDbByName(dbname, dataconnection, idb.IndexerDbOptions{ReadOnly: false}, logger)
+		postgresConfig, err := pgxpool.ParseConfig(connection)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Couldn't parse config: %v", err)
 		}
-		<-ready
+		db, err := pgxpool.ConnectConfig(context.Background(), postgresConfig)
+		if err != nil {
+			return nil, fmt.Errorf("connecting to postgres: %v", err)
+		}
 		dm := Postgressql{
 			Config: cfg,
-			DB:     conn,
+			DB:     db,
 			Logger: logger,
 		}
 		return dm, nil
@@ -49,6 +54,54 @@ func MakeDataManager(cfg *PruneConfigurations, dbname string, dataconnection str
 		return nil, fmt.Errorf("data source %s is not supported", datasource)
 	}
 }
-func (p Postgressql) Delete(rnd <-chan uint64) {
-	fmt.Println("TO BE IMPLEMENTED")
+func (p Postgressql) Delete(ctx context.Context, rnd <-chan uint64) {
+	select {
+	case round := <-rnd:
+		p.Logger.Infof("received round %d", round)
+		p.deleteTransactions(round)
+	case <-ctx.Done():
+		p.Logger.Info("exporter closed")
+		p.DB.Close()
+	}
+}
+
+func (p Postgressql) deleteTransactions(round uint64) {
+	keep := round - p.Config.Rounds
+	prune := true
+	dbctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if p.Config.Interval != once {
+		currentTime := time.Now()
+		query := "SELECT last_pruned from metastate"
+		result, err := p.DB.Query(dbctx, query)
+		if err != nil {
+			p.Logger.Warnf("err %v", err)
+		}
+		var last_pruned time.Time
+		err = result.Scan(last_pruned)
+		if err != nil {
+			p.Logger.Warnf("err %v", err)
+		}
+		diff := currentTime.Sub(last_pruned)
+		if diff.Hours() < 24 {
+			prune = false
+		}
+	}
+	if keep > 0 && prune {
+		//	sql: DELETE FROM txn WHERE round < keep;
+		query := "DELETE FROM txn WHERE round < keep"
+		cmd, err := p.DB.Exec(dbctx, query)
+		if err != nil {
+			p.Logger.Warnf("err %v", err)
+		} else {
+			p.Logger.Infof("%d transactions deleted", cmd.RowsAffected())
+			// sql: update last_pruned
+			metastate := fmt.Sprintf("{last_pruned: %s}", time.Now())
+			query = "INSERT INTO metastate (k,v) VALUES('prune',$1) ON CONFLICT(k) DO UPDATE SET v=EXCLUDED.v"
+			_, err = p.DB.Exec(dbctx, query, metastate)
+			if err != nil {
+				p.Logger.Warnf("err %v", err)
+			}
+		}
+	}
 }

--- a/exporters/util/prune.go
+++ b/exporters/util/prune.go
@@ -65,7 +65,7 @@ func (p postgresql) Delete(wg *sync.WaitGroup) {
 	if p.config.Frequency == once {
 		_, err := p.db.DeleteTransactions(p.ctx, p.config.Rounds, time.Duration(timeout)*time.Second)
 		if err != nil {
-			p.logger.Warnf("exec: data pruning err: %v", err)
+			p.logger.Warnf("Delete(): data pruning err: %v", err)
 		}
 		return
 	} else if p.config.Frequency == daily {

--- a/exporters/util/prune.go
+++ b/exporters/util/prune.go
@@ -2,10 +2,11 @@ package util
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/sirupsen/logrus"
 )
@@ -33,16 +34,15 @@ type Postgressql struct {
 	Logger *logrus.Logger
 }
 
-func MakeDataManager(cfg *PruneConfigurations, connection string, logger *logrus.Logger) (DataManager, error) {
-	datasource := strings.Split(connection, ":")[0]
-	if datasource == "postgres" {
+func MakeDataManager(cfg *PruneConfigurations, dbname string, connection string, logger *logrus.Logger) (DataManager, error) {
+	if dbname == "postgres" {
 		postgresConfig, err := pgxpool.ParseConfig(connection)
 		if err != nil {
 			return nil, fmt.Errorf("Couldn't parse config: %v", err)
 		}
 		db, err := pgxpool.ConnectConfig(context.Background(), postgresConfig)
 		if err != nil {
-			return nil, fmt.Errorf("connecting to postgres: %v", err)
+			return nil, fmt.Errorf("connecting to postgres: %w", err)
 		}
 		dm := Postgressql{
 			Config: cfg,
@@ -51,13 +51,13 @@ func MakeDataManager(cfg *PruneConfigurations, connection string, logger *logrus
 		}
 		return dm, nil
 	} else {
-		return nil, fmt.Errorf("data source %s is not supported", datasource)
+		return nil, fmt.Errorf("data source %s is not supported", dbname)
 	}
 }
 func (p Postgressql) Delete(ctx context.Context, rnd <-chan uint64) {
 	select {
 	case round := <-rnd:
-		p.Logger.Infof("received round %d", round)
+		p.Logger.Infof("received exporter round %d", round)
 		p.deleteTransactions(round)
 	case <-ctx.Done():
 		p.Logger.Info("exporter closed")
@@ -66,42 +66,85 @@ func (p Postgressql) Delete(ctx context.Context, rnd <-chan uint64) {
 }
 
 func (p Postgressql) deleteTransactions(round uint64) {
-	keep := round - p.Config.Rounds
-	prune := true
-	dbctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if p.Config.Interval != once {
-		currentTime := time.Now()
-		query := "SELECT last_pruned from metastate"
-		result, err := p.DB.Query(dbctx, query)
-		if err != nil {
-			p.Logger.Warnf("err %v", err)
-		}
-		var last_pruned time.Time
-		err = result.Scan(last_pruned)
-		if err != nil {
-			p.Logger.Warnf("err %v", err)
-		}
-		diff := currentTime.Sub(last_pruned)
-		if diff.Hours() < 24 {
-			prune = false
-		}
+	// current exporter round < desired number of rounds to keep
+	if round < p.Config.Rounds {
+		// no data to remove
+		return
 	}
-	if keep > 0 && prune {
-		//	sql: DELETE FROM txn WHERE round < keep;
-		query := "DELETE FROM txn WHERE round < keep"
-		cmd, err := p.DB.Exec(dbctx, query)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// oldest round to keep
+	keep := round - p.Config.Rounds
+
+	// delete old txns and update metastate
+	deleteTxns := func() {
+		// start a transaction
+		tx, err := p.DB.BeginTx(ctx, pgx.TxOptions{})
 		if err != nil {
-			p.Logger.Warnf("err %v", err)
+			p.Logger.Warnf("delete transactions: %v", err)
+			return
+		}
+		defer tx.Rollback(ctx)
+		p.Logger.Infof("keeping round %d and later", keep)
+		query := "DELETE FROM txn WHERE round < $1"
+		cmd, err := tx.Exec(ctx, query, keep)
+		t := time.Now()
+		if err != nil {
+			p.Logger.Warnf("transaction delete err %v", err)
+			return
 		} else {
-			p.Logger.Infof("%d transactions deleted", cmd.RowsAffected())
-			// sql: update last_pruned
-			metastate := fmt.Sprintf("{last_pruned: %s}", time.Now())
-			query = "INSERT INTO metastate (k,v) VALUES('prune',$1) ON CONFLICT(k) DO UPDATE SET v=EXCLUDED.v"
-			_, err = p.DB.Exec(dbctx, query, metastate)
+			// format time, "2006-01-02T15:04:05Z07:00"
+			ft := t.Format(time.RFC3339)
+			p.Logger.Infof("%d transactions deleted, last pruned at %s", cmd.RowsAffected(), ft)
+			// update last_pruned
+			metastate := fmt.Sprintf("{last_pruned: %s}", ft)
+			encoded, err := json.Marshal(metastate)
 			if err != nil {
-				p.Logger.Warnf("err %v", err)
+				p.Logger.Warnf("transaction delete err %v", err)
+				return
+			}
+			query = "INSERT INTO metastate (k,v) VALUES('prune',$1) ON CONFLICT(k) DO UPDATE SET v=EXCLUDED.v"
+			_, err = tx.Exec(ctx, query, string(encoded))
+			if err != nil {
+				p.Logger.Warnf("metastate update err %v", err)
+				return
 			}
 		}
+		// Commit the transaction.
+		if err = tx.Commit(ctx); err != nil {
+			p.Logger.Warnf("delete transactions: %v", err)
+		}
 	}
+
+	if p.Config.Interval == once {
+		deleteTxns()
+	} else if p.Config.Interval == daily {
+		prune := false
+		var lastPruned time.Time
+		query := "SELECT last_pruned from metastate"
+		result, err := p.DB.Query(ctx, query)
+		if err != nil {
+			p.Logger.Warnf("err %v", err)
+		}
+		err = result.Scan(lastPruned)
+		if err == pgx.ErrNoRows {
+			// first prune
+			prune = true
+		} else if err != nil {
+			p.Logger.Warnf("err %v", err)
+		} else {
+			currentTime := time.Now()
+			diff := currentTime.Sub(lastPruned)
+			if diff.Hours() >= 24 {
+				prune = true
+			}
+		}
+		if prune {
+			deleteTxns()
+		}
+	} else {
+		p.Logger.Warnf("%s pruning interval is not supported", p.Config.Interval)
+	}
+
 }

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -1,0 +1,41 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/algorand/indexer/exporters/util"
+	"github.com/algorand/indexer/idb"
+	"github.com/algorand/indexer/idb/postgres"
+	pgtest "github.com/algorand/indexer/idb/postgres/testing"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+var logger *logrus.Logger
+
+func init() {
+	logger, _ = test.NewNullLogger()
+}
+func TestDataPruning(t *testing.T) {
+	_, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
+
+	db, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+	defer db.Close()
+	dm := makeMockedDataManager(db)
+	ch := make(chan uint64)
+	dm.Delete(ch)
+}
+
+func makeMockedDataManager(db *postgres.IndexerDb) util.DataManager {
+	return util.Postgressql{
+		Config: &util.PruneConfigurations{
+			Interval: "once",
+			Rounds:   10,
+		},
+		DB:     db,
+		Logger: nil,
+	}
+}

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -1,4 +1,4 @@
-package util_test
+package util
 
 import (
 	"context"
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/algorand/indexer/exporters/util"
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/idb/postgres"
 	pgtest "github.com/algorand/indexer/idb/postgres/testing"
@@ -24,33 +23,45 @@ func init() {
 	logger, _ = test.NewNullLogger()
 }
 
+var config = PruneConfigurations{
+	Frequency: "once",
+	Rounds:    10,
+}
+
 func TestMakeDataManager(t *testing.T) {
-	config := util.PruneConfigurations{
-		Interval: "once",
-		Rounds:   10,
-	}
 	_, connStr, shutdownFunc := pgtest.SetupPostgres(t)
 	defer shutdownFunc()
 
-	dm, err := util.MakeDataManager(&config, "postgres", connStr, logger)
+	dm, err := MakeDataManager(context.Background(), &config, "postgres", connStr, logger)
 	assert.NoError(t, err)
 	assert.NotNil(t, dm)
 }
 
-func TestDataPruning(t *testing.T) {
-	_, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+func TestDeleteEmptyTxnTable(t *testing.T) {
+	logger.SetOutput(os.Stdout)
+	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
 	defer shutdownFunc()
 
-	db, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	// init the tables
+	idb, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
-	defer db.Close()
+	idb.Close()
 
-	dm := makeMockedDataManager(nil)
-	ch := make(chan uint64)
-	ctx := context.Background()
-	dm.Delete(ctx, ch)
+	// empty txn table
+	err = populateTxnTable(db, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, rowsInTxnTable(db))
+
+	// data manager
+	dm, err := MakeDataManager(context.Background(), &config, "postgres", connStr, logger)
+	assert.NoError(t, err)
+	go dm.Delete()
+	// wait
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, 0, rowsInTxnTable(db))
 }
-func TestDelete(t *testing.T) {
+
+func TestDeleteTxns(t *testing.T) {
 	logger.SetOutput(os.Stdout)
 	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
 	defer shutdownFunc()
@@ -61,51 +72,188 @@ func TestDelete(t *testing.T) {
 	idb.Close()
 
 	// add 20 records to txn table
-	err = populateTxnTable(db)
+	err = populateTxnTable(db, 20)
 	assert.NoError(t, err)
 	assert.Equal(t, 20, rowsInTxnTable(db))
 
-	config := util.PruneConfigurations{
-		Interval: "once",
-		Rounds:   10,
-	}
 	// data manager
-	dm, err := util.MakeDataManager(&config, "postgres", connStr, logger)
+	dm, err := MakeDataManager(context.Background(), &config, "postgres", connStr, logger)
 	assert.NoError(t, err)
-	ch := make(chan uint64)
-	go dm.Delete(context.Background(), ch)
-	// ch empty, nothing happens
-	assert.Equal(t, 20, rowsInTxnTable(db))
-	// send current round
-	ch <- 20
+	go dm.Delete()
 	// wait
 	time.Sleep(1 * time.Second)
 	// 10 rounds removed
 	assert.Equal(t, 10, rowsInTxnTable(db))
 	// check remaining rounds are correct
 	assert.True(t, validateTxnTable(db, 10, 20))
-	// todo: test rollback
-	// todo: test context closed.
-	// todo: test daily
-	// todo: test timeout
-	// todo: test round < p.Config.Rounds
-	// todo: test round == p.Config.Rounds
-	close(ch)
-}
-func makeMockedDataManager(db *pgxpool.Pool) util.DataManager {
-	return util.Postgressql{
-		Config: &util.PruneConfigurations{
-			Interval: "once",
-			Rounds:   10,
-		},
-		DB:     db,
-		Logger: nil,
-	}
+	//	processor ended
+	assert.True(t, dm.Closed())
+
 }
 
-func populateTxnTable(db *pgxpool.Pool) error {
+func TestDeleteConfigs(t *testing.T) {
+	logger.SetOutput(os.Stdout)
+	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
+
+	// init the tables
+	idb, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+	idb.Close()
+
+	// add 3 record to txn table
+	err = populateTxnTable(db, 3)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, rowsInTxnTable(db))
+
+	// config.Rounds > rounds in DB
+	config = PruneConfigurations{
+		Frequency: "once",
+		Rounds:    5,
+	}
+	dm, err := MakeDataManager(context.Background(), &config, "postgres", connStr, logger)
+	assert.NoError(t, err)
+	go dm.Delete()
+	// wait
+	time.Sleep(1 * time.Second)
+	// delete didn't happen
+	assert.Equal(t, 3, rowsInTxnTable(db))
+
+	// config.Rounds == rounds in DB
+	config.Rounds = 3
+	dm, err = MakeDataManager(context.Background(), &config, "postgres", connStr, logger)
+	assert.NoError(t, err)
+	go dm.Delete()
+	// wait
+	time.Sleep(1 * time.Second)
+	// delete didn't happen
+	assert.Equal(t, 3, rowsInTxnTable(db))
+	//	processor ended
+	assert.True(t, dm.Closed())
+}
+
+func TestDeleteDaily(t *testing.T) {
+	logger.SetOutput(os.Stdout)
+	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
+
+	// init the tables
+	idb, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+	idb.Close()
+
+	// add 20 record to txn table
+	err = populateTxnTable(db, 20)
+	assert.NoError(t, err)
+	assert.Equal(t, 20, rowsInTxnTable(db))
+
+	config = PruneConfigurations{
+		Frequency: "daily",
+		Rounds:    15,
+	}
+	ctx, cf := context.WithCancel(context.Background())
+	dm, err := MakeDataManager(ctx, &config, "postgres", connStr, logger)
+	assert.NoError(t, err)
+	go dm.Delete()
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, 15, rowsInTxnTable(db))
+	// database connection stays open
+	assert.False(t, dm.Closed())
+	// cancel
+	cf()
+	// database connection should be closed
+	time.Sleep(1 * time.Second)
+	assert.True(t, dm.Closed())
+
+	//	reconnect
+	config = PruneConfigurations{
+		Frequency: "daily",
+		Rounds:    10,
+	}
+	dm, err = MakeDataManager(context.Background(), &config, "postgres", connStr, logger)
+	assert.NoError(t, err)
+	go dm.Delete()
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, 10, rowsInTxnTable(db))
+}
+
+func TestDeleteRollback(t *testing.T) {
+	logger.SetOutput(os.Stdout)
+	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
+
+	// init the tables
+	idb, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+	idb.Close()
+
+	// remove metastate table
+	_, err = db.Exec(context.Background(), "DROP TABLE metastate")
+	assert.NoError(t, err)
+
+	// add 10 record to txn table
+	err = populateTxnTable(db, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, rowsInTxnTable(db))
+
+	config = PruneConfigurations{
+		Frequency: "once",
+		Rounds:    5,
+	}
+	postgres := Postgressql{
+		Config: &config,
+		DB:     db,
+		Logger: logger,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = postgres.deleteTransactions(ctx)
+	// delete didn't happen
+	assert.Equal(t, 10, rowsInTxnTable(db))
+	// metastate update failed
+	assert.Contains(t, err.Error(), "\"metastate\" does not exist")
+
+}
+
+func TestDeleteTimeout(t *testing.T) {
+	logger.SetOutput(os.Stdout)
+	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
+
+	// init the tables
+	idb, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+	idb.Close()
+
+	// add 10 record to txn table
+	err = populateTxnTable(db, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, rowsInTxnTable(db))
+
+	config = PruneConfigurations{
+		Frequency: "once",
+		Rounds:    5,
+		Timeout:   0,
+	}
+	postgres := Postgressql{
+		Config: &config,
+		DB:     db,
+		Logger: logger,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	defer cancel()
+	err = postgres.deleteTransactions(ctx)
+	// delete didn't happen
+	assert.Equal(t, 10, rowsInTxnTable(db))
+	// context deadline exceeded
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+}
+
+func populateTxnTable(db *pgxpool.Pool, n int) error {
 	batch := &pgx.Batch{}
-	for i := 0; i < 20; i++ {
+	for i := 0; i < n; i++ {
 		query := "INSERT INTO txn(round, intra, typeenum,asset,txn,extra) VALUES ($1,$2,$3,$4,$5,$6)"
 		batch.Queue(query, i, i, 1, 0, "{}", "{}")
 	}

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -3,7 +3,6 @@ package util
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -19,9 +18,10 @@ import (
 )
 
 var logger *logrus.Logger
+var hook *test.Hook
 
 func init() {
-	logger, _ = test.NewNullLogger()
+	logger, hook = test.NewNullLogger()
 }
 
 var config = PruneConfigurations{
@@ -181,7 +181,6 @@ func TestDeleteDaily(t *testing.T) {
 }
 
 func TestDeleteRollback(t *testing.T) {
-	logger.SetOutput(os.Stdout)
 	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
 	defer shutdownFunc()
 
@@ -218,6 +217,7 @@ func TestDeleteRollback(t *testing.T) {
 	wg.Wait()
 	// delete didn't happen
 	assert.Equal(t, 10, rowsInTxnTable(db))
+	assert.Contains(t, hook.LastEntry().Message, "relation \"metastate\" does not exist")
 }
 
 func populateTxnTable(db *pgxpool.Pool, n int) error {

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -236,7 +236,7 @@ func TestDeleteRollback(t *testing.T) {
 		Frequency: "once",
 		Rounds:    5,
 	}
-	postgres := postgressql{
+	postgres := postgresql{
 		config: &config,
 		db:     db,
 		logger: logger,
@@ -274,7 +274,7 @@ func TestDeleteTimeout(t *testing.T) {
 		Rounds:    5,
 		Timeout:   0,
 	}
-	postgres := postgressql{
+	postgres := postgresql{
 		config: &config,
 		db:     db,
 		logger: logger,

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -1,12 +1,14 @@
 package util_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/algorand/indexer/exporters/util"
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/idb/postgres"
 	pgtest "github.com/algorand/indexer/idb/postgres/testing"
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -24,12 +26,13 @@ func TestDataPruning(t *testing.T) {
 	db, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 	defer db.Close()
-	dm := makeMockedDataManager(db)
+	dm := makeMockedDataManager(nil)
 	ch := make(chan uint64)
-	dm.Delete(ch)
+	ctx := context.Background()
+	dm.Delete(ctx, ch)
 }
 
-func makeMockedDataManager(db *postgres.IndexerDb) util.DataManager {
+func makeMockedDataManager(db *pgxpool.Pool) util.DataManager {
 	return util.Postgressql{
 		Config: &util.PruneConfigurations{
 			Interval: "once",

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -218,48 +218,7 @@ func TestDeleteRollback(t *testing.T) {
 	wg.Wait()
 	// delete didn't happen
 	assert.Equal(t, 10, rowsInTxnTable(db))
-	// metastate update failed
-	//assert.Contains(t, err.Error(), "\"metastate\" does not exist")
 }
-
-//
-//func TestDeleteTimeout(t *testing.T) {
-//	logger.SetOutput(os.Stdout)
-//	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
-//	defer shutdownFunc()
-//
-//	// init the tables
-//	idb, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
-//	assert.NoError(t, err)
-//	idb.Close()
-//
-//	// add 10 record to txn table
-//	err = populateTxnTable(db, 10)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 10, rowsInTxnTable(db))
-//
-//	ctx, cancel := context.WithCancel(context.Background())
-//
-//	config = PruneConfigurations{
-//		Frequency: "once",
-//		Rounds:    5,
-//		Timeout:   0,
-//	}
-//	postgres := postgresql{
-//		config: &config,
-//		db:     db,
-//		logger: logger,
-//		ctx:    ctx,
-//		cf:     cancel,
-//		test:   true,
-//	}
-//
-//	err = postgres.deleteTransactions()
-//	// delete didn't happen
-//	assert.Equal(t, 10, rowsInTxnTable(db))
-//	// context deadline exceeded
-//	assert.Contains(t, err.Error(), "context deadline exceeded")
-//}
 
 func populateTxnTable(db *pgxpool.Pool, n int) error {
 	batch := &pgx.Batch{}

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -84,7 +84,12 @@ func TestDelete(t *testing.T) {
 	assert.Equal(t, 10, rowsInTxnTable(db))
 	// check remaining rounds are correct
 	assert.True(t, validateTxnTable(db, 10, 20))
-
+	// todo: test rollback
+	// todo: test context closed.
+	// todo: test daily
+	// todo: test timeout
+	// todo: test round < p.Config.Rounds
+	// todo: test round == p.Config.Rounds
 	close(ch)
 }
 func makeMockedDataManager(db *pgxpool.Pool) util.DataManager {

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -48,7 +48,7 @@ func TestDeleteEmptyTxnTable(t *testing.T) {
 	dm := MakeDataManager(context.Background(), &config, idb, logger)
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go dm.Delete(&wg)
+	go dm.Delete(&wg, nil)
 	wg.Wait()
 	assert.Equal(t, 0, rowsInTxnTable(db))
 }
@@ -71,7 +71,7 @@ func TestDeleteTxns(t *testing.T) {
 	dm := MakeDataManager(context.Background(), &config, idb, logger)
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go dm.Delete(&wg)
+	go dm.Delete(&wg, nil)
 	wg.Wait()
 	// 10 rounds removed
 	assert.Equal(t, 10, rowsInTxnTable(db))
@@ -102,7 +102,7 @@ func TestDeleteConfigs(t *testing.T) {
 	assert.NoError(t, err)
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go dm.Delete(&wg)
+	go dm.Delete(&wg, nil)
 	wg.Wait()
 	// delete didn't happen
 	assert.Equal(t, 3, rowsInTxnTable(db))
@@ -112,7 +112,7 @@ func TestDeleteConfigs(t *testing.T) {
 	dm = MakeDataManager(context.Background(), &config, idb, logger)
 	assert.NoError(t, err)
 	wg.Add(1)
-	go dm.Delete(&wg)
+	go dm.Delete(&wg, nil)
 	wg.Wait()
 	// delete didn't happen
 	assert.Equal(t, 3, rowsInTxnTable(db))
@@ -125,7 +125,7 @@ func TestDeleteConfigs(t *testing.T) {
 	dm = MakeDataManager(context.Background(), &config, idb, logger)
 	assert.NoError(t, err)
 	wg.Add(1)
-	go dm.Delete(&wg)
+	go dm.Delete(&wg, nil)
 	wg.Wait()
 	// delete didn't happen
 	assert.Equal(t, 3, rowsInTxnTable(db))
@@ -154,7 +154,7 @@ func TestDeleteDaily(t *testing.T) {
 	dm := MakeDataManager(ctx, &config, idb, logger)
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go dm.Delete(&wg)
+	go dm.Delete(&wg, nil)
 	go func() {
 		time.Sleep(1 * time.Second)
 		cancel()
@@ -171,7 +171,7 @@ func TestDeleteDaily(t *testing.T) {
 	ctx, cancel = context.WithCancel(context.Background())
 	dm = MakeDataManager(ctx, &config, idb, logger)
 	wg.Add(1)
-	go dm.Delete(&wg)
+	go dm.Delete(&wg, nil)
 	go func() {
 		time.Sleep(1 * time.Second)
 		cancel()
@@ -204,13 +204,14 @@ func TestDeleteRollback(t *testing.T) {
 	config = PruneConfigurations{
 		Frequency: "once",
 		Rounds:    5,
-		Timeout:   0,
 	}
 
+	errChan := make(chan error)
 	dm := MakeDataManager(ctx, &config, idb, logger)
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go dm.Delete(&wg)
+	go dm.Delete(&wg, errChan)
+	err = <-errChan
 	go func() {
 		time.Sleep(1 * time.Second)
 		cancel()
@@ -218,48 +219,8 @@ func TestDeleteRollback(t *testing.T) {
 	wg.Wait()
 	// delete didn't happen
 	assert.Equal(t, 10, rowsInTxnTable(db))
-	// metastate update failed
-	//assert.Contains(t, err.Error(), "\"metastate\" does not exist")
+	assert.Contains(t, err.Error(), "relation \"metastate\" does not exist")
 }
-
-//
-//func TestDeleteTimeout(t *testing.T) {
-//	logger.SetOutput(os.Stdout)
-//	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
-//	defer shutdownFunc()
-//
-//	// init the tables
-//	idb, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
-//	assert.NoError(t, err)
-//	idb.Close()
-//
-//	// add 10 record to txn table
-//	err = populateTxnTable(db, 10)
-//	assert.NoError(t, err)
-//	assert.Equal(t, 10, rowsInTxnTable(db))
-//
-//	ctx, cancel := context.WithCancel(context.Background())
-//
-//	config = PruneConfigurations{
-//		Frequency: "once",
-//		Rounds:    5,
-//		Timeout:   0,
-//	}
-//	postgres := postgresql{
-//		config: &config,
-//		db:     db,
-//		logger: logger,
-//		ctx:    ctx,
-//		cf:     cancel,
-//		test:   true,
-//	}
-//
-//	err = postgres.deleteTransactions()
-//	// delete didn't happen
-//	assert.Equal(t, 10, rowsInTxnTable(db))
-//	// context deadline exceeded
-//	assert.Contains(t, err.Error(), "context deadline exceeded")
-//}
 
 func populateTxnTable(db *pgxpool.Pool, n int) error {
 	batch := &pgx.Batch{}

--- a/exporters/util/prune_test.go
+++ b/exporters/util/prune_test.go
@@ -2,12 +2,16 @@ package util_test
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/algorand/indexer/exporters/util"
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/idb/postgres"
 	pgtest "github.com/algorand/indexer/idb/postgres/testing"
+	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -19,6 +23,20 @@ var logger *logrus.Logger
 func init() {
 	logger, _ = test.NewNullLogger()
 }
+
+func TestMakeDataManager(t *testing.T) {
+	config := util.PruneConfigurations{
+		Interval: "once",
+		Rounds:   10,
+	}
+	_, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
+
+	dm, err := util.MakeDataManager(&config, "postgres", connStr, logger)
+	assert.NoError(t, err)
+	assert.NotNil(t, dm)
+}
+
 func TestDataPruning(t *testing.T) {
 	_, connStr, shutdownFunc := pgtest.SetupPostgres(t)
 	defer shutdownFunc()
@@ -26,12 +44,49 @@ func TestDataPruning(t *testing.T) {
 	db, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	assert.NoError(t, err)
 	defer db.Close()
+
 	dm := makeMockedDataManager(nil)
 	ch := make(chan uint64)
 	ctx := context.Background()
 	dm.Delete(ctx, ch)
 }
+func TestDelete(t *testing.T) {
+	logger.SetOutput(os.Stdout)
+	db, connStr, shutdownFunc := pgtest.SetupPostgres(t)
+	defer shutdownFunc()
 
+	// init the tables
+	idb, _, err := postgres.OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
+	assert.NoError(t, err)
+	idb.Close()
+
+	// add 20 records to txn table
+	err = populateTxnTable(db)
+	assert.NoError(t, err)
+	assert.Equal(t, 20, rowsInTxnTable(db))
+
+	config := util.PruneConfigurations{
+		Interval: "once",
+		Rounds:   10,
+	}
+	// data manager
+	dm, err := util.MakeDataManager(&config, "postgres", connStr, logger)
+	assert.NoError(t, err)
+	ch := make(chan uint64)
+	go dm.Delete(context.Background(), ch)
+	// ch empty, nothing happens
+	assert.Equal(t, 20, rowsInTxnTable(db))
+	// send current round
+	ch <- 20
+	// wait
+	time.Sleep(1 * time.Second)
+	// 10 rounds removed
+	assert.Equal(t, 10, rowsInTxnTable(db))
+	// check remaining rounds are correct
+	assert.True(t, validateTxnTable(db, 10, 20))
+
+	close(ch)
+}
 func makeMockedDataManager(db *pgxpool.Pool) util.DataManager {
 	return util.Postgressql{
 		Config: &util.PruneConfigurations{
@@ -41,4 +96,58 @@ func makeMockedDataManager(db *pgxpool.Pool) util.DataManager {
 		DB:     db,
 		Logger: nil,
 	}
+}
+
+func populateTxnTable(db *pgxpool.Pool) error {
+	batch := &pgx.Batch{}
+	for i := 0; i < 20; i++ {
+		query := "INSERT INTO txn(round, intra, typeenum,asset,txn,extra) VALUES ($1,$2,$3,$4,$5,$6)"
+		batch.Queue(query, i, i, 1, 0, "{}", "{}")
+	}
+	results := db.SendBatch(context.Background(), batch)
+	defer results.Close()
+	for i := 0; i < batch.Len(); i++ {
+		_, err := results.Exec()
+		if err != nil {
+			return fmt.Errorf("populateTxnTable() exec err: %w", err)
+		}
+	}
+	return nil
+}
+
+func rowsInTxnTable(db *pgxpool.Pool) int {
+	var rows int
+	r, err := db.Query(context.Background(), "SELECT count(*) FROM txn")
+	if err != nil {
+		return 0
+	}
+	defer r.Close()
+	for r.Next() {
+		err = r.Scan(&rows)
+		if err != nil {
+			return 0
+		}
+	}
+	return rows
+}
+
+func validateTxnTable(db *pgxpool.Pool, first, last uint64) bool {
+	res, err := db.Query(context.Background(), "SELECT round FROM txn")
+	if err != nil {
+		return false
+	}
+	defer res.Close()
+	var round uint64
+	// expected round
+	expected := first
+	next := first + 1
+	for res.Next() {
+		err = res.Scan(&round)
+		if err != nil || round != expected {
+			return false
+		}
+		expected = next
+		next++
+	}
+	return expected == last
 }

--- a/idb/dummy/dummy.go
+++ b/idb/dummy/dummy.go
@@ -2,6 +2,8 @@ package dummy
 
 import (
 	"context"
+	"time"
+
 	"github.com/algorand/go-algorand/crypto"
 
 	"github.com/algorand/go-algorand/data/bookkeeping"
@@ -97,4 +99,9 @@ func (db *dummyIndexerDb) GetNetworkState() (state idb.NetworkState, err error) 
 // SetNetworkState is part of idb.IndexerDB
 func (db *dummyIndexerDb) SetNetworkState(genesis bookkeeping.Genesis) error {
 	return nil
+}
+
+// SetNetworkState is part of idb.IndexerDB
+func (db *dummyIndexerDb) DeleteTransactions(ctx context.Context, keep uint64, timeout time.Duration) (int64, error) {
+	return 0, nil
 }

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -184,6 +184,8 @@ type IndexerDb interface {
 	AppLocalState(ctx context.Context, filter ApplicationQuery) (<-chan AppLocalStateRow, uint64)
 
 	Health(ctx context.Context) (status Health, err error)
+
+	DeleteTransactions(ctx context.Context, keep uint64, timeout time.Duration) (int64, error)
 }
 
 // GetBlockOptions contains the options when requesting to load a block from the database.

--- a/idb/mocks/IndexerDb.go
+++ b/idb/mocks/IndexerDb.go
@@ -15,6 +15,8 @@ import (
 
 	testing "testing"
 
+	time "time"
+
 	transactions "github.com/algorand/go-algorand/data/transactions"
 )
 
@@ -132,6 +134,27 @@ func (_m *IndexerDb) Assets(ctx context.Context, filter idb.AssetsQuery) (<-chan
 // Close provides a mock function with given fields:
 func (_m *IndexerDb) Close() {
 	_m.Called()
+}
+
+// DeleteTransactions provides a mock function with given fields: ctx, keep, timeout
+func (_m *IndexerDb) DeleteTransactions(ctx context.Context, keep uint64, timeout time.Duration) (int64, error) {
+	ret := _m.Called(ctx, keep, timeout)
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, time.Duration) int64); ok {
+		r0 = rf(ctx, keep, timeout)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, time.Duration) error); ok {
+		r1 = rf(ctx, keep, timeout)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // GetAccounts provides a mock function with given fields: ctx, opts

--- a/idb/postgres/internal/encoding/encoding.go
+++ b/idb/postgres/internal/encoding/encoding.go
@@ -749,7 +749,7 @@ func DecodeDeleteStatus(data []byte) (types.DeleteStatus, error) {
 	var status types.DeleteStatus
 	err := DecodeJSON(data, &status)
 	if err != nil {
-		return types.DeleteStatus{}, fmt.Errorf("DecodePruned() err: %w", err)
+		return types.DeleteStatus{}, fmt.Errorf("DecodeDeleteStatus() err: %w", err)
 	}
 
 	return status, nil

--- a/idb/postgres/internal/encoding/encoding.go
+++ b/idb/postgres/internal/encoding/encoding.go
@@ -738,3 +738,19 @@ func DecodeTrimmedLcAccountData(data []byte) (ledgercore.AccountData, error) {
 
 	return unconvertTrimmedLcAccountData(ba), nil
 }
+
+// EncodeDeleteStatus encodes network metastate into json.
+func EncodeDeleteStatus(p *types.DeleteStatus) []byte {
+	return encodeJSON(p)
+}
+
+// DecodeDeleteStatus decodes network metastate from json.
+func DecodeDeleteStatus(data []byte) (types.DeleteStatus, error) {
+	var status types.DeleteStatus
+	err := DecodeJSON(data, &status)
+	if err != nil {
+		return types.DeleteStatus{}, fmt.Errorf("DecodePruned() err: %w", err)
+	}
+
+	return status, nil
+}

--- a/idb/postgres/internal/schema/metastate.go
+++ b/idb/postgres/internal/schema/metastate.go
@@ -7,4 +7,5 @@ const (
 	SpecialAccountsMetastateKey = "accounts"
 	AccountTotals               = "totals"
 	NetworkMetaStateKey         = "network"
+	DeleteStatusKey             = "pruned"
 )

--- a/idb/postgres/internal/types/types.go
+++ b/idb/postgres/internal/types/types.go
@@ -1,6 +1,8 @@
 package types
 
-import "github.com/algorand/go-algorand/crypto"
+import (
+	"github.com/algorand/go-algorand/crypto"
+)
 
 // ImportState encodes an import round counter.
 type ImportState struct {
@@ -25,4 +27,10 @@ type MigrationState struct {
 // NetworkState encodes network metastate.
 type NetworkState struct {
 	GenesisHash crypto.Digest `codec:"genesis-hash"`
+}
+
+// DeleteStatus encodes pruned metastate.
+type DeleteStatus struct {
+	LastPruned  string `codec:"last_pruned"`
+	OldestRound uint64 `codec:"oldest_txn_round"`
 }

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -2556,9 +2556,8 @@ func (db *IndexerDb) DeleteTransactions(ctx context.Context, keep uint64, timeou
 		return cmd.RowsAffected(), nil
 	}
 	// retry
-	var rows int64
 	for i := 1; i <= 3; i++ {
-		rows, err = deleteTxns()
+		rows, err := deleteTxns()
 		if err == nil {
 			return rows, nil
 		}

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -2497,6 +2497,7 @@ func (db *IndexerDb) SetNetworkState(genesis bookkeeping.Genesis) error {
 }
 
 // DeleteTransactions removes old transactions
+// keep is the number of rounds to keep in db
 func (db *IndexerDb) DeleteTransactions(ctx context.Context, keep uint64, timeout time.Duration) (int64, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -2533,7 +2534,7 @@ func (db *IndexerDb) DeleteTransactions(ctx context.Context, keep uint64, timeou
 		if err2 != nil {
 			return 0, fmt.Errorf("deleteTxns(): transaction delete err %w", err2)
 		}
-		t := time.Now()
+		t := time.Now().UTC()
 		// update metastate
 		status := types.DeleteStatus{
 			// format time, "2006-01-02T15:04:05Z07:00"
@@ -2543,7 +2544,7 @@ func (db *IndexerDb) DeleteTransactions(ctx context.Context, keep uint64, timeou
 		if err2 != nil {
 			return 0, fmt.Errorf("deleteTxns(): transaction delete err %w", err2)
 		}
-		err2 = db.setMetastate(tx, "pruned", string(encoding.EncodeDeleteStatus(&status)))
+		err2 = db.setMetastate(tx, schema.DeleteStatusKey, string(encoding.EncodeDeleteStatus(&status)))
 		if err2 != nil {
 			return 0, fmt.Errorf("deleteTxns(): metastate update err %w", err2)
 		}

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -7,6 +7,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -2494,4 +2495,73 @@ func (db *IndexerDb) SetNetworkState(genesis bookkeeping.Genesis) error {
 		GenesisHash: crypto.HashObj(genesis),
 	}
 	return db.setNetworkState(nil, &networkState)
+}
+
+// DeleteTransactions removes old transactions
+func (db *IndexerDb) DeleteTransactions(ctx context.Context, keep uint64, timeout time.Duration) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	// get max round in db
+	var maxround uint64
+	query := "SELECT round FROM txn ORDER BY round DESC LIMIT 1"
+	err := db.db.QueryRow(ctx, query).Scan(&maxround)
+	if err != nil {
+		return 0, fmt.Errorf("DeleteTransactions(): %v", err)
+	}
+	db.log.Infof("max round in database %d", maxround)
+	// max round < desired number of rounds to keep
+	if maxround < keep {
+		// no data to remove
+		return 0, nil
+	}
+
+	// oldest round to keep
+	oldestRound := maxround - keep + 1
+
+	// delete old transactions and update metastate
+	deleteTxns := func() (int64, error) {
+		// start a transaction
+		tx, err2 := db.db.BeginTx(ctx, pgx.TxOptions{})
+		if err2 != nil {
+			return 0, fmt.Errorf("deleteTxns(): %w", err2)
+		}
+		defer tx.Rollback(ctx)
+
+		db.log.Infof("deleteTxns(): keeping round %d and later", oldestRound)
+		// delete query
+		query = "DELETE FROM txn WHERE round < $1"
+		cmd, err2 := tx.Exec(ctx, query, oldestRound)
+		if err2 != nil {
+			return 0, fmt.Errorf("deleteTxns(): transaction delete err %w", err2)
+		}
+		t := time.Now()
+		// update last_pruned in metastate
+		// format time, "2006-01-02T15:04:05Z07:00"
+		ft := t.Format(time.RFC3339)
+		metastate := fmt.Sprintf("{last_pruned: %s}", ft)
+		encoded, err2 := json.Marshal(metastate)
+		if err2 != nil {
+			return 0, fmt.Errorf("deleteTxns(): transaction delete err %w", err2)
+		}
+		query = "INSERT INTO metastate (k,v) VALUES('prune',$1) ON CONFLICT(k) DO UPDATE SET v=EXCLUDED.v"
+		_, err2 = tx.Exec(ctx, query, string(encoded))
+		if err2 != nil {
+			return 0, fmt.Errorf("deleteTxns(): metastate update err %w", err2)
+		}
+		// commit the transaction.
+		if err = tx.Commit(ctx); err2 != nil {
+			return 0, fmt.Errorf("deleteTxns(): delete transactions: %w", err2)
+		}
+		db.log.Infof("%d transactions deleted, last pruned at %s", cmd.RowsAffected(), ft)
+		return cmd.RowsAffected(), nil
+	}
+	// retry
+	for i := 1; i <= 3; i++ {
+		rows, err := deleteTxns()
+		if err == nil {
+			return rows, nil
+		}
+		db.log.Infof("data pruning retry %d", i)
+	}
+	return 0, err
 }

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -2556,8 +2556,9 @@ func (db *IndexerDb) DeleteTransactions(ctx context.Context, keep uint64, timeou
 		return cmd.RowsAffected(), nil
 	}
 	// retry
+	var rows int64
 	for i := 1; i <= 3; i++ {
-		rows, err := deleteTxns()
+		rows, err = deleteTxns()
 		if err == nil {
 			return rows, nil
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Adding an option for postgresql exporter to discard old transaction data by round.

## Test Plan

Adding new tests, run indexer for multiple days to validate data are removed correctly for the recurring option.
