### PR TITLE
fix: use CI_E2E_FILENAME in s3 prefix 

### DIFF
--- a/misc/e2elive.py
+++ b/misc/e2elive.py
@@ -83,12 +83,16 @@ def main():
         from botocore.config import Config
         from botocore import UNSIGNED
         s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
+        prefix = "indexer/e2e4"
         if "/" in tarname:
-            tarname = tarname.split("/")[1]
+            cmhash_tarnme = tarname.split("/")
+            cmhash = cmhash_tarnme[0]
+            tarname =cmhash_tarnme[1]
+            prefix+="/"+cmhash
             tarpath = os.path.join(tempdir, tarname)
         else:
             tarpath = os.path.join(tempdir, tarname)
-        prefix = "indexer/e2e4"
+
         success = firstFromS3Prefix(s3, bucket, prefix, tarname, outpath=tarpath)
         if not success:
             raise Exception(
@@ -203,7 +207,7 @@ def countblocks(path):
     return row[0]
 
 
-def tryhealthurl(healthurl, verbose=False, waitforround=100):
+def tryhealthurl(healthurl, verbose=False, waitforround=200):
     try:
         response = urllib.request.urlopen(healthurl)
         if response.code != 200:

--- a/misc/e2elive.py
+++ b/misc/e2elive.py
@@ -85,6 +85,7 @@ def main():
         s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
         prefix = "indexer/e2e4"
         if "/" in tarname:
+        # parse tarname like fafa8862/rel-nightly
             cmhash_tarnme = tarname.split("/")
             cmhash = cmhash_tarnme[0]
             tarname =cmhash_tarnme[1]


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary
This PR fixes a string parsing error in e2e test script. commit hash wasn't included in the s3 file prefix and so e2e test was only using the latest artifact from nightly build. 

## Test Plan
check CI build to make sure test artifact is downloaded from the correct file path. 
