### PR TITLE
Adding a link to the data directory documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ There are two primary modes of operation:
 
 In both configurations, a postgres connection string is required. Both DSN and URL formats are supported, [details are available here](https://pkg.go.dev/github.com/jackc/pgx/v4/pgxpool@v4.11.0#ParseConfig).
 
+In addition, the indexer uses a data directory that stores data needed for runtime operation and configuration.
+See the [Data Directory documentation](docs/DataDirectory.md) for how to (re-)initialize this directory in case it is lost or needs to be re-created.
+
 ### Database updater
 In this mode, the database will be populated with data fetched from an [Algorand archival node](https://developer.algorand.org/docs/run-a-node/setup/types/#archival-mode). Because every block must be fetched to bootstrap the database, the initial import for a ledger with a long history will take a while. If the daemon is terminated, it will resume processing wherever it left off.
 


### PR DESCRIPTION

<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

This change is to add a link to the data directory documentation of the indexer. New users starting from an indexer DB snapshot or losing the data directory may not realize that there is some operations that need to be done in that case.

## Test Plan

N/A - documentation