### PR TITLE
Conduit: filereader / filewriter plugins and compatibility changes.

### DIFF
--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -375,11 +375,11 @@ func makeConduitConfig(dCfg *daemonConfig) conduit.PipelineConfig {
 			{
 				Name: "block_evaluator",
 				Config: map[string]interface{}{
-					"catchpoint":       dCfg.catchpoint,
-					"indexer-data-dir": dCfg.indexerDataDir,
-					"algod-data-dir":   dCfg.algodDataDir,
-					"algod-token":      dCfg.algodToken,
-					"algod-addr":       dCfg.algodAddr,
+					"catchpoint":     dCfg.catchpoint,
+					"data-dir":       dCfg.indexerDataDir,
+					"algod-data-dir": dCfg.algodDataDir,
+					"algod-token":    dCfg.algodToken,
+					"algod-addr":     dCfg.algodAddr,
 				},
 			},
 		},

--- a/cmd/conduit/conduit.yml.example
+++ b/cmd/conduit/conduit.yml.example
@@ -18,3 +18,4 @@ Exporter:
     Name: filewriter
     Config:
       - block-dir: "path where data should be written"
+      - exclude-state-delta: true

--- a/cmd/conduit/conduit.yml.example
+++ b/cmd/conduit/conduit.yml.example
@@ -18,4 +18,3 @@ Exporter:
     Name: filewriter
     Config:
       - block-dir: "path where data should be written"
-      - exclude-state-delta: true

--- a/conduit/pipeline.go
+++ b/conduit/pipeline.go
@@ -263,6 +263,8 @@ func (p *pipelineImpl) Init() error {
 		if err != nil {
 			return fmt.Errorf("Pipeline.Start(): could not serialize Processors[%d].Config : %w", idx, err)
 		}
+		fmt.Println("CONFIG")
+		fmt.Println(string(configs))
 		err := (*processor).Init(p.ctx, *p.initProvider, plugins.PluginConfig(configs), processorLogger)
 		processorName := (*processor).Metadata().Name()
 		if err != nil {

--- a/conduit/pipeline.go
+++ b/conduit/pipeline.go
@@ -263,8 +263,6 @@ func (p *pipelineImpl) Init() error {
 		if err != nil {
 			return fmt.Errorf("Pipeline.Start(): could not serialize Processors[%d].Config : %w", idx, err)
 		}
-		fmt.Println("CONFIG")
-		fmt.Println(string(configs))
 		err := (*processor).Init(p.ctx, *p.initProvider, plugins.PluginConfig(configs), processorLogger)
 		processorName := (*processor).Metadata().Name()
 		if err != nil {

--- a/data/block_export_data.go
+++ b/data/block_export_data.go
@@ -26,16 +26,16 @@ type InitProvider interface {
 type BlockData struct {
 
 	// BlockHeader is the immutable header from the block
-	BlockHeader bookkeeping.BlockHeader `json:"block"`
+	BlockHeader bookkeeping.BlockHeader `json:"block,omitempty"`
 
 	// Payset is the set of data the block is carrying--can be modified as it is processed
-	Payset []transactions.SignedTxnInBlock `json:"payset"`
+	Payset []transactions.SignedTxnInBlock `json:"payset,omitempty"`
 
 	// Delta contains a list of account changes resulting from the block. Processor plugins may have modify this data.
-	Delta *ledgercore.StateDelta `json:"delta"`
+	Delta *ledgercore.StateDelta `json:"delta,omitempty"`
 
 	// Certificate contains voting data that certifies the block. The certificate is non deterministic, a node stops collecting votes once the voting threshold is reached.
-	Certificate *agreement.Certificate `json:"cert"`
+	Certificate *agreement.Certificate `json:"cert,omitempty"`
 }
 
 // MakeBlockDataFromValidatedBlock makes BlockData from agreement.ValidatedBlock

--- a/data/block_export_data.go
+++ b/data/block_export_data.go
@@ -26,16 +26,16 @@ type InitProvider interface {
 type BlockData struct {
 
 	// BlockHeader is the immutable header from the block
-	BlockHeader bookkeeping.BlockHeader
+	BlockHeader bookkeeping.BlockHeader `json:"block"`
 
 	// Payset is the set of data the block is carrying--can be modified as it is processed
-	Payset []transactions.SignedTxnInBlock
+	Payset []transactions.SignedTxnInBlock `json:"payset"`
 
 	// Delta contains a list of account changes resulting from the block. Processor plugins may have modify this data.
-	Delta *ledgercore.StateDelta
+	Delta *ledgercore.StateDelta `json:"delta"`
 
 	// Certificate contains voting data that certifies the block. The certificate is non deterministic, a node stops collecting votes once the voting threshold is reached.
-	Certificate *agreement.Certificate
+	Certificate *agreement.Certificate `json:"cert"`
 }
 
 // MakeBlockDataFromValidatedBlock makes BlockData from agreement.ValidatedBlock

--- a/docs/conduit/Configuration.md
+++ b/docs/conduit/Configuration.md
@@ -38,5 +38,5 @@ exporter:
 
 ## Plugin configuration
 
-See [plugins/home.md](plugins/home.md) for details.
+See [plugin list](plugins/home.md) for details.
 Each plugin is identified by a `name`, and provided the `config` during initialization.

--- a/docs/conduit/plugins/block_evaluator.md
+++ b/docs/conduit/plugins/block_evaluator.md
@@ -29,7 +29,7 @@ For example, if you want to get **Mainnet** round `22212765`, you would refer to
 processors:
   - name: block_evaluator
     config:
-      - indexer-data-dir: "location where the local ledger will be stored."
+      - data-dir: "location where the local ledger will be stored."
         algod-data-dir: "local algod data directory"
         algod-addr: "algod URL"
         algod-token: "algod token"

--- a/docs/conduit/plugins/file_writer.md
+++ b/docs/conduit/plugins/file_writer.md
@@ -7,8 +7,12 @@ Data is written to one file per block in JSON format.
 # Config
 ```yaml
 exporter:
-  - name: filewriter
+  - name: file_writer
     config:
       - block-dir: "path to write block data"
+        # override the filename pattern.
+        filename-pattern: "%[1]d_block.json"
+        # exclude the vote certificate from the file.
+        drop-certificate: false
 ```
 

--- a/docs/conduit/plugins/home.md
+++ b/docs/conduit/plugins/home.md
@@ -5,6 +5,7 @@ Each plugin is identified by a `name`, and provided the `config` during initiali
 ## Importers
 
 * [algod](algod.md)
+* [file_reader](file_reader.md)
 
 ## Processors
 * [block_evaluator](block_evaluator.md)
@@ -12,7 +13,7 @@ Each plugin is identified by a `name`, and provided the `config` during initiali
 * [noop_processor](noop_processor.md)
 
 ## Exporters
-* [filewriter](filewriter.md)
+* [file_writer](file_writer.md)
 * [postgresql](postgresql.md)
 * [noop_exporter](noop_exporter.md)
 

--- a/e2e_tests/src/e2e_conduit/fixtures/processors/block_evaluator.py
+++ b/e2e_tests/src/e2e_conduit/fixtures/processors/block_evaluator.py
@@ -33,7 +33,7 @@ class BlockEvaluator(PluginFixture):
     def resolve_config_input(self):
         self.config_input = {
             "catchpoint": self.catchpoint,
-            "indexer-data-dir": self.indexer_data_dir,
+            "data-dir": self.indexer_data_dir,
             "algod-data-dir": self.algod_data_dir,
             "algod-token": self.algod_token,
             "algod-addr": self.algod_net,

--- a/e2e_tests/src/e2e_conduit/fixtures/processors/block_evaluator.py
+++ b/e2e_tests/src/e2e_conduit/fixtures/processors/block_evaluator.py
@@ -33,7 +33,7 @@ class BlockEvaluator(PluginFixture):
     def resolve_config_input(self):
         self.config_input = {
             "catchpoint": self.catchpoint,
-            "data-dir": self.indexer_data_dir,
+            "indexer-data-dir": self.indexer_data_dir,
             "algod-data-dir": self.algod_data_dir,
             "algod-token": self.algod_token,
             "algod-addr": self.algod_net,

--- a/e2e_tests/src/e2e_indexer/e2elive.py
+++ b/e2e_tests/src/e2e_indexer/e2elive.py
@@ -138,11 +138,12 @@ def main():
     psqlstring = ensure_test_db(args.connection_string, args.keep_temps)
     algoddir = os.path.join(tempnet, "Primary")
     aiport = args.indexer_port or random.randint(4000, 30000)
+    indexerdir = os.path.join(tempdir, "indexer_data_dir")
     cmd = [
         indexer_bin,
         "daemon",
         "--data-dir",
-        tempdir,
+        indexerdir,
         "-P",
         psqlstring,
         "--dev-mode",

--- a/exporters/filewriter/file_exporter.go
+++ b/exporters/filewriter/file_exporter.go
@@ -18,6 +18,7 @@ import (
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/exporters"
 	"github.com/algorand/indexer/plugins"
+	"github.com/algorand/indexer/util"
 )
 
 const (
@@ -59,19 +60,6 @@ func (c *Constructor) New() exporters.Exporter {
 
 func (exp *fileExporter) Metadata() exporters.ExporterMetadata {
 	return fileExporterMetadata
-}
-
-func encode(filename string, v interface{}, pretty bool) error {
-	file, err := os.Create(filename)
-	if err != nil {
-		return fmt.Errorf("encodeMetadataToFile(): failed to create temp metadata file: %w", err)
-	}
-	defer file.Close()
-	enc := json.NewEncoder(file)
-	if pretty {
-		enc.SetIndent("", "  ")
-	}
-	return enc.Encode(v)
 }
 
 func (exp *fileExporter) Init(cfg plugins.PluginConfig, logger *logrus.Logger) error {
@@ -136,7 +124,7 @@ func (exp *fileExporter) Config() plugins.PluginConfig {
 
 func (exp *fileExporter) encodeMetadataToFile() error {
 	tempFilename := fmt.Sprintf("%s.temp", exp.blockMetadataFile)
-	err := encode(tempFilename, exp.blockMetadata, true)
+	err := util.EncodeToFile(tempFilename, exp.blockMetadata, true)
 	if err != nil {
 		return fmt.Errorf("encodeMetadataToFile(): failed to write temp metadata: %w", err)
 	}
@@ -202,7 +190,7 @@ func (exp *fileExporter) HandleGenesis(genesis bookkeeping.Genesis) error {
 		}
 
 		genesisFilename := path.Join(exp.cfg.BlocksDir, "genesis.json")
-		if err := encode(genesisFilename, genesis, true); err != nil {
+		if err := util.EncodeToFile(genesisFilename, genesis, true); err != nil {
 			return fmt.Errorf("HandleGenesis() failed to serialize genesis file: %w", err)
 		}
 	} else {

--- a/exporters/filewriter/file_exporter.go
+++ b/exporters/filewriter/file_exporter.go
@@ -31,7 +31,7 @@ type fileExporter struct {
 	round             uint64
 	blockMetadataFile string
 	blockMetadata     BlockMetaData
-	cfg               ExporterConfig
+	cfg               Config
 	logger            *logrus.Logger
 }
 
@@ -152,6 +152,10 @@ func (exp *fileExporter) Receive(exportData data.BlockData) error {
 
 	// write block to file
 	{
+		if exp.cfg.DropCertificate {
+			exportData.Certificate = nil
+		}
+
 		blockFile := path.Join(exp.cfg.BlocksDir, fmt.Sprintf(exp.cfg.FilenamePattern, exportData.Round()))
 		file, err := os.OpenFile(blockFile, os.O_WRONLY|os.O_CREATE, 0755)
 		if err != nil {
@@ -205,8 +209,8 @@ func (exp *fileExporter) Round() uint64 {
 	return exp.round
 }
 
-func unmarshalConfig(cfg string) (ExporterConfig, error) {
-	var config ExporterConfig
+func unmarshalConfig(cfg string) (Config, error) {
+	var config Config
 	err := yaml.Unmarshal([]byte(cfg), &config)
 	return config, err
 }

--- a/exporters/filewriter/file_exporter_config.go
+++ b/exporters/filewriter/file_exporter_config.go
@@ -5,4 +5,6 @@ type ExporterConfig struct {
 	// BlocksDir is the path to a directory where block data should be stored.
 	// The directory is created if it doesn't exist.
 	BlocksDir string `yaml:"block-dir"`
+	// FilenamePattern is the format used to write block files.
+	FilenamePattern string `yaml:"filename-pattern"`
 }

--- a/exporters/filewriter/file_exporter_config.go
+++ b/exporters/filewriter/file_exporter_config.go
@@ -5,6 +5,6 @@ type ExporterConfig struct {
 	// BlocksDir is the path to a directory where block data should be stored.
 	// The directory is created if it doesn't exist.
 	BlocksDir string `yaml:"block-dir"`
-	// FilenamePattern is the format used to write block files.
+	// FilenamePattern is the format used to write block files. It uses go string formatting and should accept one number for the round.
 	FilenamePattern string `yaml:"filename-pattern"`
 }

--- a/exporters/filewriter/file_exporter_config.go
+++ b/exporters/filewriter/file_exporter_config.go
@@ -1,10 +1,12 @@
 package filewriter
 
-// ExporterConfig specific to the file exporter
-type ExporterConfig struct {
+// Config specific to the file exporter
+type Config struct {
 	// BlocksDir is the path to a directory where block data should be stored.
 	// The directory is created if it doesn't exist.
 	BlocksDir string `yaml:"block-dir"`
 	// FilenamePattern is the format used to write block files. It uses go string formatting and should accept one number for the round.
 	FilenamePattern string `yaml:"filename-pattern"`
+	// DropCertificate is used to remove the vote certificate from the block data before writing files.
+	DropCertificate bool `yaml:"drop-certificate"`
 }

--- a/exporters/filewriter/file_exporter_config.go
+++ b/exporters/filewriter/file_exporter_config.go
@@ -12,4 +12,10 @@ type Config struct {
 	FilenamePattern string `yaml:"filename-pattern"`
 	// DropCertificate is used to remove the vote certificate from the block data before writing files.
 	DropCertificate bool `yaml:"drop-certificate"`
+
+	// TODO: compression level - Default, Fastest, Best compression, etc
+
+	// TODO: How to avoid having millions of files in a directory?
+	//       Write batches of blocks to a single file?
+	//       Tree of directories
 }

--- a/exporters/filewriter/file_exporter_config.go
+++ b/exporters/filewriter/file_exporter_config.go
@@ -5,6 +5,4 @@ type ExporterConfig struct {
 	// BlocksDir is the path to a directory where block data should be stored.
 	// The directory is created if it doesn't exist.
 	BlocksDir string `yaml:"block-dir"`
-	// ExcludeStateDelta indicates that the state delta file for each round should not be written.
-	ExcludeStateDelta bool `yaml:"exclude-state-delta"`
 }

--- a/exporters/filewriter/file_exporter_config.go
+++ b/exporters/filewriter/file_exporter_config.go
@@ -2,8 +2,9 @@ package filewriter
 
 // ExporterConfig specific to the file exporter
 type ExporterConfig struct {
-	// full file path to a directory
-	// where the block data should be stored.
-	// Create if directory doesn't exist
+	// BlocksDir is the path to a directory where block data should be stored.
+	// The directory is created if it doesn't exist.
 	BlocksDir string `yaml:"block-dir"`
+	// ExcludeStateDelta indicates that the state delta file for each round should not be written.
+	ExcludeStateDelta bool `yaml:"exclude-state-delta"`
 }

--- a/exporters/filewriter/file_exporter_config.go
+++ b/exporters/filewriter/file_exporter_config.go
@@ -5,7 +5,10 @@ type Config struct {
 	// BlocksDir is the path to a directory where block data should be stored.
 	// The directory is created if it doesn't exist.
 	BlocksDir string `yaml:"block-dir"`
-	// FilenamePattern is the format used to write block files. It uses go string formatting and should accept one number for the round.
+	// FilenamePattern is the format used to write block files. It uses go
+	// string formatting and should accept one number for the round.
+	// If the file has a '.gz' extension, blocks will be gzipped.
+	// Default: "%[1]d_block.json"
 	FilenamePattern string `yaml:"filename-pattern"`
 	// DropCertificate is used to remove the vote certificate from the block data before writing files.
 	DropCertificate bool `yaml:"drop-certificate"`

--- a/exporters/filewriter/file_exporter_test.go
+++ b/exporters/filewriter/file_exporter_test.go
@@ -286,11 +286,10 @@ func TestDropCertificate(t *testing.T) {
 	// block data is valid
 	for i := 0; i < numRounds; i++ {
 		filename := fmt.Sprintf(FilePattern, i)
-		path := fmt.Sprintf("%s/blocks/%s", tempdir, filename)
+		path := fmt.Sprintf("%s/%s", tempdir, filename)
 		assert.FileExists(t, path)
-		b, _ := os.ReadFile(path)
 		var blockData data.BlockData
-		err := json.Unmarshal(b, &blockData)
+		err := util.DecodeFromFile(path, &blockData)
 		assert.NoError(t, err)
 		assert.Nil(t, blockData.Certificate)
 	}

--- a/exporters/filewriter/file_exporter_test.go
+++ b/exporters/filewriter/file_exporter_test.go
@@ -3,14 +3,13 @@ package filewriter
 import (
 	"context"
 	"fmt"
-	"github.com/algorand/indexer/util"
-	"gopkg.in/yaml.v3"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/data/basics"
@@ -20,6 +19,7 @@ import (
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/exporters"
 	"github.com/algorand/indexer/plugins"
+	"github.com/algorand/indexer/util"
 	testutil "github.com/algorand/indexer/util/test"
 )
 

--- a/exporters/filewriter/file_exporter_test.go
+++ b/exporters/filewriter/file_exporter_test.go
@@ -91,15 +91,32 @@ func TestExporterHandleGenesis(t *testing.T) {
 	err := fileExp.HandleGenesis(genesisA)
 	fileExp.Close()
 	assert.NoError(t, err)
-	metadataFile := fmt.Sprintf("%s/blocks/metadata.json", tempdir)
-	require.FileExists(t, metadataFile)
-	configs, err := ioutil.ReadFile(metadataFile)
-	assert.NoError(t, err)
-	var blockMetaData filewriter.BlockMetaData
-	err = json.Unmarshal(configs, &blockMetaData)
-	assert.Equal(t, uint64(0), blockMetaData.NextRound)
-	assert.Equal(t, string(genesisA.Network), blockMetaData.Network)
-	assert.Equal(t, crypto.HashObj(genesisA).String(), blockMetaData.GenesisHash)
+
+	{
+		// Check that metadata.json is written
+		metadataFile := fmt.Sprintf("%s/blocks/metadata.json", tempdir)
+		require.FileExists(t, metadataFile)
+		configs, err := ioutil.ReadFile(metadataFile)
+		assert.NoError(t, err)
+		var blockMetaData filewriter.BlockMetaData
+		err = json.Unmarshal(configs, &blockMetaData)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(0), blockMetaData.NextRound)
+		assert.Equal(t, string(genesisA.Network), blockMetaData.Network)
+		assert.Equal(t, crypto.HashObj(genesisA).String(), blockMetaData.GenesisHash)
+	}
+
+	{
+		// Check that genesis.json is written.
+		genesisFile := fmt.Sprintf("%s/blocks/genesis.json", tempdir)
+		require.FileExists(t, genesisFile)
+		genesisBytes, err := ioutil.ReadFile(genesisFile)
+		assert.NoError(t, err)
+		var genesis bookkeeping.Genesis
+		err = json.Unmarshal(genesisBytes, &genesis)
+		assert.NoError(t, err)
+		assert.Equal(t, genesisA, genesis)
+	}
 
 	// genesis mismatch
 	fileExp.Init(plugins.PluginConfig(config), logger)

--- a/exporters/filewriter/file_exporter_test.go
+++ b/exporters/filewriter/file_exporter_test.go
@@ -203,6 +203,7 @@ func sendData(t *testing.T, fileExp exporters.Exporter, config string, numRounds
 
 func TestExporterReceive(t *testing.T) {
 	config, tempdir := getConfig(t)
+	ctx := context.Background()
 	fileExp := fileCons.New()
 	numRounds := 5
 	sendData(t, fileExp, config, numRounds)

--- a/exporters/filewriter/file_exporter_test.go
+++ b/exporters/filewriter/file_exporter_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -35,42 +34,6 @@ func getConfig(t *testing.T) (config, tempdir string) {
 	tempdir = t.TempDir()
 	config = fmt.Sprintf(configTemplate, tempdir)
 	return
-}
-
-func TestEncode(t *testing.T) {
-	tempdir := t.TempDir()
-
-	type test struct {
-		One string `json:"one"`
-		Two int    `json:"two"`
-	}
-	data := test{
-		One: "one",
-		Two: 2,
-	}
-
-	{
-		pretty := path.Join(tempdir, "pretty.json")
-		encode(pretty, data, true)
-		require.FileExists(t, pretty)
-		bytes, err := ioutil.ReadFile(pretty)
-		require.NoError(t, err)
-		require.Contains(t, string(bytes), "  \"one\": \"one\",\n")
-		var testDecode test
-		json.Unmarshal(bytes, &testDecode)
-		require.Equal(t, data, testDecode)
-	}
-
-	{
-		small := path.Join(tempdir, "small.json")
-		encode(small, data, false)
-		require.FileExists(t, small)
-		bytes, err := ioutil.ReadFile(small)
-		require.NoError(t, err)
-		var testDecode test
-		json.Unmarshal(bytes, &testDecode)
-		require.Equal(t, data, testDecode)
-	}
 }
 
 func TestExporterMetadata(t *testing.T) {

--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -86,7 +86,11 @@ func (exp *postgresqlExporter) Close() error {
 
 func (exp *postgresqlExporter) Receive(exportData data.BlockData) error {
 	if exportData.Delta == nil {
-		return fmt.Errorf("receive got an invalid block: %#v", exportData)
+		if exportData.Round() == 0 {
+			exportData.Delta = &ledgercore.StateDelta{}
+		} else {
+			return fmt.Errorf("receive got an invalid block: %#v", exportData)
+		}
 	}
 	// Do we need to test for consensus protocol here?
 	/*

--- a/exporters/postgresql/postgresql_exporter_test.go
+++ b/exporters/postgresql/postgresql_exporter_test.go
@@ -82,7 +82,9 @@ func TestReceiveInvalidBlock(t *testing.T) {
 	assert.NoError(t, pgsqlExp.Init(context.Background(), cfg, logger))
 
 	invalidBlock := data.BlockData{
-		BlockHeader: bookkeeping.BlockHeader{},
+		BlockHeader: bookkeeping.BlockHeader{
+			Round: 1,
+		},
 		Payset:      transactions.Payset{},
 		Certificate: &agreement.Certificate{},
 		Delta:       nil,

--- a/importer/helper.go
+++ b/importer/helper.go
@@ -142,7 +142,10 @@ func importTar(imp Importer, tarfile io.Reader, logger *log.Logger, genesisReade
 		maybeFail(err, logger, "error decoding genesis, %v", err)
 	}
 
-	ld, err := util.MakeLedger(logger, false, &genesis, "")
+	dir, err := os.MkdirTemp(os.TempDir(), "indexer_import_tempdir")
+	maybeFail(err, logger, "Failed to make temp dir")
+
+	ld, err := util.MakeLedger(logger, false, &genesis, dir)
 	maybeFail(err, logger, "Cannot open ledger")
 
 	proc, err := blockprocessor.MakeBlockProcessorWithLedger(logger, ld, imp.ImportBlock)

--- a/importers/algod/algod_importer.go
+++ b/importers/algod/algod_importer.go
@@ -30,7 +30,7 @@ type algodImporter struct {
 
 var algodImporterMetadata = importers.ImporterMetadata{
 	ImpName:        importerName,
-	ImpDescription: "Importer for fetching block from algod rest endpoint.",
+	ImpDescription: "Importer for fetching blocks from an algod REST API.",
 	ImpDeprecated:  false,
 }
 
@@ -59,7 +59,7 @@ func init() {
 func (algodImp *algodImporter) Init(ctx context.Context, cfg plugins.PluginConfig, logger *logrus.Logger) (*bookkeeping.Genesis, error) {
 	algodImp.ctx, algodImp.cancel = context.WithCancel(ctx)
 	algodImp.logger = logger
-	if err := algodImp.unmarhshalConfig(string(cfg)); err != nil {
+	if err := algodImp.unmarshalConfig(string(cfg)); err != nil {
 		return nil, fmt.Errorf("connect failure in unmarshalConfig: %v", err)
 	}
 	var client *algod.Client
@@ -143,6 +143,6 @@ func (algodImp *algodImporter) GetBlock(rnd uint64) (data.BlockData, error) {
 	return blk, fmt.Errorf("finished retries without fetching a block")
 }
 
-func (algodImp *algodImporter) unmarhshalConfig(cfg string) error {
+func (algodImp *algodImporter) unmarshalConfig(cfg string) error {
 	return yaml.Unmarshal([]byte(cfg), &algodImp.cfg)
 }

--- a/importers/algod/algod_importer.go
+++ b/importers/algod/algod_importer.go
@@ -23,7 +23,7 @@ const importerName = "algod"
 type algodImporter struct {
 	aclient *algod.Client
 	logger  *logrus.Logger
-	cfg     ImporterConfig
+	cfg     Config
 	ctx     context.Context
 	cancel  context.CancelFunc
 }
@@ -59,7 +59,9 @@ func init() {
 func (algodImp *algodImporter) Init(ctx context.Context, cfg plugins.PluginConfig, logger *logrus.Logger) (*bookkeeping.Genesis, error) {
 	algodImp.ctx, algodImp.cancel = context.WithCancel(ctx)
 	algodImp.logger = logger
-	if err := algodImp.unmarshalConfig(string(cfg)); err != nil {
+	var err error
+	algodImp.cfg, err = unmarshalConfig(string(cfg))
+	if err != nil {
 		return nil, fmt.Errorf("connect failure in unmarshalConfig: %v", err)
 	}
 	var client *algod.Client
@@ -143,6 +145,7 @@ func (algodImp *algodImporter) GetBlock(rnd uint64) (data.BlockData, error) {
 	return blk, fmt.Errorf("finished retries without fetching a block")
 }
 
-func (algodImp *algodImporter) unmarshalConfig(cfg string) error {
-	return yaml.Unmarshal([]byte(cfg), &algodImp.cfg)
+func unmarshalConfig(cfg string) (config Config, err error) {
+	err = yaml.Unmarshal([]byte(cfg), &config)
+	return
 }

--- a/importers/algod/algod_importer_config.go
+++ b/importers/algod/algod_importer_config.go
@@ -1,7 +1,7 @@
 package algodimporter
 
-// ImporterConfig specific to the algod importer
-type ImporterConfig struct {
+// Config specific to the algod importer
+type Config struct {
 	// Algod netaddr string
 	NetAddr string `yaml:"netaddr"`
 	// Algod rest endpoint token

--- a/importers/algod/algod_importer_test.go
+++ b/importers/algod/algod_importer_test.go
@@ -65,9 +65,9 @@ func TestInitUnmarshalFailure(t *testing.T) {
 
 func TestConfigDefault(t *testing.T) {
 	testImporter = New()
-	expected, err := yaml.Marshal(&ImporterConfig{})
+	expected, err := yaml.Marshal(&Config{})
 	if err != nil {
-		t.Fatalf("unable to Marshal default algodimporter.ImporterConfig: %v", err)
+		t.Fatalf("unable to Marshal default algodimporter.Config: %v", err)
 	}
 	assert.Equal(t, plugins.PluginConfig(expected), testImporter.Config())
 }

--- a/importers/algod/algod_importer_test.go
+++ b/importers/algod/algod_importer_test.go
@@ -28,7 +28,7 @@ func init() {
 	ctx, cancel = context.WithCancel(context.Background())
 }
 
-func TestImporterorterMetadata(t *testing.T) {
+func TestImporterMetadata(t *testing.T) {
 	testImporter = New()
 	metadata := testImporter.Metadata()
 	assert.Equal(t, metadata.Type(), algodImporterMetadata.Type())

--- a/importers/all/all.go
+++ b/importers/all/all.go
@@ -3,4 +3,5 @@ package all
 import (
 	// Call package wide init function
 	_ "github.com/algorand/indexer/importers/algod"
+	_ "github.com/algorand/indexer/importers/filereader"
 )

--- a/importers/filereader/filereader.go
+++ b/importers/filereader/filereader.go
@@ -96,6 +96,7 @@ func (r *fileReader) GetBlock(rnd uint64) (data.BlockData, error) {
 	for {
 		filename := path.Join(r.cfg.BlocksDir, fmt.Sprintf(r.cfg.FilenamePattern, rnd))
 		var blockData data.BlockData
+		start := time.Now()
 		err := util.DecodeFromFile(filename, &blockData)
 		if err != nil && errors.Is(err, fs.ErrNotExist) {
 			// If the file read failed because the file didn't exist, wait before trying again
@@ -113,6 +114,7 @@ func (r *fileReader) GetBlock(rnd uint64) (data.BlockData, error) {
 			// Other error, return error to pipeline
 			return data.BlockData{}, fmt.Errorf("GetBlock(): unable to read block file '%s': %w", filename, err)
 		} else {
+			r.logger.Infof("Block %d read time: %s", rnd, time.Since(start))
 			// The read was fine, return the data.
 			return blockData, nil
 		}

--- a/importers/filereader/filereader.go
+++ b/importers/filereader/filereader.go
@@ -19,7 +19,7 @@ import (
 	"github.com/algorand/indexer/util"
 )
 
-const importerName = "filereader"
+const importerName = "file_reader"
 
 type fileReader struct {
 	logger *logrus.Logger

--- a/importers/filereader/filereader.go
+++ b/importers/filereader/filereader.go
@@ -104,10 +104,6 @@ func (r *fileReader) GetBlock(rnd uint64) (data.BlockData, error) {
 			}
 			attempts--
 
-			if r.cfg.RetryDuration == 0 {
-				// TODO: Special error type that terminates the pipeline gracefully.
-			}
-
 			select {
 			case <-time.After(r.cfg.RetryDuration):
 			case <-r.ctx.Done():

--- a/importers/filereader/filereader.go
+++ b/importers/filereader/filereader.go
@@ -71,7 +71,7 @@ func (r *fileReader) Init(ctx context.Context, cfg plugins.PluginConfig, logger 
 
 	genesisFile := path.Join(r.cfg.BlocksDir, "genesis.json")
 	var genesis bookkeeping.Genesis
-	util.DecodeFromFile(genesisFile, &genesis)
+	err = util.DecodeFromFile(genesisFile, &genesis)
 	if err != nil {
 		return nil, fmt.Errorf("Init(): failed to process genesis file: %w", err)
 	}

--- a/importers/filereader/filereader.go
+++ b/importers/filereader/filereader.go
@@ -1,0 +1,130 @@
+package fileimporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/indexer/data"
+	"github.com/algorand/indexer/exporters/filewriter"
+	"github.com/algorand/indexer/importers"
+	"github.com/algorand/indexer/plugins"
+	"github.com/algorand/indexer/util"
+)
+
+const importerName = "filereader"
+
+type fileReader struct {
+	logger *logrus.Logger
+	cfg    Config
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+var metadata = importers.ImporterMetadata{
+	ImpName:        importerName,
+	ImpDescription: "Importer for fetching blocks from files in a directory created by the 'file_writer' plugin.",
+	ImpDeprecated:  false,
+}
+
+// New initializes an algod importer
+func New() importers.Importer {
+	return &fileReader{}
+}
+
+// Constructor is the Constructor implementation for the "algod" importer
+type Constructor struct{}
+
+// New initializes a blockProcessorConstructor
+func (c *Constructor) New() importers.Importer {
+	return &fileReader{}
+}
+
+func (r *fileReader) Metadata() importers.ImporterMetadata {
+	return metadata
+}
+
+// package-wide init function
+func init() {
+	importers.RegisterImporter(importerName, &Constructor{})
+}
+
+func (r *fileReader) Init(ctx context.Context, cfg plugins.PluginConfig, logger *logrus.Logger) (*bookkeeping.Genesis, error) {
+	r.ctx, r.cancel = context.WithCancel(ctx)
+	r.logger = logger
+	var err error
+	r.cfg, err = unmarshalConfig(string(cfg))
+	if err != nil {
+		return nil, fmt.Errorf("invalid configuration: %v", err)
+	}
+
+	if r.cfg.FilenamePattern == "" {
+		r.cfg.FilenamePattern = filewriter.FilePattern
+	}
+
+	genesisFile := path.Join(r.cfg.BlocksDir, "genesis.json")
+	var genesis bookkeeping.Genesis
+	util.DecodeFromFile(genesisFile, &genesis)
+	if err != nil {
+		return nil, fmt.Errorf("Init(): failed to process genesis file: %w", err)
+	}
+
+	return &genesis, err
+}
+
+func (r *fileReader) Config() plugins.PluginConfig {
+	s, _ := yaml.Marshal(r.cfg)
+	return plugins.PluginConfig(s)
+}
+
+func (r *fileReader) Close() error {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	return nil
+}
+
+func (r *fileReader) GetBlock(rnd uint64) (data.BlockData, error) {
+	attempts := r.cfg.RetryCount
+	for {
+		filename := path.Join(r.cfg.BlocksDir, fmt.Sprintf(r.cfg.FilenamePattern, rnd))
+		var blockData data.BlockData
+		err := util.DecodeFromFile(filename, &blockData)
+		if err != nil && errors.Is(err, fs.ErrNotExist) {
+			// If the file read failed because the file didn't exist, wait before trying again
+			if attempts == 0 {
+				return data.BlockData{}, fmt.Errorf("GetBlock(): block not found after (%d) attempts", r.cfg.RetryCount)
+			}
+			attempts--
+
+			if r.cfg.RetryDuration == 0 {
+				// TODO: Special error type that terminates the pipeline gracefully.
+			}
+
+			select {
+			case <-time.After(r.cfg.RetryDuration):
+			case <-r.ctx.Done():
+				return data.BlockData{}, fmt.Errorf("GetBlock() context finished: %w", r.ctx.Err())
+			}
+		} else if err != nil {
+			// Other error, return error to pipeline
+			return data.BlockData{}, fmt.Errorf("GetBlock(): unable to read block file '%s': %w", filename, err)
+		} else {
+			// The read was fine, return the data.
+			return blockData, nil
+		}
+	}
+}
+
+func unmarshalConfig(cfg string) (Config, error) {
+	var config Config
+	err := yaml.Unmarshal([]byte(cfg), &config)
+	return config, err
+}

--- a/importers/filereader/filereader_config.go
+++ b/importers/filereader/filereader_config.go
@@ -1,0 +1,20 @@
+package fileimporter
+
+import "time"
+
+// Config specific to the file importer
+type Config struct {
+	// BlocksDir is the path to a directory where block data should be stored.
+	// The directory is created if it doesn't exist.
+	BlocksDir string `yaml:"block-dir"`
+	// RetryDuration controls the delay between checks when the importer has
+	// caught up and is waiting for new blocks to appear.
+	// When set to 0 the importer will
+	RetryDuration time.Duration `yaml:"retry-duration"`
+	// RetryCount controls the number of times to check for a missing block
+	// before generating an error. The retry count and retry duration should
+	// be configured according the the expected round time.
+	RetryCount uint64 `yaml:"retry-count"`
+	// FilenamePattern is the format used to find block files. It uses go string formatting and should accept one number for the round.
+	FilenamePattern string `yaml:"filename-pattern"`
+}

--- a/importers/filereader/filereader_config.go
+++ b/importers/filereader/filereader_config.go
@@ -9,7 +9,6 @@ type Config struct {
 	BlocksDir string `yaml:"block-dir"`
 	// RetryDuration controls the delay between checks when the importer has
 	// caught up and is waiting for new blocks to appear.
-	// When set to 0 the importer will
 	RetryDuration time.Duration `yaml:"retry-duration"`
 	// RetryCount controls the number of times to check for a missing block
 	// before generating an error. The retry count and retry duration should

--- a/importers/filereader/filereader_config.go
+++ b/importers/filereader/filereader_config.go
@@ -16,4 +16,6 @@ type Config struct {
 	RetryCount uint64 `yaml:"retry-count"`
 	// FilenamePattern is the format used to find block files. It uses go string formatting and should accept one number for the round.
 	FilenamePattern string `yaml:"filename-pattern"`
+
+	// TODO: Option to delete files after processing them
 }

--- a/importers/filereader/filereader_test.go
+++ b/importers/filereader/filereader_test.go
@@ -1,0 +1,189 @@
+package fileimporter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
+
+	"github.com/algorand/indexer/data"
+	"github.com/algorand/indexer/exporters/filewriter"
+	"github.com/algorand/indexer/importers"
+	"github.com/algorand/indexer/plugins"
+	"github.com/algorand/indexer/util"
+)
+
+var (
+	logger       *logrus.Logger
+	ctx          context.Context
+	cancel       context.CancelFunc
+	testImporter importers.Importer
+)
+
+func init() {
+	logger = logrus.New()
+	logger.SetOutput(os.Stdout)
+	logger.SetLevel(logrus.InfoLevel)
+}
+
+func TestImporterorterMetadata(t *testing.T) {
+	testImporter = New()
+	m := testImporter.Metadata()
+	assert.Equal(t, metadata.Type(), m.Type())
+	assert.Equal(t, metadata.Name(), m.Name())
+	assert.Equal(t, metadata.Description(), m.Description())
+	assert.Equal(t, metadata.Deprecated(), m.Deprecated())
+}
+
+// initializeTestData fills a data directory with some dummy data for the importer to read.
+func initializeTestData(t *testing.T, dir string, numRounds int) bookkeeping.Genesis {
+	genesisA := bookkeeping.Genesis{
+		SchemaID:    "test",
+		Network:     "test",
+		Proto:       "test",
+		Allocation:  nil,
+		RewardsPool: "AAAAAAA",
+		FeeSink:     "AAAAAAA",
+		Timestamp:   1234,
+		Comment:     "",
+		DevMode:     true,
+	}
+
+	err := util.EncodeToFile(path.Join(dir, "genesis.json"), genesisA, true)
+	require.NoError(t, err)
+
+	for i := 0; i < numRounds; i++ {
+		block := data.BlockData{
+			BlockHeader: bookkeeping.BlockHeader{
+				Round: basics.Round(i),
+			},
+			Payset:      make([]transactions.SignedTxnInBlock, 0),
+			Delta:       &ledgercore.StateDelta{},
+			Certificate: nil,
+		}
+		blockFile := path.Join(dir, fmt.Sprintf(filewriter.FilePattern, i))
+		err = util.EncodeToFile(blockFile, block, true)
+		require.NoError(t, err)
+	}
+
+	return genesisA
+}
+
+func initializeImporter(t *testing.T, numRounds int) (importer importers.Importer, tempdir string, genesis *bookkeeping.Genesis, err error) {
+	tempdir = t.TempDir()
+	genesisExpected := initializeTestData(t, tempdir, numRounds)
+	importer = New()
+	defer importer.Config()
+	cfg := Config{
+		BlocksDir:     tempdir,
+		RetryDuration: 0,
+	}
+	data, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	genesis, err = importer.Init(context.Background(), plugins.PluginConfig(data), logger)
+	assert.NoError(t, err)
+	require.NotNil(t, genesis)
+	require.Equal(t, genesisExpected, *genesis)
+	return
+}
+
+func TestInitSuccess(t *testing.T) {
+	_, _, _, err := initializeImporter(t, 1)
+	require.NoError(t, err)
+}
+
+func TestInitUnmarshalFailure(t *testing.T) {
+	testImporter = New()
+	_, err := testImporter.Init(context.Background(), "`", logger)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid configuration")
+	testImporter.Close()
+}
+
+func TestConfigDefault(t *testing.T) {
+	testImporter = New()
+	expected, err := yaml.Marshal(&Config{})
+	require.NoError(t, err)
+	assert.Equal(t, plugins.PluginConfig(expected), testImporter.Config())
+}
+
+// TODO: remaining tests
+
+func TestGetBlockSuccess(t *testing.T) {
+	numRounds := 10
+	importer, tempdir, genesis, err := initializeImporter(t, 10)
+	require.NoError(t, err)
+	require.NotEqual(t, "", tempdir)
+	require.NotNil(t, genesis)
+
+	for i := 0; i < numRounds; i++ {
+		block, err := importer.GetBlock(uint64(i))
+		require.NoError(t, err)
+		require.Equal(t, basics.Round(i), block.BlockHeader.Round)
+	}
+}
+
+func TestRetryAndDuration(t *testing.T) {
+	tempdir := t.TempDir()
+	initializeTestData(t, tempdir, 0)
+	importer := New()
+	defer importer.Config()
+	cfg := Config{
+		BlocksDir:     tempdir,
+		RetryDuration: 10 * time.Millisecond,
+		RetryCount:    3,
+	}
+	data, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	_, err = importer.Init(context.Background(), plugins.PluginConfig(data), logger)
+	assert.NoError(t, err)
+
+	start := time.Now()
+	_, err = importer.GetBlock(0)
+	assert.ErrorContains(t, err, "GetBlock(): block not found after (3) attempts")
+
+	expectedDuration := cfg.RetryDuration*time.Duration(cfg.RetryCount) + 10*time.Millisecond
+	assert.WithinDuration(t, start, time.Now(), expectedDuration, "Error should generate after retry count * retry duration")
+}
+
+func TestRetryWithCancel(t *testing.T) {
+	tempdir := t.TempDir()
+	initializeTestData(t, tempdir, 0)
+	importer := New()
+	defer importer.Config()
+	cfg := Config{
+		BlocksDir:     tempdir,
+		RetryDuration: 1 * time.Hour,
+		RetryCount:    3,
+	}
+	data, err := yaml.Marshal(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, err)
+	_, err = importer.Init(ctx, plugins.PluginConfig(data), logger)
+	assert.NoError(t, err)
+
+	// Cancel after delay
+	delay := time.Millisecond
+	go func() {
+		time.Sleep(delay)
+		cancel()
+	}()
+	start := time.Now()
+	_, err = importer.GetBlock(0)
+	assert.ErrorContains(t, err, "GetBlock() context finished: context canceled")
+
+	// within 1ms of the expected time (but much less than the 3hr configuration.
+	assert.WithinDuration(t, start, time.Now(), delay+time.Millisecond)
+}

--- a/importers/filereader/filereader_test.go
+++ b/importers/filereader/filereader_test.go
@@ -119,8 +119,6 @@ func TestConfigDefault(t *testing.T) {
 	assert.Equal(t, plugins.PluginConfig(expected), testImporter.Config())
 }
 
-// TODO: remaining tests
-
 func TestGetBlockSuccess(t *testing.T) {
 	numRounds := 10
 	importer, tempdir, genesis, err := initializeImporter(t, 10)

--- a/processors/blockprocessor/block_processor.go
+++ b/processors/blockprocessor/block_processor.go
@@ -3,9 +3,10 @@ package blockprocessor
 import (
 	"context"
 	"fmt"
+	"time"
+
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
-	"time"
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"

--- a/processors/blockprocessor/block_processor.go
+++ b/processors/blockprocessor/block_processor.go
@@ -84,10 +84,6 @@ func (proc *blockProcessor) Init(ctx context.Context, initProvider data.InitProv
 		return fmt.Errorf("blockprocessor init error: %w", err)
 	}
 	proc.cfg = cfg
-	fmt.Println("BLOCKPROCESSOR CONFIG")
-	fmt.Println(cfg)
-	fmt.Println(pCfg)
-	fmt.Printf("DATA DIR: %s\n", pCfg.IndexerDatadir)
 
 	genesis := initProvider.GetGenesis()
 	round := uint64(initProvider.NextDBRound())
@@ -97,10 +93,6 @@ func (proc *blockProcessor) Init(ctx context.Context, initProvider data.InitProv
 		return fmt.Errorf("could not initialize ledger: %w", err)
 	}
 
-	fmt.Println("BLOCKPROCESSOR CONFIG-------------")
-	fmt.Println(cfg)
-	fmt.Println(pCfg)
-	fmt.Printf("DATA DIR: %s\n", pCfg.IndexerDatadir)
 	l, err := util.MakeLedger(proc.logger, false, genesis, pCfg.IndexerDatadir)
 	if err != nil {
 		return fmt.Errorf("could not make ledger: %w", err)

--- a/processors/blockprocessor/block_processor.go
+++ b/processors/blockprocessor/block_processor.go
@@ -84,6 +84,10 @@ func (proc *blockProcessor) Init(ctx context.Context, initProvider data.InitProv
 		return fmt.Errorf("blockprocessor init error: %w", err)
 	}
 	proc.cfg = cfg
+	fmt.Println("BLOCKPROCESSOR CONFIG")
+	fmt.Println(cfg)
+	fmt.Println(pCfg)
+	fmt.Printf("DATA DIR: %s\n", pCfg.IndexerDatadir)
 
 	genesis := initProvider.GetGenesis()
 	round := uint64(initProvider.NextDBRound())
@@ -93,6 +97,10 @@ func (proc *blockProcessor) Init(ctx context.Context, initProvider data.InitProv
 		return fmt.Errorf("could not initialize ledger: %w", err)
 	}
 
+	fmt.Println("BLOCKPROCESSOR CONFIG-------------")
+	fmt.Println(cfg)
+	fmt.Println(pCfg)
+	fmt.Printf("DATA DIR: %s\n", pCfg.IndexerDatadir)
 	l, err := util.MakeLedger(proc.logger, false, genesis, pCfg.IndexerDatadir)
 	if err != nil {
 		return fmt.Errorf("could not make ledger: %w", err)

--- a/processors/blockprocessor/block_processor.go
+++ b/processors/blockprocessor/block_processor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
+	"time"
 
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"
@@ -220,6 +221,7 @@ func addGenesisBlock(l *ledger.Ledger, handler func(block *ledgercore.ValidatedB
 }
 
 func (proc *blockProcessor) Process(input data.BlockData) (data.BlockData, error) {
+	start := time.Now()
 
 	blockCert := input.EncodedBlockCertificate()
 
@@ -235,6 +237,8 @@ func (proc *blockProcessor) Process(input data.BlockData) (data.BlockData, error
 	delta := vb.Delta()
 	input.Payset = modifiedTxns
 	input.Delta = &delta
+
+	proc.logger.Infof("Block processor: processed block %d (%s)", input.Round(), time.Since(start))
 
 	return input, nil
 }

--- a/processors/blockprocessor/block_processor.go
+++ b/processors/blockprocessor/block_processor.go
@@ -241,7 +241,7 @@ func (proc *blockProcessor) Process(input data.BlockData) (data.BlockData, error
 	input.Payset = modifiedTxns
 	input.Delta = &delta
 
-	proc.logger.Infof("Block processor: processed block %d (%s)", input.Round(), time.Since(start))
+	proc.logger.Debugf("Block processor: processed block %d (%s)", input.Round(), time.Since(start))
 
 	return input, nil
 }

--- a/processors/blockprocessor/initialize.go
+++ b/processors/blockprocessor/initialize.go
@@ -127,13 +127,14 @@ func blockHandler(logger *log.Logger, dbRound uint64, procHandler func(block *rp
 }
 
 func handleBlock(logger *log.Logger, block *rpcs.EncodedBlockCert, procHandler func(block *rpcs.EncodedBlockCert) error) error {
+	start := time.Now()
 	err := procHandler(block)
 	if err != nil {
 		logger.WithError(err).Errorf(
 			"block %d import failed", block.Block.Round())
 		return fmt.Errorf("handleBlock() err: %w", err)
 	}
-	logger.Infof("Initialize Ledger: added block %d to ledger", block.Block.Round())
+	logger.Infof("Initialize Ledger: added block %d to ledger (%s)", block.Block.Round(), time.Since(start))
 	return nil
 }
 

--- a/test/common.sh
+++ b/test/common.sh
@@ -3,6 +3,7 @@
 # The cleanup hook ensures these containers are removed when the script exits.
 POSTGRES_CONTAINER=test-container
 export INDEXER_DATA=/tmp/e2e_test/
+TEST_DATA_DIR=$(mktemp)
 
 NET=localhost:8981
 CURL_TEMPFILE=curl_out.txt
@@ -202,7 +203,7 @@ function start_indexer_with_connection_string() {
   ALGORAND_DATA= ../cmd/algorand-indexer/algorand-indexer daemon \
     -S $NET "$RO" \
     -P "$1" \
-    -i /tmp \
+    -i "$TEST_DATA_DIR" \
     --enable-all-parameters \
     "$RO" \
     --pidfile $PIDFILE 2>&1 > /dev/null &
@@ -212,7 +213,7 @@ function start_indexer_with_connection_string() {
 # $2 - if set, halts execution
 function start_indexer() {
   if [ ! -z $2 ]; then
-    echo "daemon -i /tmp -S $NET -P \"${CONNECTION_STRING/DB_NAME_HERE/$1}\""
+    echo "daemon -i "$TEST_DATA_DIR" -S $NET -P \"${CONNECTION_STRING/DB_NAME_HERE/$1}\""
     sleep_forever
   fi
 
@@ -292,9 +293,9 @@ function kill_indexer() {
     kill -9 $(cat "$PIDFILE") > /dev/null 2>&1 || true
     rm $PIDFILE
     rm -rf $INDEXER_DATA
+    rm -rf $TEST_DATA_DIR/*
     pwd
     ls -l
-    rm ledger*sqlite* || true
   fi
 }
 

--- a/util/ledger_util.go
+++ b/util/ledger_util.go
@@ -65,6 +65,7 @@ func createInitState(genesis *bookkeeping.Genesis) (ledgercore.InitState, error)
 // MakeLedger opens a ledger, initializing if necessary.
 func MakeLedger(logger *log.Logger, inMemory bool, genesis *bookkeeping.Genesis, dataDir string) (*ledger.Ledger, error) {
 	const prefix = "ledger"
+	fmt.Printf("MakeLedger(%s)\n", dataDir)
 	err := os.MkdirAll(dataDir, 0755)
 	if err != nil {
 		return nil, fmt.Errorf("MakeProcessor() failed to create '%s': %w", dataDir, err)

--- a/util/ledger_util.go
+++ b/util/ledger_util.go
@@ -65,7 +65,6 @@ func createInitState(genesis *bookkeeping.Genesis) (ledgercore.InitState, error)
 // MakeLedger opens a ledger, initializing if necessary.
 func MakeLedger(logger *log.Logger, inMemory bool, genesis *bookkeeping.Genesis, dataDir string) (*ledger.Ledger, error) {
 	const prefix = "ledger"
-	fmt.Printf("MakeLedger(%s)\n", dataDir)
 	err := os.MkdirAll(dataDir, 0755)
 	if err != nil {
 		return nil, fmt.Errorf("MakeProcessor() failed to create '%s': %w", dataDir, err)

--- a/util/ledger_util.go
+++ b/util/ledger_util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
@@ -64,6 +65,10 @@ func createInitState(genesis *bookkeeping.Genesis) (ledgercore.InitState, error)
 // MakeLedger opens a ledger, initializing if necessary.
 func MakeLedger(logger *log.Logger, inMemory bool, genesis *bookkeeping.Genesis, dataDir string) (*ledger.Ledger, error) {
 	const prefix = "ledger"
+	err := os.MkdirAll(dataDir, 0755)
+	if err != nil {
+		return nil, fmt.Errorf("MakeProcessor() failed to create '%s': %w", dataDir, err)
+	}
 	dbPrefix := filepath.Join(dataDir, prefix)
 	initState, err := createInitState(genesis)
 	if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -53,10 +53,12 @@ func DecodeFromFile(filename string, v interface{}) error {
 	defer file.Close()
 
 	if strings.HasSuffix(filename, ".gz") {
-		reader, err = gzip.NewReader(file)
+		gz, err := gzip.NewReader(file)
+		defer gz.Close()
 		if err != nil {
 			return fmt.Errorf("DecodeFromFile(): failed to make gzip reader: %w", err)
 		}
+		reader = gz
 	} else {
 		reader = file
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -25,6 +25,7 @@ func EncodeToFile(filename string, v interface{}, pretty bool) error {
 
 	if strings.HasSuffix(filename, ".gz") {
 		gz := gzip.NewWriter(file)
+		gz.Name = filename
 		defer gz.Close()
 		writer = gz
 	} else {

--- a/util/util.go
+++ b/util/util.go
@@ -61,8 +61,6 @@ func DecodeFromFile(filename string, v interface{}) error {
 			return fmt.Errorf("DecodeFromFile(): failed to make gzip reader: %w", err)
 		}
 		reader = gz
-	} else {
-		reader = reader
 	}
 
 	enc := codec.NewDecoder(reader, json.CodecHandle)

--- a/util/util.go
+++ b/util/util.go
@@ -35,7 +35,7 @@ func DecodeFromFile(filename string, v interface{}) error {
 		return fmt.Errorf("DecodeFromFile(): failed to open %s: %w", filename, err)
 	}
 	defer file.Close()
-	enc := json.NewDecoder(file)
+	enc := codec.NewDecoder(file, json.CodecHandle)
 	return enc.Decode(v)
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/algorand/go-codec/codec"
 )
 
+// EncodeToFile is used to encode an object to a file.
 func EncodeToFile(filename string, v interface{}, pretty bool) error {
 	file, err := os.Create(filename)
 	if err != nil {
@@ -27,6 +28,7 @@ func EncodeToFile(filename string, v interface{}, pretty bool) error {
 	return enc.Encode(v)
 }
 
+// DecodeFromFile is used to decode a file to an object.
 func DecodeFromFile(filename string, v interface{}) error {
 	file, err := os.Open(filename)
 	if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -7,8 +7,35 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/algorand/go-algorand-sdk/encoding/json"
 	"github.com/algorand/go-codec/codec"
 )
+
+func EncodeToFile(filename string, v interface{}, pretty bool) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("EncodeToFile(): failed to create %s: %w", filename, err)
+	}
+	defer file.Close()
+	handle := json.CodecHandle
+	if pretty {
+		handle.Indent = 2
+	} else {
+		handle.Indent = 0
+	}
+	enc := codec.NewEncoder(file, json.CodecHandle)
+	return enc.Encode(v)
+}
+
+func DecodeFromFile(filename string, v interface{}) error {
+	file, err := os.Open(filename)
+	if err != nil {
+		return fmt.Errorf("DecodeFromFile(): failed to open %s: %w", filename, err)
+	}
+	defer file.Close()
+	enc := json.NewDecoder(file)
+	return enc.Decode(v)
+}
 
 // PrintableUTF8OrEmpty checks to see if the entire string is a UTF8 printable string.
 // If this is the case, the string is returned as is. Otherwise, the empty string is returned.

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -2,8 +2,50 @@ package util
 
 import (
 	"encoding/base64"
+	"io/ioutil"
+	"path"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+func TestEncodeToAndFromFile(t *testing.T) {
+	tempdir := t.TempDir()
+
+	type test struct {
+		One string `json:"one"`
+		Two int    `json:"two"`
+	}
+	data := test{
+		One: "one",
+		Two: 2,
+	}
+
+	{
+		pretty := path.Join(tempdir, "pretty.json")
+		err := EncodeToFile(pretty, data, true)
+		require.NoError(t, err)
+		require.FileExists(t, pretty)
+		var testDecode test
+		err = DecodeFromFile(pretty, &testDecode)
+		require.Equal(t, data, testDecode)
+
+		// Check the pretty printing
+		bytes, err := ioutil.ReadFile(pretty)
+		require.NoError(t, err)
+		require.Contains(t, string(bytes), "  \"one\": \"one\",\n")
+	}
+
+	{
+		small := path.Join(tempdir, "small.json")
+		err := EncodeToFile(small, data, false)
+		require.NoError(t, err)
+		require.FileExists(t, small)
+		var testDecode test
+		err = DecodeFromFile(small, &testDecode)
+		require.Equal(t, data, testDecode)
+	}
+}
 
 func TestPrintableUTF8OrEmpty(t *testing.T) {
 	encodeArg := func(str string) string {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -45,6 +45,17 @@ func TestEncodeToAndFromFile(t *testing.T) {
 		err = DecodeFromFile(small, &testDecode)
 		require.Equal(t, data, testDecode)
 	}
+
+	// gzip test
+	{
+		small := path.Join(tempdir, "small.json.gz")
+		err := EncodeToFile(small, data, false)
+		require.NoError(t, err)
+		require.FileExists(t, small)
+		var testDecode test
+		err = DecodeFromFile(small, &testDecode)
+		require.Equal(t, data, testDecode)
+	}
 }
 
 func TestPrintableUTF8OrEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary

* New filereader plugin.
* Small changes / improvements to the filewriter plugin:
  1. Add tags to the BlockData type so that the serialization is explicit.
  2. Change the block encoder function to use go-codec, the `StateDelta` object contains a map with non-string keys which caused a problem with the json encoder.
  3. Use t.TempDir() for tests so that the tests don't leave artifacts behind.
  4. Save a genesis.json file
  5. Some new configurations - Removing the vote certificate (should be in the filter plugin?), specifying the filename format.

## Test Plan

New unit tests.