### PR TITLE
Conduit: Add context to exporter interface

### DIFF
--- a/conduit/pipeline.go
+++ b/conduit/pipeline.go
@@ -192,7 +192,7 @@ func (p *pipelineImpl) Init() error {
 	exporterLogger.SetFormatter(makePluginLogFormatter(plugins.Exporter, (*p.exporter).Metadata().Name()))
 
 	jsonEncode := string(json.Encode(p.cfg.Exporter.Config))
-	err := (*p.exporter).Init(plugins.PluginConfig(jsonEncode), exporterLogger)
+	err := (*p.exporter).Init(p.ctx, plugins.PluginConfig(jsonEncode), exporterLogger)
 	exporterName := (*p.exporter).Metadata().Name()
 	if err != nil {
 		return fmt.Errorf("Pipeline.Start(): could not initialize Exporter (%s): %w", exporterName, err)

--- a/conduit/pipeline_test.go
+++ b/conduit/pipeline_test.go
@@ -221,7 +221,7 @@ func (m *mockExporter) Metadata() exporters.ExporterMetadata {
 	}
 }
 
-func (m *mockExporter) Init(_ plugins.PluginConfig, _ *log.Logger) error {
+func (m *mockExporter) Init(_ context.Context, _ plugins.PluginConfig, _ *log.Logger) error {
 	return nil
 }
 

--- a/exporters/example/example_exporter.go
+++ b/exporters/example/example_exporter.go
@@ -1,6 +1,7 @@
 package example
 
 import (
+	"context"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/exporters"
@@ -33,7 +34,7 @@ func (exp *exampleExporter) Metadata() exporters.ExporterMetadata {
 }
 
 // Init provides the opportunity for your Exporter to initialize connections, store config variables, etc.
-func (exp *exampleExporter) Init(_ plugins.PluginConfig, _ *logrus.Logger) error {
+func (exp *exampleExporter) Init(_ context.Context, _ plugins.PluginConfig, _ *logrus.Logger) error {
 	panic("not implemented")
 }
 

--- a/exporters/example/example_exporter_test.go
+++ b/exporters/example/example_exporter_test.go
@@ -1,11 +1,13 @@
 package example
 
 import (
+	"context"
+	"testing"
+
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/plugins"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 var exCons = &Constructor{}
@@ -21,7 +23,7 @@ func TestExporterMetadata(t *testing.T) {
 }
 
 func TestExporterInit(t *testing.T) {
-	assert.Panics(t, func() { exExp.Init("", nil) })
+	assert.Panics(t, func() { exExp.Init(context.Background(), "", nil) })
 }
 
 func TestExporterConfig(t *testing.T) {

--- a/exporters/exporter.go
+++ b/exporters/exporter.go
@@ -1,6 +1,7 @@
 package exporters
 
 import (
+	"context"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/plugins"
@@ -16,7 +17,7 @@ type Exporter interface {
 	// Typically used for things like initializing network connections.
 	// The ExporterConfig passed to Connect will contain the Unmarhsalled config file specific to this plugin.
 	// Should return an error if it fails--this will result in the Indexer process terminating.
-	Init(cfg plugins.PluginConfig, logger *logrus.Logger) error
+	Init(ctx context.Context, cfg plugins.PluginConfig, logger *logrus.Logger) error
 
 	// Config returns the configuration options used to create an Exporter.
 	// Initialized during Connect, it should return nil until the Exporter has been Connected.

--- a/exporters/exporter_factory_test.go
+++ b/exporters/exporter_factory_test.go
@@ -1,10 +1,11 @@
 package exporters
 
 import (
+	"testing"
+
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 var logger *logrus.Logger

--- a/exporters/filewriter/file_exporter.go
+++ b/exporters/filewriter/file_exporter.go
@@ -1,6 +1,7 @@
 package filewriter
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -55,7 +56,7 @@ func (exp *fileExporter) Metadata() exporters.ExporterMetadata {
 	return fileExporterMetadata
 }
 
-func (exp *fileExporter) Init(cfg plugins.PluginConfig, logger *logrus.Logger) error {
+func (exp *fileExporter) Init(_ context.Context, cfg plugins.PluginConfig, logger *logrus.Logger) error {
 	exp.logger = logger
 	if err := exp.unmarhshalConfig(string(cfg)); err != nil {
 		return fmt.Errorf("connect failure in unmarshalConfig: %w", err)

--- a/exporters/filewriter/file_exporter_test.go
+++ b/exporters/filewriter/file_exporter_test.go
@@ -1,6 +1,7 @@
 package filewriter_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -37,17 +38,18 @@ func TestExporterMetadata(t *testing.T) {
 }
 
 func TestExporterInit(t *testing.T) {
+	ctx := context.Background()
 	fileExp := fileCons.New()
 	assert.Equal(t, uint64(0), fileExp.Round())
 	// creates a new output file
-	err := fileExp.Init(plugins.PluginConfig(config), logger)
+	err := fileExp.Init(ctx, plugins.PluginConfig(config), logger)
 	assert.NoError(t, err)
 	pluginConfig := fileExp.Config()
 	assert.Equal(t, config, string(pluginConfig))
 	assert.Equal(t, uint64(0), fileExp.Round())
 	fileExp.Close()
 	// can open existing file
-	err = fileExp.Init(plugins.PluginConfig(config), logger)
+	err = fileExp.Init(ctx, plugins.PluginConfig(config), logger)
 	assert.NoError(t, err)
 	fileExp.Close()
 	// re-initializes empty file
@@ -56,14 +58,15 @@ func TestExporterInit(t *testing.T) {
 	f, err := os.Create(path)
 	f.Close()
 	assert.NoError(t, err)
-	err = fileExp.Init(plugins.PluginConfig(config), logger)
+	err = fileExp.Init(ctx, plugins.PluginConfig(config), logger)
 	assert.NoError(t, err)
 	fileExp.Close()
 }
 
 func TestExporterHandleGenesis(t *testing.T) {
+	ctx := context.Background()
 	fileExp := fileCons.New()
-	fileExp.Init(plugins.PluginConfig(config), logger)
+	fileExp.Init(ctx, plugins.PluginConfig(config), logger)
 	genesisA := bookkeeping.Genesis{
 		SchemaID:    "test",
 		Network:     "test",
@@ -87,7 +90,7 @@ func TestExporterHandleGenesis(t *testing.T) {
 	assert.Equal(t, crypto.HashObj(genesisA).String(), blockMetaData.GenesisHash)
 
 	// genesis mismatch
-	fileExp.Init(plugins.PluginConfig(config), logger)
+	fileExp.Init(ctx, plugins.PluginConfig(config), logger)
 	genesisB := bookkeeping.Genesis{
 		SchemaID:    "test",
 		Network:     "test",
@@ -107,6 +110,7 @@ func TestExporterHandleGenesis(t *testing.T) {
 }
 
 func TestExporterReceive(t *testing.T) {
+	ctx := context.Background()
 	fileExp := fileCons.New()
 	block := data.BlockData{
 		BlockHeader: bookkeeping.BlockHeader{
@@ -121,7 +125,7 @@ func TestExporterReceive(t *testing.T) {
 	assert.Contains(t, err.Error(), "exporter not initialized")
 
 	// initialize
-	fileExp.Init(plugins.PluginConfig(config), logger)
+	fileExp.Init(ctx, plugins.PluginConfig(config), logger)
 
 	// incorrect round
 	err = fileExp.Receive(block)
@@ -168,14 +172,15 @@ func TestExporterReceive(t *testing.T) {
 	}
 
 	//	should continue from round 6 after restart
-	fileExp.Init(plugins.PluginConfig(config), logger)
+	fileExp.Init(ctx, plugins.PluginConfig(config), logger)
 	assert.Equal(t, uint64(5), fileExp.Round())
 	fileExp.Close()
 }
 
 func TestExporterClose(t *testing.T) {
+	ctx := context.Background()
 	fileExp := fileCons.New()
-	fileExp.Init(plugins.PluginConfig(config), logger)
+	fileExp.Init(ctx, plugins.PluginConfig(config), logger)
 	block := data.BlockData{
 		BlockHeader: bookkeeping.BlockHeader{
 			Round: 5,

--- a/exporters/noop/noop_exporter.go
+++ b/exporters/noop/noop_exporter.go
@@ -1,6 +1,7 @@
 package noop
 
 import (
+	"context"
 	"fmt"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/indexer/data"
@@ -39,7 +40,7 @@ func (exp *noopExporter) Metadata() exporters.ExporterMetadata {
 	return noopExporterMetadata
 }
 
-func (exp *noopExporter) Init(cfg plugins.PluginConfig, _ *logrus.Logger) error {
+func (exp *noopExporter) Init(_ context.Context, cfg plugins.PluginConfig, _ *logrus.Logger) error {
 	if err := yaml.Unmarshal([]byte(cfg), &exp.cfg); err != nil {
 		return fmt.Errorf("init failure in unmarshalConfig: %v", err)
 	}

--- a/exporters/noop/noop_exporter_test.go
+++ b/exporters/noop/noop_exporter_test.go
@@ -1,13 +1,15 @@
 package noop
 
 import (
+	"context"
+	"testing"
+
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/exporters"
 	"github.com/algorand/indexer/plugins"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
-	"testing"
 )
 
 var nc = &Constructor{}
@@ -31,7 +33,7 @@ func TestExporterMetadata(t *testing.T) {
 }
 
 func TestExporterInit(t *testing.T) {
-	assert.NoError(t, ne.Init("", nil))
+	assert.NoError(t, ne.Init(context.Background(), "", nil))
 }
 
 func TestExporterConfig(t *testing.T) {
@@ -40,7 +42,7 @@ func TestExporterConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to Marshal default noop.ExporterConfig: %v", err)
 	}
-	assert.NoError(t, ne.Init("", nil))
+	assert.NoError(t, ne.Init(context.Background(), "", nil))
 	assert.Equal(t, plugins.PluginConfig(expected), ne.Config())
 }
 
@@ -53,9 +55,9 @@ func TestExporterHandleGenesis(t *testing.T) {
 }
 
 func TestExporterStartRound(t *testing.T) {
-	assert.NoError(t, ne.Init("", nil))
+	assert.NoError(t, ne.Init(context.Background(), "", nil))
 	assert.Equal(t, uint64(0), ne.Round())
-	assert.NoError(t, ne.Init("round: 55", nil))
+	assert.NoError(t, ne.Init(context.Background(), "round: 55", nil))
 	assert.Equal(t, uint64(55), ne.Round())
 
 }

--- a/exporters/postgresql/postgresql_exporter.go
+++ b/exporters/postgresql/postgresql_exporter.go
@@ -1,6 +1,7 @@
 package postgresql
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -47,7 +48,7 @@ func (exp *postgresqlExporter) Metadata() exporters.ExporterMetadata {
 	return postgresqlExporterMetadata
 }
 
-func (exp *postgresqlExporter) Init(cfg plugins.PluginConfig, logger *logrus.Logger) error {
+func (exp *postgresqlExporter) Init(_ context.Context, cfg plugins.PluginConfig, logger *logrus.Logger) error {
 	dbName := "postgres"
 	exp.logger = logger
 	if err := exp.unmarhshalConfig(string(cfg)); err != nil {

--- a/exporters/postgresql/postgresql_exporter_test.go
+++ b/exporters/postgresql/postgresql_exporter_test.go
@@ -1,21 +1,22 @@
 package postgresql
 
 import (
+	"context"
 	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/indexer/data"
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
-	"gopkg.in/yaml.v3"
-	"testing"
-
 	_ "github.com/algorand/indexer/idb/dummy"
 	"github.com/algorand/indexer/plugins"
-
-	"github.com/stretchr/testify/assert"
 )
 
 var pgsqlConstructor = &Constructor{}
@@ -37,20 +38,20 @@ func TestExporterMetadata(t *testing.T) {
 func TestConnectDisconnectSuccess(t *testing.T) {
 	pgsqlExp := pgsqlConstructor.New()
 	cfg := plugins.PluginConfig("test: true\nconnection-string: ''")
-	assert.NoError(t, pgsqlExp.Init(cfg, logger))
+	assert.NoError(t, pgsqlExp.Init(context.Background(), cfg, logger))
 	assert.NoError(t, pgsqlExp.Close())
 }
 
 func TestConnectUnmarshalFailure(t *testing.T) {
 	pgsqlExp := pgsqlConstructor.New()
 	cfg := plugins.PluginConfig("'")
-	assert.ErrorContains(t, pgsqlExp.Init(cfg, logger), "connect failure in unmarshalConfig")
+	assert.ErrorContains(t, pgsqlExp.Init(context.Background(), cfg, logger), "connect failure in unmarshalConfig")
 }
 
 func TestConnectDbFailure(t *testing.T) {
 	pgsqlExp := pgsqlConstructor.New()
 	cfg := plugins.PluginConfig("")
-	assert.ErrorContains(t, pgsqlExp.Init(cfg, logger), "connect failure constructing db, postgres:")
+	assert.ErrorContains(t, pgsqlExp.Init(context.Background(), cfg, logger), "connect failure constructing db, postgres:")
 }
 
 func TestConfigDefault(t *testing.T) {
@@ -71,14 +72,14 @@ func TestDefaultRoundZero(t *testing.T) {
 func TestHandleGenesis(t *testing.T) {
 	pgsqlExp := pgsqlConstructor.New()
 	cfg := plugins.PluginConfig("test: true")
-	assert.NoError(t, pgsqlExp.Init(cfg, logger))
+	assert.NoError(t, pgsqlExp.Init(context.Background(), cfg, logger))
 	assert.NoError(t, pgsqlExp.HandleGenesis(bookkeeping.Genesis{}))
 }
 
 func TestReceiveInvalidBlock(t *testing.T) {
 	pgsqlExp := pgsqlConstructor.New()
 	cfg := plugins.PluginConfig("test: true")
-	assert.NoError(t, pgsqlExp.Init(cfg, logger))
+	assert.NoError(t, pgsqlExp.Init(context.Background(), cfg, logger))
 
 	invalidBlock := data.BlockData{
 		BlockHeader: bookkeeping.BlockHeader{},
@@ -93,7 +94,7 @@ func TestReceiveInvalidBlock(t *testing.T) {
 func TestReceiveAddBlockSuccess(t *testing.T) {
 	pgsqlExp := pgsqlConstructor.New()
 	cfg := plugins.PluginConfig("test: true")
-	assert.NoError(t, pgsqlExp.Init(cfg, logger))
+	assert.NoError(t, pgsqlExp.Init(context.Background(), cfg, logger))
 
 	block := data.BlockData{
 		BlockHeader: bookkeeping.BlockHeader{},


### PR DESCRIPTION
Resolves #1260 

Adds a context parameter to the exporter init interface.

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Explain the goal of this change and what problem it is solving. Format this cleanly so that it may be used for a commit message, as your changes will be squash-merged.

## Test Plan

How did you test these changes? Please provide the exact scenarios you tested in as much detail as possible including commands, output and rationale.
