### PR TITLE
Bug-Fix: pass failing `nightly_test_indexer_vs_algod`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,10 +119,15 @@ jobs:
       go_version:
         type: string
     steps:
+      - restore_cache:
+        keys:
       - go/install:
         version: << parameters.go_version >>
       - install_dependencies
       - run_indexer_vs_algod
+      - save_cache:
+        key: just-kidding
+        paths:
 
 commands:
   install_dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,6 @@ jobs:
               ]
             }
   indexer_vs_algod_nightly_BOO:   # TEMPorarily adding for test purpose
-    no_cache: true
     machine:
       image: << pipeline.parameters.ubuntu_image >>
     parameters:
@@ -122,6 +121,10 @@ jobs:
     steps:
       - go/install:
         version: << parameters.go_version >>
+        setup:
+          no_cache: true
+        save_cache:
+          no_cache: true
       - install_dependencies
       - run_indexer_vs_algod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ jobs:
               ]
             }
   indexer_vs_algod_nightly_BOO:   # TEMPorarily adding for test purpose
+    no_cache: true
     machine:
       image: << pipeline.parameters.ubuntu_image >>
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,11 +120,8 @@ jobs:
         type: string
     steps:
       - go/install:
+        no_cache: true
         version: << parameters.go_version >>
-        load-cache:
-          no_cache: true
-        save_cache:
-          no_cache: true
       - install_dependencies
       - run_indexer_vs_algod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,14 @@ workflows:
           matrix: &go-version-matrix
             parameters:
               go_version: ["1.17.9"]
+      - test_nightly:  # TEMPorarily adding for test purpose
+          name: nightly_test_with_go_<< matrix.go_version >>
+          context: slack-secrets
+          matrix: &go-version-matrix
+            parameters:
+              go_version: ["1.17.9"]
+      - indexer_vs_algod_nightly_NOT:   # TEMPorarily adding for test purpose
+          name: nightly_test_indexer_vs_algod_NOT
 
   circleci_build_and_test_nightly:
     triggers:
@@ -101,6 +109,12 @@ jobs:
                 }
               ]
             }
+  indexer_vs_algod_nightly_NOT:   # TEMPorarily adding for test purpose
+    machine:
+      image: << pipeline.parameters.ubuntu_image >>
+    steps:
+      - install_dependencies
+      - run_indexer_vs_algod
 
 commands:
   install_dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,8 @@ jobs:
       go_version:
         type: string
     steps:
+      - go/install:
+        version: << parameters.go_version >>
       - install_dependencies
       - run_indexer_vs_algod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ workflows:
           matrix: &go-version-matrix
             parameters:
               go_version: ["1.17.9"]
+      - indexer_vs_algod_nightly_TESTING123TESTING:
+          name: indexer_vs_algod_nightly_TESTING123TESTING
 
   circleci_build_and_test_nightly:
     triggers:
@@ -103,6 +105,12 @@ jobs:
                 }
               ]
             }
+  indexer_vs_algod_nightly_TESTING123TESTING:
+    machine:
+      image: << pipeline.parameters.ubuntu_image >>
+    steps:
+      - install_dependencies
+      - run_indexer_vs_algod
 
 commands:
   install_dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ workflows:
           matrix: &go-version-matrix
             parameters:
               go_version: ["1.17.13"]
-      - indexer_vs_algod_nightly_NOT:   # TEMPorarily adding for test purpose
-          name: nightly_test_indexer_vs_algod_NOT_<< matrix.go_version >>
+      - indexer_vs_algod_nightly_BOO:   # TEMPorarily adding for test purpose
+          name: nightly_test_indexer_vs_algod_BOO_<< matrix.go_version >>
           matrix: &go-version-matrix
             parameters:
               go_version: ["1.17.13"]
@@ -112,7 +112,7 @@ jobs:
                 }
               ]
             }
-  indexer_vs_algod_nightly_NOT:   # TEMPorarily adding for test purpose
+  indexer_vs_algod_nightly_BOO:   # TEMPorarily adding for test purpose
     machine:
       image: << pipeline.parameters.ubuntu_image >>
     parameters:
@@ -148,7 +148,7 @@ commands:
 
       - run:
           name: Install golangci-lint
-          command: go install -v -x -a github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
 
   run_tests:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
 
       - run:
           name: Install golangci-lint
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 
   run_tests:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  go: circleci/go@1.7.0
+  go: circleci/go@1.7.1
   slack: circleci/slack@4.7.1
   codecov: codecov/codecov@3.1.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,10 @@ workflows:
             parameters:
               go_version: ["1.17.13"]
       - indexer_vs_algod_nightly_NOT:   # TEMPorarily adding for test purpose
-          name: nightly_test_indexer_vs_algod_NOT
+          name: nightly_test_indexer_vs_algod_NOT_<< matrix.go_version >>
+          matrix: &go-version-matrix
+            parameters:
+              go_version: ["1.17.13"]
 
   circleci_build_and_test_nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,8 @@ jobs:
     steps:
       - go/install:
         parameters:
-          - version: << parameters.go_version >>
-          - cache: false
+          version: << parameters.go_version >>
+          cache: false
       - install_dependencies
       - run_indexer_vs_algod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,13 +18,13 @@ workflows:
           name: test_with_go_<< matrix.go_version >>
           matrix: &go-version-matrix
             parameters:
-              go_version: ["1.17.9"]
+              go_version: ["1.17.13"]
       - test_nightly:  # TEMPorarily adding for test purpose
           name: nightly_test_with_go_<< matrix.go_version >>
           context: slack-secrets
           matrix: &go-version-matrix
             parameters:
-              go_version: ["1.17.9"]
+              go_version: ["1.17.13"]
       - indexer_vs_algod_nightly_NOT:   # TEMPorarily adding for test purpose
           name: nightly_test_indexer_vs_algod_NOT
 
@@ -41,7 +41,7 @@ workflows:
           context: slack-secrets
           matrix: &go-version-matrix
             parameters:
-              go_version: ["1.17.9"]
+              go_version: ["1.17.13"]
       - indexer_vs_algod_nightly:
           name: nightly_test_indexer_vs_algod
           context: slack-secrets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ jobs:
               ]
             }
   indexer_vs_algod_nightly_BOO:   # TEMPorarily adding for test purpose
+    no_cache: true
     machine:
       image: << pipeline.parameters.ubuntu_image >>
     parameters:
@@ -121,7 +122,6 @@ jobs:
     steps:
       - go/install:
         version: << parameters.go_version >>
-        no_cache: true
       - install_dependencies
       - run_indexer_vs_algod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,6 @@ workflows:
           matrix: &go-version-matrix
             parameters:
               go_version: ["1.17.9"]
-      - indexer_vs_algod_nightly_TESTING123TESTING:
-          name: indexer_vs_algod_nightly_TESTING123TESTING
 
   circleci_build_and_test_nightly:
     triggers:
@@ -105,12 +103,6 @@ jobs:
                 }
               ]
             }
-  indexer_vs_algod_nightly_TESTING123TESTING:
-    machine:
-      image: << pipeline.parameters.ubuntu_image >>
-    steps:
-      - install_dependencies
-      - run_indexer_vs_algod
 
 commands:
   install_dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,8 @@ parameters:
     default: "ubuntu-2004:202107-02"
 
 workflows:
-  version: 2
+  version: 3
   circleci_build_and_test:
-    no_cache: true
     jobs:
       - test:
           name: test_with_go_<< matrix.go_version >>
@@ -31,7 +30,6 @@ workflows:
           matrix: &go-version-matrix
             parameters:
               go_version: ["1.17.13"]
-
   circleci_build_and_test_nightly:
     triggers:
       - schedule:
@@ -62,6 +60,7 @@ jobs:
     steps:
       - go/install:
           version: << parameters.go_version >>
+
       - install_dependencies
       - run_tests
       - codecov/upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ commands:
 
       - run:
           name: Install golangci-lint
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
+          command: go install -v -x -a github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
 
   run_tests:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,25 +11,15 @@ parameters:
     default: "ubuntu-2004:202107-02"
 
 workflows:
-  version: 3
+  version: 2
   circleci_build_and_test:
     jobs:
       - test:
           name: test_with_go_<< matrix.go_version >>
           matrix: &go-version-matrix
             parameters:
-              go_version: ["1.17.13"]
-      - test_nightly:  # TEMPorarily adding for test purpose
-          name: nightly_test_with_go_<< matrix.go_version >>
-          context: slack-secrets
-          matrix: &go-version-matrix
-            parameters:
-              go_version: ["1.17.13"]
-      - indexer_vs_algod_nightly_BOO:   # TEMPorarily adding for test purpose
-          name: nightly_test_indexer_vs_algod_BOO_<< matrix.go_version >>
-          matrix: &go-version-matrix
-            parameters:
-              go_version: ["1.17.13"]
+              go_version: ["1.17.9"]
+
   circleci_build_and_test_nightly:
     triggers:
       - schedule:
@@ -43,7 +33,7 @@ workflows:
           context: slack-secrets
           matrix: &go-version-matrix
             parameters:
-              go_version: ["1.17.13"]
+              go_version: ["1.17.9"]
       - indexer_vs_algod_nightly:
           name: nightly_test_indexer_vs_algod
           context: slack-secrets
@@ -60,8 +50,8 @@ jobs:
     steps:
       - go/install:
           version: << parameters.go_version >>
-
       - install_dependencies
+      - install_linter
       - run_tests
       - codecov/upload
   test_nightly:
@@ -76,6 +66,7 @@ jobs:
       - go/install:
           version: << parameters.go_version >>
       - install_dependencies
+      - install_linter
       - run_tests
       - codecov/upload
       - slack/notify: &slack-fail-event
@@ -112,20 +103,6 @@ jobs:
                 }
               ]
             }
-  indexer_vs_algod_nightly_BOO:   # TEMPorarily adding for test purpose
-    machine:
-      image: << pipeline.parameters.ubuntu_image >>
-    parameters:
-      go_version:
-        type: string
-    steps:
-      - go/install:
-        parameters:
-          version: << parameters.go_version >>
-          cache: false
-          cache-key: go-binary-v2-1.17.9-arch1-linux-amd64-6_106
-      - install_dependencies
-      - run_indexer_vs_algod
 
 commands:
   install_dependencies:
@@ -149,6 +126,7 @@ commands:
 
       - run: echo 'export PATH=$PATH:/usr/local/go/bin:$HOME/.local/bin' >> $BASH_ENV
 
+  install_linter:
       - run:
           name: Install golangci-lint
           command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
 
       - run:
           name: Install golangci-lint
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
 
   run_tests:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,8 @@ commands:
       - run: echo 'export PATH=$PATH:/usr/local/go/bin:$HOME/.local/bin' >> $BASH_ENV
 
   install_linter:
+    description: Install golangci-lint
+    steps:
       - run:
           name: Install golangci-lint
           command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,6 @@ jobs:
         type: string
     steps:
       - go/install:
-        no_cache: true
         version: << parameters.go_version >>
       - install_dependencies
       - run_indexer_vs_algod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
         parameters:
           version: << parameters.go_version >>
           cache: false
-          cache-key: "blahblah"
+          cache-key: go-binary-v2-1.17.9-arch1-linux-amd64-6_106
       - install_dependencies
       - run_indexer_vs_algod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,7 @@ jobs:
     steps:
       - go/install:
         version: << parameters.go_version >>
+        no_cache: true
       - install_dependencies
       - run_indexer_vs_algod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
     steps:
       - go/install:
         version: << parameters.go_version >>
-        setup:
+        load-cache:
           no_cache: true
         save_cache:
           no_cache: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  go: circleci/go@1.7.1
+  go: circleci/go@1.7.0
   slack: circleci/slack@4.7.1
   codecov: codecov/codecov@3.1.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,9 @@ jobs:
   indexer_vs_algod_nightly_NOT:   # TEMPorarily adding for test purpose
     machine:
       image: << pipeline.parameters.ubuntu_image >>
+    parameters:
+      go_version:
+        type: string
     steps:
       - install_dependencies
       - run_indexer_vs_algod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,9 @@ jobs:
         type: string
     steps:
       - go/install:
-        version: << parameters.go_version >>
-        cache: false
+        parameters:
+          - version: << parameters.go_version >>
+          - cache: false
       - install_dependencies
       - run_indexer_vs_algod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,6 @@ jobs:
               ]
             }
   indexer_vs_algod_nightly_BOO:   # TEMPorarily adding for test purpose
-    no_cache: true
     machine:
       image: << pipeline.parameters.ubuntu_image >>
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,15 +119,11 @@ jobs:
       go_version:
         type: string
     steps:
-      - restore_cache:
-        keys:
       - go/install:
         version: << parameters.go_version >>
+        cache: false
       - install_dependencies
       - run_indexer_vs_algod
-      - save_cache:
-        key: just-kidding
-        paths:
 
 commands:
   install_dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,7 @@ jobs:
         parameters:
           version: << parameters.go_version >>
           cache: false
+          cache-key: "blahblah"
       - install_dependencies
       - run_indexer_vs_algod
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ parameters:
 workflows:
   version: 2
   circleci_build_and_test:
+    no_cache: true
     jobs:
       - test:
           name: test_with_go_<< matrix.go_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
 
       - run:
           name: Install golangci-lint
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
 
   run_tests:
     steps:


### PR DESCRIPTION
## Summary

The `nightly_test_indexer_vs_algod` started failing recently because of the following chain of coincidences:
1. Introduction of `golanci-lint` in #1359 
2. The installed `golangci-lint` requires go $\geq$ 1.17
3. `nightly_test_indexer_vs_algod` runs on the default Circle golang orb version (1.16)

## Solution

Break `install_linter` out of `install_dependencies` and have all the jobs run `install_linter` after `install_dependencies` except for `nightly_test_indexer_vs_algod` which is doesn't need linting, and therefore doesn't need to upgrade its golang.

## Test Plan

Once this is merged into develop, the nightly test will confirm🤞 that the fix is correct. In the meanwhile, this [commit](https://github.com/algorand/indexer/commit/c9d6eb707859b9cdcab2440970ff0743c97c6d48) (the diff is confusing because of the previous state of the repo) introduced a temporary test that simulates the `indexer_vs_algod_nightly_TESTING123TESTING` and we can see that [the test passed on circle](https://app.circleci.com/pipelines/github/algorand/indexer/2965/workflows/f243f829-bea3-4baf-96db-76a9e8beca79/jobs/4337). Here's a screenshot of the temporarily introduced test:

<img width="563" alt="image" src="https://user-images.githubusercontent.com/291133/205662758-57764d4f-e574-4617-966c-1257cdf554f3.png">
