### PR TITLE
Condensed Duplicate logger output

### DIFF
--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -117,6 +117,8 @@ func makeConduitCmd() *cobra.Command {
 			return runConduitCmdWithConfig(cfg)
 		},
 		SilenceUsage: true,
+		// Silence errors because our logger will catch and print any errors
+		SilenceErrors: true,
 	}
 
 	cfg.Flags = cmd.Flags()
@@ -183,7 +185,7 @@ func makeInitCmd() *cobra.Command {
 
 func main() {
 	if err := conduitCmd.Execute(); err != nil {
-		log.Errorf("%v", err)
+		logger.Errorf("%v", err)
 		os.Exit(1)
 	}
 

--- a/conduit/config.go
+++ b/conduit/config.go
@@ -19,7 +19,15 @@ type Config struct {
 
 func (cfg *Config) String() string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "Data Directory: %s ", cfg.ConduitDataDir)
+
+	var dataDirToPrint string
+	if cfg.ConduitDataDir == "" {
+		dataDirToPrint = "[EMPTY]"
+	} else {
+		dataDirToPrint = cfg.ConduitDataDir
+	}
+
+	fmt.Fprintf(&sb, "Data Directory: %s ", dataDirToPrint)
 
 	return sb.String()
 }


### PR DESCRIPTION
Resolves #1245 

Explicitly spell out empty data directory as well as condensed error messages when running conduit

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged.

## Test Plan

How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale.
