### PR TITLE
Bug-Fix: Update go-algorand Submodule and Wrap Ledger in MakeNewCatchpointCatchupAccessor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       go_version:
         type: string
     environment:
-      CI_E2E_FILENAME: "fafa8862/rel-nightly"
+      CI_E2E_FILENAME: "fad05790/rel-nightly"
     steps:
       - go/install:
           version: << parameters.go_version >>

--- a/processor/blockprocessor/internal/catchupservice.go
+++ b/processor/blockprocessor/internal/catchupservice.go
@@ -10,6 +10,7 @@ import (
 	"github.com/algorand/go-algorand/catchup"
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/ledger"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/network"
@@ -97,7 +98,7 @@ func CatchupServiceCatchup(ctx context.Context, logger *log.Logger, catchpoint, 
 		node,
 		wrappedLogger,
 		net,
-		l,
+		ledger.MakeCatchpointCatchupAccessor(l, wrappedLogger),
 		cfg,
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

In anticipation of releasing `integration/boxes` branch and therefore keeping it up to date with the latest in `go-algorand`'s `feature/avm-box` branch I encountered an incoming breaking change.  In particular, [PR #4535](https://github.com/algorand/go-algorand/pull/4535/files) replaces an expected `Ledger` parameter with a `interface CatchupAccessorClientLedger` parameter in the `MakeNewCatchpointCatchupService()` [constructor](https://github.com/algorandskiy/go-algorand/blob/661764e3817bf16abab1684909451d1a935bce2d/node/node.go#L1122-L1123).

The PR follows a similar approach to replace a `Ledger` with a `CatchupAccessorClientLedger` inside of `processor/blockprocessor/internal/catchupservice.go::CatchupServiceCatchup()` 

### Submodule Commit
Bringing in the commit for the PR mentioned above:

`cbdc68ad329d46441bc4947f27d3f6622ffa6248`

### Other changes:

[update test job's CI_E2E_FILENAME to latest rel-nightly s3 key](https://github.com/algorand/indexer/pull/1257/commits/8f9c9408fc020c48307a0bf7d8295eb008394716)

## Test Plan

C.I.
