### PR TITLE
tech debt: Indexer initialization improvements

### DIFF
--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -106,6 +106,7 @@ func DaemonCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := runDaemon(cfg); err != nil {
 				fmt.Fprintf(os.Stderr, "Exiting with error: %s\n", err.Error())
+				os.Exit(1)
 			}
 		},
 	}
@@ -335,7 +336,9 @@ func runDaemon(daemonConfig *daemonConfig) error {
 
 	if daemonConfig.algodDataDir != "" {
 		daemonConfig.algodAddr, daemonConfig.algodToken, _, err = fetcher.AlgodArgsForDataDir(daemonConfig.algodDataDir)
-		maybeFail(err, "algod data dir err, %v", err)
+		if err != nil {
+			return fmt.Errorf("algod data dir err, %v", err)
+		}
 	} else if daemonConfig.algodAddr == "" || daemonConfig.algodToken == "" {
 		// no algod was found
 		logger.Info("no algod was found, provide either --algod OR --algod-net and --algod-token to enable")

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -356,7 +356,10 @@ func runDaemon(daemonConfig *daemonConfig) error {
 	opts.AlgodToken = daemonConfig.algodToken
 	opts.AlgodAddr = daemonConfig.algodAddr
 
-	db, availableCh := indexerDbFromFlags(opts)
+	db, availableCh, err := indexerDbFromFlags(opts)
+	if err != nil {
+		return err
+	}
 	defer db.Close()
 	var dataError func() error
 	if daemonConfig.noAlgod != true {

--- a/cmd/algorand-indexer/daemon_test.go
+++ b/cmd/algorand-indexer/daemon_test.go
@@ -17,18 +17,10 @@ import (
 	"github.com/algorand/indexer/util"
 )
 
-func createTempDir(t *testing.T) string {
-	dir, err := os.MkdirTemp("", "indexer")
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
-	return dir
-}
-
 // TestParameterConfigErrorWhenBothFileTypesArePresent test that if both file types are there then it is an error
 func TestParameterConfigErrorWhenBothFileTypesArePresent(t *testing.T) {
 
-	indexerDataDir := createTempDir(t)
+	indexerDataDir := t.TempDir()
 	defer os.RemoveAll(indexerDataDir)
 	for _, configFiletype := range config.FileTypes {
 		autoloadPath := filepath.Join(indexerDataDir, autoLoadParameterConfigFileName+"."+configFiletype)
@@ -47,7 +39,7 @@ func TestParameterConfigErrorWhenBothFileTypesArePresent(t *testing.T) {
 // TestIndexerConfigErrorWhenBothFileTypesArePresent test that if both file types are there then it is an error
 func TestIndexerConfigErrorWhenBothFileTypesArePresent(t *testing.T) {
 
-	indexerDataDir := createTempDir(t)
+	indexerDataDir := t.TempDir()
 	defer os.RemoveAll(indexerDataDir)
 	for _, configFiletype := range config.FileTypes {
 		autoloadPath := filepath.Join(indexerDataDir, autoLoadIndexerConfigFileName+"."+configFiletype)
@@ -67,7 +59,7 @@ func TestIndexerConfigErrorWhenBothFileTypesArePresent(t *testing.T) {
 // enable all parameters are provided together.
 func TestConfigWithEnableAllParamsExpectError(t *testing.T) {
 	for _, configFiletype := range config.FileTypes {
-		indexerDataDir := createTempDir(t)
+		indexerDataDir := t.TempDir()
 		defer os.RemoveAll(indexerDataDir)
 		autoloadPath := filepath.Join(indexerDataDir, autoLoadIndexerConfigFileName+"."+configFiletype)
 		os.WriteFile(autoloadPath, []byte{}, fs.ModePerm)
@@ -83,7 +75,7 @@ func TestConfigWithEnableAllParamsExpectError(t *testing.T) {
 }
 
 func TestConfigDoesNotExistExpectError(t *testing.T) {
-	indexerDataDir := createTempDir(t)
+	indexerDataDir := t.TempDir()
 	defer os.RemoveAll(indexerDataDir)
 	tempConfigFile := indexerDataDir + "/indexer.yml"
 	daemonConfig := &daemonConfig{}
@@ -92,13 +84,13 @@ func TestConfigDoesNotExistExpectError(t *testing.T) {
 	daemonConfig.configFile = tempConfigFile
 	err := runDaemon(daemonConfig)
 	// This error string is probably OS-specific
-	errorStr := fmt.Sprintf("open %s: no such file or directory", tempConfigFile)
+	errorStr := fmt.Sprintf("config file does not exist: open %s: no such file or directory", tempConfigFile)
 	assert.EqualError(t, err, errorStr)
 }
 
 func TestConfigInvalidExpectError(t *testing.T) {
 	b := bytes.NewBufferString("")
-	indexerDataDir := createTempDir(t)
+	indexerDataDir := t.TempDir()
 	defer os.RemoveAll(indexerDataDir)
 	tempConfigFile := indexerDataDir + "/indexer-alt.yml"
 	os.WriteFile(tempConfigFile, []byte(";;;"), fs.ModePerm)
@@ -108,12 +100,12 @@ func TestConfigInvalidExpectError(t *testing.T) {
 	daemonConfig.configFile = tempConfigFile
 	logger.SetOutput(b)
 	err := runDaemon(daemonConfig)
-	errorStr := "While parsing config: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `;;;` into map[string]interface {}"
+	errorStr := fmt.Sprintf("invalid config file (%s): While parsing config: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `;;;` into map[string]interface {}", tempConfigFile)
 	assert.EqualError(t, err, errorStr)
 }
 
 func TestConfigSpecifiedTwiceExpectError(t *testing.T) {
-	indexerDataDir := createTempDir(t)
+	indexerDataDir := t.TempDir()
 	defer os.RemoveAll(indexerDataDir)
 	tempConfigFile := indexerDataDir + "/indexer.yml"
 	os.WriteFile(tempConfigFile, []byte{}, fs.ModePerm)
@@ -130,7 +122,7 @@ func TestConfigSpecifiedTwiceExpectError(t *testing.T) {
 func TestLoadAPIConfigGivenAutoLoadAndUserSuppliedExpectError(t *testing.T) {
 
 	for _, configFiletype := range config.FileTypes {
-		indexerDataDir := createTempDir(t)
+		indexerDataDir := t.TempDir()
 		defer os.RemoveAll(indexerDataDir)
 
 		autoloadPath := filepath.Join(indexerDataDir, autoLoadParameterConfigFileName+"."+configFiletype)
@@ -148,7 +140,7 @@ func TestLoadAPIConfigGivenAutoLoadAndUserSuppliedExpectError(t *testing.T) {
 }
 
 func TestLoadAPIConfigGivenUserSuppliedExpectSuccess(t *testing.T) {
-	indexerDataDir := createTempDir(t)
+	indexerDataDir := t.TempDir()
 	defer os.RemoveAll(indexerDataDir)
 
 	userSuppliedPath := filepath.Join(indexerDataDir, "foobar.yml")
@@ -162,7 +154,7 @@ func TestLoadAPIConfigGivenUserSuppliedExpectSuccess(t *testing.T) {
 
 func TestLoadAPIConfigGivenAutoLoadExpectSuccess(t *testing.T) {
 	for _, configFiletype := range config.FileTypes {
-		indexerDataDir := createTempDir(t)
+		indexerDataDir := t.TempDir()
 		defer os.RemoveAll(indexerDataDir)
 
 		autoloadPath := filepath.Join(indexerDataDir, autoLoadParameterConfigFileName+"."+configFiletype)
@@ -189,7 +181,7 @@ func TestIndexerDataDirCreateFailExpectError(t *testing.T) {
 }
 
 func TestIndexerPidFileExpectSuccess(t *testing.T) {
-	indexerDataDir := createTempDir(t)
+	indexerDataDir := t.TempDir()
 	defer os.RemoveAll(indexerDataDir)
 
 	pidFilePath := path.Join(indexerDataDir, "pidFile")
@@ -198,7 +190,7 @@ func TestIndexerPidFileExpectSuccess(t *testing.T) {
 
 func TestIndexerPidFileCreateFailExpectError(t *testing.T) {
 	for _, configFiletype := range config.FileTypes {
-		indexerDataDir := createTempDir(t)
+		indexerDataDir := t.TempDir()
 		defer os.RemoveAll(indexerDataDir)
 		autoloadPath := filepath.Join(indexerDataDir, autoLoadIndexerConfigFileName+"."+configFiletype)
 		os.WriteFile(autoloadPath, []byte{}, fs.ModePerm)

--- a/cmd/algorand-indexer/import.go
+++ b/cmd/algorand-indexer/import.go
@@ -23,7 +23,11 @@ var importCmd = &cobra.Command{
 			panic(exit{1})
 		}
 
-		db, availableCh := indexerDbFromFlags(idb.IndexerDbOptions{})
+		db, availableCh, err := indexerDbFromFlags(idb.IndexerDbOptions{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, err.Error())
+			return
+		}
 		defer db.Close()
 		<-availableCh
 

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -120,6 +120,7 @@ func init() {
 
 	// Version should be available globally
 	rootCmd.Flags().BoolVarP(&doVersion, "version", "v", false, "print version and exit")
+
 	// Not applied globally to avoid adding to utility commands.
 	addFlags := func(cmd *cobra.Command) {
 		cmd.Flags().StringVarP(&logLevel, "loglevel", "l", "info", "verbosity of logs: [error, warn, info, debug, trace]")
@@ -138,18 +139,6 @@ func init() {
 	// just hard-code yaml since we support multiple yaml filetypes
 	viper.SetConfigType("yaml")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			// Config file not found, not an error since it may be set on the CLI.
-		} else {
-			fmt.Fprintf(os.Stderr, "invalid config file (%s): %v", viper.ConfigFileUsed(), err)
-			panic(exit{1})
-		}
-	} else {
-		fmt.Printf("Using configuration file: %s\n", viper.ConfigFileUsed())
-	}
-
 	viper.SetEnvPrefix(config.EnvPrefix)
 	viper.AutomaticEnv()
 

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -81,17 +81,18 @@ var (
 	logger         *log.Logger
 )
 
-func indexerDbFromFlags(opts idb.IndexerDbOptions) (idb.IndexerDb, chan struct{}) {
+func indexerDbFromFlags(opts idb.IndexerDbOptions) (idb.IndexerDb, chan struct{}, error) {
 	if postgresAddr != "" {
 		db, ch, err := idb.IndexerDbByName("postgres", postgresAddr, opts, logger)
 		maybeFail(err, "could not init db, %v", err)
-		return db, ch
+		return db, ch, nil
 	}
 	if dummyIndexerDb {
-		return dummy.IndexerDb(), nil
+		return dummy.IndexerDb(), nil, nil
 	}
-	logger.Errorf("no import db set")
-	panic(exit{1})
+	err := fmt.Errorf("no import db set")
+	logger.WithError(err)
+	return nil, nil, err
 }
 
 func init() {


### PR DESCRIPTION
## Summary

* Print correct logfile.
* Do not use logger before initialized.
* Do not require data dir in read-only mode.
* Print error messages to the console.
* Avoid calling `BindFlagSet` twice.
* Replace some instances of `panic` with an error return.

## Test Plan

Existing / new unit tests.
Manual testing.