### PR TITLE
conduit: Fix init template and allow plugins which have empty config.

### DIFF
--- a/cmd/conduit/conduit.yml.example
+++ b/cmd/conduit/conduit.yml.example
@@ -1,10 +1,17 @@
 # Generated conduit configuration file.
+log-level: INFO
+
+# When enabled prometheus metrics are available on '/metrics'
+metrics:
+  mode: OFF
+  addr: ":9999"
+  prefix: "conduit"
 
 # The importer is typically an algod archival instance.
 importer:
     name: algod
     config:
-      - netaddr: "your algod address here"
+        netaddr: "your algod address here"
         token: "your algod token here"
 
 # One or more processors may be defined to manipulate what data
@@ -15,6 +22,7 @@ processors:
 # Here the filewriter is defined which writes the raw block
 # data to files.
 exporter:
-    name: filewriter
+    name: file_writer
     config:
-      - block-dir: "path where data should be written"
+        # optionally provide a different directory to store blocks.
+        #block-dir: "path where data should be written"

--- a/conduit/pipeline/pipeline.go
+++ b/conduit/pipeline/pipeline.go
@@ -74,14 +74,6 @@ func (cfg *Config) Valid() error {
 		}
 	}
 
-	if len(cfg.Importer.Config) == 0 {
-		return fmt.Errorf("Args.Valid(): importer configuration was empty")
-	}
-
-	if len(cfg.Exporter.Config) == 0 {
-		return fmt.Errorf("Args.Valid(): exporter configuration was empty")
-	}
-
 	// If it is a negative time, it is an error
 	if cfg.RetryDelay < 0 {
 		return fmt.Errorf("Args.Valid(): invalid retry delay - time duration was negative (%s)", cfg.RetryDelay.String())

--- a/conduit/pipeline/pipeline_test.go
+++ b/conduit/pipeline/pipeline_test.go
@@ -56,21 +56,6 @@ func TestPipelineConfigValidity(t *testing.T) {
 
 		{"empty config", Config{ConduitArgs: nil}, "Args.Valid(): conduit args were nil"},
 		{"invalid log level", Config{ConduitArgs: &conduit.Args{ConduitDataDir: ""}, PipelineLogLevel: "asdf"}, "Args.Valid(): pipeline log level (asdf) was invalid:"},
-		{"importer config was 0",
-			Config{
-				ConduitArgs:      &conduit.Args{ConduitDataDir: ""},
-				PipelineLogLevel: "info",
-				Importer:         NameConfigPair{"test", map[string]interface{}{}},
-			}, "Args.Valid(): importer configuration was empty"},
-
-		{"exporter config was 0",
-			Config{
-				ConduitArgs:      &conduit.Args{ConduitDataDir: ""},
-				PipelineLogLevel: "info",
-				Importer:         NameConfigPair{"test", map[string]interface{}{"a": "a"}},
-				Processors:       []NameConfigPair{{"test", map[string]interface{}{"a": "a"}}},
-				Exporter:         NameConfigPair{"test", map[string]interface{}{}},
-			}, "Args.Valid(): exporter configuration was empty"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

This is a stopgap fix for the init template until #1360 is finished. This PR overlaps slightly with https://github.com/algorand/indexer/pull/1372

## Test Plan

Manual testing.