### PR TITLE
Enhancement: Update git submodule with go-algorand release commit `31a1099c`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ _*.json
 
 # Python
 __pycache__
+.venv
 
 # jetbrains IDE
 .idea

--- a/misc/parity/reports/algod2indexer_full.yml
+++ b/misc/parity/reports/algod2indexer_full.yml
@@ -18,15 +18,17 @@ definitions:
         - INDEXER: '"Indicates what type of signature is used by this account, must be one of:\n* sig\n* msig\n* lsig\n* or null if unknown"'
         - ALGOD: '"Indicates what type of signature is used by this account, must be one of:\n* sig\n* msig\n* lsig"'
       total-box-bytes:
-      - INDEXER: '{"description":"For app-accounts only. The total n...'
-      - ALGOD: null
+        description:
+        - INDEXER: '"For app-accounts only. The total number of bytes allocated for the keys and values of boxes which belong to the associated application."'
+        - ALGOD: '"\\[tbxb\\] The total number of bytes used by this account''s app''s box keys and values."'
       total-boxes:
-      - INDEXER: '{"description":"For app-accounts only. The total n...'
-      - ALGOD: null
+        description:
+        - INDEXER: '"For app-accounts only. The total number of boxes which belong to the associated application."'
+        - ALGOD: '"\\[tbx\\] The number of existing boxes created by this account''s app."'
     required:
-    - - INDEXER: '"total-boxes"'
-      - ALGOD: null
     - - INDEXER: '"total-box-bytes"'
+      - ALGOD: null
+    - - INDEXER: '"total-boxes"'
       - ALGOD: null
     - - INDEXER: null
       - ALGOD: '"min-balance"'


### PR DESCRIPTION
## Preparing for Indexer Release

This also fixes the [failing nightly swagger comparison test](https://app.circleci.com/pipelines/github/algorand/indexer/2741/workflows/0045d988-d23e-4344-b7bd-43ad0bdcc2d1/jobs/4056).

Please note that the changes to `misc/parity/reports/algod2indexer_full.yml` declare that the differences between Algod's and Indexer's swagger acceptable in the boxes case.

## Test Plan

CI