### PR TITLE
Ignore no op asset transfers.

### DIFF
--- a/accounting/eval_preload.go
+++ b/accounting/eval_preload.go
@@ -27,7 +27,7 @@ func addToCreatorsRequest(stxnad *transactions.SignedTxnWithAD, assetsReq map[ba
 			!fields.AssetCloseTo.IsZero() && // closeout
 			!fields.AssetSender.IsZero() // clawback
 
-		if fields.XferAsset == 0 && !noOpXfer {
+		if fields.XferAsset != 0 && !noOpXfer {
 			assetsReq[fields.XferAsset] = struct{}{}
 		}
 	case protocol.AssetFreezeTx:

--- a/accounting/eval_preload.go
+++ b/accounting/eval_preload.go
@@ -23,9 +23,9 @@ func addToCreatorsRequest(stxnad *transactions.SignedTxnWithAD, assetsReq map[ba
 	case protocol.AssetTransferTx:
 		fields := &txn.AssetTransferTxnFields
 
-		noOpXfer := (fields.AssetAmount == 0) && (txn.Sender != fields.AssetReceiver) && // optin
-			!fields.AssetCloseTo.IsZero() && // closeout
-			!fields.AssetSender.IsZero() // clawback
+		noOpXfer := (fields.AssetAmount == 0) && (txn.Sender != fields.AssetReceiver) && // not an optin
+			fields.AssetCloseTo.IsZero() && // not a closeout
+			fields.AssetSender.IsZero() // not a clawback
 
 		if fields.XferAsset != 0 && !noOpXfer {
 			assetsReq[fields.XferAsset] = struct{}{}
@@ -118,9 +118,9 @@ func addToAccountsResourcesRequest(stxnad *transactions.SignedTxnWithAD, assetCr
 	case protocol.AssetTransferTx:
 		fields := &txn.AssetTransferTxnFields
 
-		noOpXfer := (fields.AssetAmount == 0) && (txn.Sender != fields.AssetReceiver) && // optin
-			!fields.AssetCloseTo.IsZero() && // closeout
-			!fields.AssetSender.IsZero() // clawback
+		noOpXfer := (fields.AssetAmount == 0) && (txn.Sender != fields.AssetReceiver) && // not an optin
+			fields.AssetCloseTo.IsZero() && // not a closeout
+			fields.AssetSender.IsZero() // not a clawback
 
 		if noOpXfer {
 			break

--- a/accounting/eval_preload.go
+++ b/accounting/eval_preload.go
@@ -23,9 +23,9 @@ func addToCreatorsRequest(stxnad *transactions.SignedTxnWithAD, assetsReq map[ba
 	case protocol.AssetTransferTx:
 		fields := &txn.AssetTransferTxnFields
 
-		noOpXfer := (fields.AssetAmount == 0) &&
-			(txn.Sender != fields.AssetReceiver) &&
-			(fields.AssetCloseTo != basics.Address{})
+		noOpXfer := (fields.AssetAmount == 0) && (txn.Sender != fields.AssetReceiver) && // optin
+			!fields.AssetCloseTo.IsZero() && // closeout
+			!fields.AssetSender.IsZero() // clawback
 
 		if fields.XferAsset == 0 && !noOpXfer {
 			assetsReq[fields.XferAsset] = struct{}{}
@@ -118,9 +118,10 @@ func addToAccountsResourcesRequest(stxnad *transactions.SignedTxnWithAD, assetCr
 	case protocol.AssetTransferTx:
 		fields := &txn.AssetTransferTxnFields
 
-		noOpXfer := (fields.AssetAmount == 0) &&
-			(txn.Sender != fields.AssetReceiver) &&
-			(fields.AssetCloseTo != basics.Address{})
+		noOpXfer := (fields.AssetAmount == 0) && (txn.Sender != fields.AssetReceiver) && // optin
+			!fields.AssetCloseTo.IsZero() && // closeout
+			!fields.AssetSender.IsZero() // clawback
+
 		if noOpXfer {
 			break
 		}

--- a/accounting/eval_preload.go
+++ b/accounting/eval_preload.go
@@ -9,6 +9,19 @@ import (
 	"github.com/algorand/go-algorand/protocol"
 )
 
+func isNoOpAssetXfer(stxnad *transactions.SignedTxnWithAD) bool {
+	txn := &stxnad.Txn
+	fields := &txn.AssetTransferTxnFields
+
+	if txn.Type != protocol.AssetTransferTx {
+		return false
+	}
+
+	return (fields.AssetAmount == 0) && (txn.Sender != fields.AssetReceiver) && // not an optin
+		fields.AssetCloseTo.IsZero() && // not a closeout
+		fields.AssetSender.IsZero() // not a clawback
+}
+
 // Add requests for asset and app creators to `assetsReq` and `appsReq` for the given
 // transaction.
 func addToCreatorsRequest(stxnad *transactions.SignedTxnWithAD, assetsReq map[basics.AssetIndex]struct{}, appsReq map[basics.AppIndex]struct{}) {
@@ -23,11 +36,7 @@ func addToCreatorsRequest(stxnad *transactions.SignedTxnWithAD, assetsReq map[ba
 	case protocol.AssetTransferTx:
 		fields := &txn.AssetTransferTxnFields
 
-		noOpXfer := (fields.AssetAmount == 0) && (txn.Sender != fields.AssetReceiver) && // not an optin
-			fields.AssetCloseTo.IsZero() && // not a closeout
-			fields.AssetSender.IsZero() // not a clawback
-
-		if fields.XferAsset != 0 && !noOpXfer {
+		if fields.XferAsset != 0 && !isNoOpAssetXfer(stxnad) {
 			assetsReq[fields.XferAsset] = struct{}{}
 		}
 	case protocol.AssetFreezeTx:
@@ -116,15 +125,11 @@ func addToAccountsResourcesRequest(stxnad *transactions.SignedTxnWithAD, assetCr
 			}
 		}
 	case protocol.AssetTransferTx:
-		fields := &txn.AssetTransferTxnFields
-
-		noOpXfer := (fields.AssetAmount == 0) && (txn.Sender != fields.AssetReceiver) && // not an optin
-			fields.AssetCloseTo.IsZero() && // not a closeout
-			fields.AssetSender.IsZero() // not a clawback
-
-		if noOpXfer {
+		if isNoOpAssetXfer(stxnad) {
 			break
 		}
+
+		fields := &txn.AssetTransferTxnFields
 
 		creatable := ledger.Creatable{
 			Index: basics.CreatableIndex(fields.XferAsset),

--- a/accounting/eval_preload.go
+++ b/accounting/eval_preload.go
@@ -22,7 +22,12 @@ func addToCreatorsRequest(stxnad *transactions.SignedTxnWithAD, assetsReq map[ba
 		}
 	case protocol.AssetTransferTx:
 		fields := &txn.AssetTransferTxnFields
-		if fields.XferAsset != 0 {
+
+		noOpXfer := (fields.AssetAmount == 0) &&
+			(txn.Sender != fields.AssetReceiver) &&
+			(fields.AssetCloseTo != basics.Address{})
+
+		if fields.XferAsset == 0 && !noOpXfer {
 			assetsReq[fields.XferAsset] = struct{}{}
 		}
 	case protocol.AssetFreezeTx:
@@ -112,6 +117,14 @@ func addToAccountsResourcesRequest(stxnad *transactions.SignedTxnWithAD, assetCr
 		}
 	case protocol.AssetTransferTx:
 		fields := &txn.AssetTransferTxnFields
+
+		noOpXfer := (fields.AssetAmount == 0) &&
+			(txn.Sender != fields.AssetReceiver) &&
+			(fields.AssetCloseTo != basics.Address{})
+		if noOpXfer {
+			break
+		}
+
 		creatable := ledger.Creatable{
 			Index: basics.CreatableIndex(fields.XferAsset),
 			Type:  basics.AssetCreatable,


### PR DESCRIPTION
## Summary

If an asset transfer moves no assets, and is not an optin or closeout transaction, do not prefetch its resources.

## Test Plan

CI and manual testing.