### PR TITLE
lint: Fix errors showing up w/ golanci-lint

### DIFF
--- a/conduit/errors.go
+++ b/conduit/errors.go
@@ -7,5 +7,5 @@ import "fmt"
 type CriticalError struct{}
 
 func (e *CriticalError) Error() string {
-	return fmt.Sprintf("critical error occured")
+	return fmt.Sprintf("critical error occurred")
 }

--- a/conduit/pipeline/pipeline.go
+++ b/conduit/pipeline/pipeline.go
@@ -17,9 +17,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-
-	"github.com/algorand/go-algorand/crypto"
-	"github.com/algorand/go-algorand/data/basics"
 	"gopkg.in/yaml.v3"
 
 	"github.com/algorand/indexer/conduit"
@@ -30,6 +27,9 @@ import (
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/util"
 	"github.com/algorand/indexer/util/metrics"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/basics"
 )
 
 func init() {
@@ -319,7 +319,7 @@ func (p *pipelineImpl) Init() error {
 		for _, cb := range p.metricsCallback {
 			collectors := cb()
 			for _, c := range collectors {
-				prometheus.Register(c)
+				_ = prometheus.Register(c)
 			}
 		}
 		go p.startMetricsServer()
@@ -429,7 +429,7 @@ func (p *pipelineImpl) Start() {
 
 					// Increment Round, update metadata
 					p.pipelineMetadata.NextRound++
-					p.encodeMetadataToFile()
+					_ = p.encodeMetadataToFile()
 
 					// Callback Processors
 					for _, cb := range p.completeCallback {
@@ -518,7 +518,7 @@ func (p *pipelineImpl) initializeOrLoadBlockMetadata() (state, error) {
 // start a http server serving /metrics
 func (p *pipelineImpl) startMetricsServer() {
 	http.Handle("/metrics", promhttp.Handler())
-	http.ListenAndServe(p.cfg.Metrics.Addr, nil)
+	_ = http.ListenAndServe(p.cfg.Metrics.Addr, nil)
 	p.logger.Infof("conduit metrics serving on %s", p.cfg.Metrics.Addr)
 }
 

--- a/conduit/plugins/exporters/postgresql/util/prune.go
+++ b/conduit/plugins/exporters/postgresql/util/prune.go
@@ -5,8 +5,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/algorand/indexer/idb"
 	"github.com/sirupsen/logrus"
+
+	"github.com/algorand/indexer/idb"
 )
 
 // Interval determines how often to delete data

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -11,15 +11,15 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
-	"github.com/algorand/go-algorand-sdk/client/v2/algod"
-	"github.com/algorand/go-algorand/data/bookkeeping"
-	"github.com/algorand/go-algorand/protocol"
-	"github.com/algorand/go-algorand/rpcs"
-
 	"github.com/algorand/indexer/conduit"
 	"github.com/algorand/indexer/conduit/plugins"
 	"github.com/algorand/indexer/conduit/plugins/importers"
 	"github.com/algorand/indexer/data"
+
+	"github.com/algorand/go-algorand-sdk/client/v2/algod"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/protocol"
+	"github.com/algorand/go-algorand/rpcs"
 )
 
 const importerName = "algod"

--- a/conduit/plugins/importers/filereader/filereader.go
+++ b/conduit/plugins/importers/filereader/filereader.go
@@ -12,14 +12,14 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
-	"github.com/algorand/go-algorand/data/bookkeeping"
-
 	"github.com/algorand/indexer/conduit"
 	"github.com/algorand/indexer/conduit/plugins"
 	"github.com/algorand/indexer/conduit/plugins/exporters/filewriter"
 	"github.com/algorand/indexer/conduit/plugins/importers"
 	"github.com/algorand/indexer/data"
 	"github.com/algorand/indexer/util"
+
+	"github.com/algorand/go-algorand/data/bookkeeping"
 )
 
 const importerName = "file_reader"

--- a/conduit/plugins/importers/importer.go
+++ b/conduit/plugins/importers/importer.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/algorand/go-algorand/data/bookkeeping"
-
 	"github.com/algorand/indexer/conduit"
 	"github.com/algorand/indexer/conduit/plugins"
 	"github.com/algorand/indexer/data"
+
+	"github.com/algorand/go-algorand/data/bookkeeping"
 )
 
 // Importer defines the interface for importer plugins

--- a/conduit/plugins/processors/blockprocessor/block_processor.go
+++ b/conduit/plugins/processors/blockprocessor/block_processor.go
@@ -10,6 +10,14 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
+	"github.com/algorand/indexer/accounting"
+	"github.com/algorand/indexer/conduit"
+	"github.com/algorand/indexer/conduit/plugins"
+	"github.com/algorand/indexer/conduit/plugins/processors"
+	indexerledger "github.com/algorand/indexer/conduit/plugins/processors/eval"
+	"github.com/algorand/indexer/data"
+	"github.com/algorand/indexer/util"
+
 	"github.com/algorand/go-algorand/agreement"
 	"github.com/algorand/go-algorand/config"
 	"github.com/algorand/go-algorand/data/basics"
@@ -18,14 +26,6 @@ import (
 	"github.com/algorand/go-algorand/ledger"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/rpcs"
-
-	"github.com/algorand/indexer/accounting"
-	"github.com/algorand/indexer/conduit"
-	"github.com/algorand/indexer/conduit/plugins"
-	"github.com/algorand/indexer/conduit/plugins/processors"
-	indexerledger "github.com/algorand/indexer/conduit/plugins/processors/eval"
-	"github.com/algorand/indexer/data"
-	"github.com/algorand/indexer/util"
 )
 
 const implementationName = "block_evaluator"

--- a/conduit/plugins/processors/blockprocessor/initialize.go
+++ b/conduit/plugins/processors/blockprocessor/initialize.go
@@ -8,12 +8,12 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/algorand/indexer/conduit/plugins/processors/blockprocessor/internal"
+	"github.com/algorand/indexer/fetcher"
+
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/rpcs"
-
-	"github.com/algorand/indexer/conduit/plugins/processors/blockprocessor/internal"
-	"github.com/algorand/indexer/fetcher"
 )
 
 // InitializeLedger will initialize a ledger to the directory given by the

--- a/conduit/plugins/processors/filterprocessor/fields/filter.go
+++ b/conduit/plugins/processors/filterprocessor/fields/filter.go
@@ -3,8 +3,9 @@ package fields
 import (
 	"fmt"
 
-	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/indexer/data"
+
+	"github.com/algorand/go-algorand/data/transactions"
 )
 
 // Operation an operation like "any" or "all" for boolean logic

--- a/conduit/plugins/processors/filterprocessor/fields/searcher.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/algorand/go-algorand/data/transactions"
-
 	"github.com/algorand/indexer/conduit/plugins/processors/filterprocessor/expression"
+
+	"github.com/algorand/go-algorand/data/transactions"
 )
 
 // Searcher searches the struct with an expression and method to call
@@ -55,7 +55,7 @@ func checkTagExistsAndHasCorrectFunction(expressionType expression.FilterType, t
 		// actually reach inside the if conditional unless we intentionally panic.
 		// However, having this function gives additional safety to a critical function
 		if r := recover(); r != nil {
-			outError = fmt.Errorf("error occured regarding tag %s - %v", tag, r)
+			outError = fmt.Errorf("error occurred regarding tag %s - %v", tag, r)
 		}
 	}()
 

--- a/conduit/plugins/processors/filterprocessor/filter_processor.go
+++ b/conduit/plugins/processors/filterprocessor/filter_processor.go
@@ -9,14 +9,14 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
-	"github.com/algorand/go-algorand/data/transactions"
-
 	"github.com/algorand/indexer/conduit"
 	"github.com/algorand/indexer/conduit/plugins"
 	"github.com/algorand/indexer/conduit/plugins/processors"
 	"github.com/algorand/indexer/conduit/plugins/processors/filterprocessor/expression"
 	"github.com/algorand/indexer/conduit/plugins/processors/filterprocessor/fields"
 	"github.com/algorand/indexer/data"
+
+	"github.com/algorand/go-algorand/data/transactions"
 )
 
 const implementationName = "filter_processor"

--- a/idb/dummy/dummy.go
+++ b/idb/dummy/dummy.go
@@ -3,14 +3,14 @@ package dummy
 import (
 	"context"
 
-	"github.com/algorand/go-algorand/crypto"
-
-	"github.com/algorand/go-algorand/data/bookkeeping"
-	"github.com/algorand/go-algorand/data/transactions"
-	"github.com/algorand/go-algorand/ledger/ledgercore"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/algorand/indexer/idb"
+
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/data/transactions"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 )
 
 type dummyIndexerDb struct {

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -6,7 +6,7 @@ import "github.com/prometheus/client_golang/prometheus"
 // metrics handler.
 func RegisterPrometheusMetrics() {
 	for _, c := range collectors {
-		prometheus.Register(c)
+		_ = prometheus.Register(c)
 	}
 }
 

--- a/util/test/mock_algod.go
+++ b/util/test/mock_algod.go
@@ -1,17 +1,18 @@
 package test
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strconv"
+	"strings"
+
 	"github.com/algorand/go-algorand-sdk/client/v2/algod"
 	"github.com/algorand/go-algorand-sdk/client/v2/common/models"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/protocol"
 	"github.com/algorand/go-algorand/rpcs"
-	"net/http"
-	"net/http/httptest"
-	"path"
-	"strconv"
-	"strings"
 )
 
 // AlgodHandler is used to handle http requests to a mock algod server
@@ -52,7 +53,7 @@ func BlockResponder(reqPath string, w http.ResponseWriter) bool {
 		blk := rpcs.EncodedBlockCert{Block: bookkeeping.Block{BlockHeader: bookkeeping.BlockHeader{Round: basics.Round(rnd)}}}
 		blockbytes := protocol.Encode(&blk)
 		w.WriteHeader(http.StatusOK)
-		w.Write(blockbytes)
+		_, _ = w.Write(blockbytes)
 		return true
 	}
 	return false
@@ -64,7 +65,7 @@ func GenesisResponder(reqPath string, w http.ResponseWriter) bool {
 		w.WriteHeader(http.StatusOK)
 		genesis := &bookkeeping.Genesis{}
 		blockbytes := protocol.EncodeJSON(*genesis)
-		w.Write(blockbytes)
+		_, _ = w.Write(blockbytes)
 		return true
 	}
 	return false
@@ -75,7 +76,7 @@ func BlockAfterResponder(reqPath string, w http.ResponseWriter) bool {
 	if strings.Contains(reqPath, "/wait-for-block-after") {
 		w.WriteHeader(http.StatusOK)
 		nStatus := models.NodeStatus{}
-		w.Write(protocol.EncodeJSON(nStatus))
+		_, _ = w.Write(protocol.EncodeJSON(nStatus))
 		return true
 	}
 	return false

--- a/util/test/testutil.go
+++ b/util/test/testutil.go
@@ -7,13 +7,14 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/algorand/go-algorand/data/bookkeeping"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/algorand/go-algorand/data/basics"
-	"github.com/algorand/go-algorand/ledger"
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/util"
+
+	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand/ledger"
 )
 
 var quiet = false

--- a/util/util.go
+++ b/util/util.go
@@ -11,8 +11,9 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/algorand/go-algorand-sdk/encoding/json"
 	"github.com/algorand/go-codec/codec"
+
+	"github.com/algorand/go-algorand-sdk/encoding/json"
 )
 
 // EncodeToFile is used to encode an object to a file. If the file ends in .gz it will be gzipped.


### PR DESCRIPTION


## Summary

Corrects _most_ of the errors showing up when I merge the 2.15.0 release changes (including golangci-lint) into develop.
* misspellings
* unhandled errors -- I've chosen to acknowledge those instead of handle them explicitly
* import order
