### PR TITLE
conduit: Add version flag to conduit root command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ export GO_IMAGE = golang:$(shell go version | cut -d ' ' -f 3 | tail -c +3 )
 all: conduit cmd/algorand-indexer/algorand-indexer go-algorand idb/postgres/internal/schema/setup_postgres_sql.go idb/mocks/IndexerDb.go
 
 conduit: go-algorand
-	go generate ./... && cd cmd/conduit && go build
+	go generate ./... && cd cmd/conduit && go build -ldflags="${GOLDFLAGS}"
 
 cmd/algorand-indexer/algorand-indexer: idb/postgres/internal/schema/setup_postgres_sql.go go-algorand
 	cd cmd/algorand-indexer && go build -ldflags="${GOLDFLAGS}"

--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -66,7 +66,7 @@ var rootCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if doVersion {
 			fmt.Printf("%s\n", version.LongVersion())
-			panic(exit{0})
+			os.Exit(0)
 		}
 	},
 }

--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/algorand/indexer/conduit/plugins/importers/all"
 	_ "github.com/algorand/indexer/conduit/plugins/processors/all"
 	"github.com/algorand/indexer/loggers"
+	"github.com/algorand/indexer/version"
 )
 
 var (
@@ -79,6 +80,7 @@ func runConduitCmdWithConfig(args *conduit.Args) error {
 // makeConduitCmd creates the main cobra command, initializes flags
 func makeConduitCmd() *cobra.Command {
 	cfg := &conduit.Args{}
+	var vFlag bool
 	cmd := &cobra.Command{
 		Use:   "conduit",
 		Short: "run the conduit framework",
@@ -87,12 +89,20 @@ func makeConduitCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runConduitCmdWithConfig(cfg)
 		},
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if vFlag {
+				fmt.Println("Conduit Pre-Release")
+				fmt.Printf("%s\n", version.LongVersion())
+				os.Exit(0)
+			}
+		},
 		SilenceUsage: true,
 		// Silence errors because our logger will catch and print any errors
 		SilenceErrors: true,
 	}
 	cmd.Flags().StringVarP(&cfg.ConduitDataDir, "data-dir", "d", "", "set the data directory for the conduit binary")
 	cmd.Flags().Uint64VarP(&cfg.NextRoundOverride, "next-round-override", "r", 0, "set the starting round. Overrides next-round in metadata.json")
+	cmd.Flags().BoolVarP(&vFlag, "version", "v", false, "print the conduit version")
 
 	cmd.AddCommand(list.Command)
 


### PR DESCRIPTION
## Summary

Simple version flag that hooks into the same system Indexer uses.

## Test Plan

Manually.