### PR TITLE
docs: Docs automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cmd/conduit/conduit
 api/.3tmp.json
 api/generate
 tmp/
+conduit-docs/
 
 # Binaries for programs and plugins
 *.exe

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ cmd/conduit/conduit
 api/.3tmp.json
 api/generate
 tmp/
-conduit-docs/
+./conduit-docs/
 
 # Binaries for programs and plugins
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,11 @@ export GO_IMAGE = golang:$(shell go version | cut -d ' ' -f 3 | tail -c +3 )
 # This is the default target, build everything:
 all: conduit cmd/algorand-indexer/algorand-indexer go-algorand idb/postgres/internal/schema/setup_postgres_sql.go idb/mocks/IndexerDb.go
 
-conduit: go-algorand
+conduit: go-algorand conduit-docs
 	go generate ./... && cd cmd/conduit && go build -ldflags="${GOLDFLAGS}"
+
+conduit-docs:
+	go install ./cmd/conduit-docs/
 
 cmd/algorand-indexer/algorand-indexer: idb/postgres/internal/schema/setup_postgres_sql.go go-algorand
 	cd cmd/algorand-indexer && go build -ldflags="${GOLDFLAGS}"

--- a/Makefile
+++ b/Makefile
@@ -114,4 +114,4 @@ indexer-v-algod: nightly-setup indexer-v-algod-swagger nightly-teardown
 update-submodule:
 	git submodule update --remote
 
-.PHONY: all test e2e integration fmt lint deploy sign test-package package fakepackage cmd/algorand-indexer/algorand-indexer idb/mocks/IndexerDb.go go-algorand indexer-v-algod conduit
+.PHONY: all test e2e integration fmt lint deploy sign test-package package fakepackage cmd/algorand-indexer/algorand-indexer idb/mocks/IndexerDb.go go-algorand indexer-v-algod conduit conduit-docs

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,8 @@ export GO_IMAGE = golang:$(shell go version | cut -d ' ' -f 3 | tail -c +3 )
 # This is the default target, build everything:
 all: conduit cmd/algorand-indexer/algorand-indexer go-algorand idb/postgres/internal/schema/setup_postgres_sql.go idb/mocks/IndexerDb.go
 
-conduit: go-algorand generate conduit-docs
-	cd cmd/conduit && go build -ldflags="${GOLDFLAGS}"
-
-generate: conduit-docs
-	go generate ./...
+conduit: go-algorand conduit-docs
+	go generate ./... && cd cmd/conduit && go build -ldflags="${GOLDFLAGS}"
 
 conduit-docs:
 	go install ./cmd/conduit-docs/

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ package: go-algorand
 	misc/release.py --host-only --outdir $(PKG_DIR)
 
 # used in travis test builds; doesn't verify that tag and .version match
-fakepackage: go-algorand
+fakepackage: go-algorand conduit-docs
 	rm -rf $(PKG_DIR)
 	mkdir -p $(PKG_DIR)
 	misc/release.py --host-only --outdir $(PKG_DIR) --fake-release

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,11 @@ export GO_IMAGE = golang:$(shell go version | cut -d ' ' -f 3 | tail -c +3 )
 # This is the default target, build everything:
 all: conduit cmd/algorand-indexer/algorand-indexer go-algorand idb/postgres/internal/schema/setup_postgres_sql.go idb/mocks/IndexerDb.go
 
-conduit: go-algorand conduit-docs
-	go generate ./... && cd cmd/conduit && go build -ldflags="${GOLDFLAGS}"
+conduit: go-algorand generate conduit-docs
+	cd cmd/conduit && go build -ldflags="${GOLDFLAGS}"
+
+generate: conduit-docs
+	go generate ./...
 
 conduit-docs:
 	go install ./cmd/conduit-docs/

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ integration: cmd/algorand-indexer/algorand-indexer
 	curl -s https://algorand-testdata.s3.amazonaws.com/indexer/test_blockdata/create_destroy.tar.bz2 -o test/blockdata/create_destroy.tar.bz2
 	test/postgres_integration_test.sh
 
-e2e: cmd/algorand-indexer/algorand-indexer
+e2e: cmd/algorand-indexer/algorand-indexer conduit-docs
 	cd e2e_tests/docker/indexer/ && docker-compose build --build-arg GO_IMAGE=${GO_IMAGE} && docker-compose up --exit-code-from e2e
 
 e2e-conduit: conduit

--- a/cmd/conduit-docs/README.md
+++ b/cmd/conduit-docs/README.md
@@ -1,0 +1,77 @@
+## conduit-docs
+
+`conduit-docts` is a utility used to generate markdown files from Conduit plugin config structs.  
+It's usage is designed around `//go:generate`, which should be run on each plugin's `*.go` config file.
+
+### Converting structs to graphs
+The structs within the file will be turned into a graph listing the yaml key, the type of the entry, and
+using the comment above each field as a description.
+
+For example,
+
+```go
+package example 
+
+//go:generate conduit-docs output-dir
+
+type Config struct {
+	// description field of the graph
+	Field string `yaml:"field-name"`
+}
+```
+will output the following graph:
+<table>
+<tr>
+<th>key</th><th>type</th><th>description</th>
+</tr>
+<tr>
+<td>field-name</td><td>string</td><td>description field of the graph</td>
+</tr>
+</table>
+
+### Additional data in header/footer
+
+In addition to converting structs to documentation graphs, you can add additional markdown to the top and bottom of the
+output document via comments denoted with certain values.
+
+A multi-line comment beginning with `/*Header` will be added to the beginning of the document.
+
+And a multi-line comment beginning with `/*Footer` will be added to the end of the document.
+
+So the following config,
+
+```go
+package example 
+
+//go:generate conduit-docs output-dir
+
+/*Header
+## Config Documentation
+This is a config which is being documented.
+ */
+
+type Config struct {
+	// description field of the graph
+	Field string `yaml:"field-name"`
+}
+/*Footer
+## Examples
+These are some examples  
+`Foo=bar`
+ */
+```
+will output the following document:
+## Config Documentation
+This is a config which is being documented.
+<table>
+<tr>
+<th>key</th><th>type</th><th>description</th>
+</tr>
+<tr>
+<td>field-name</td><td>string</td><td>description field of the graph</td>
+</tr>
+</table>
+
+## Examples
+These are some examples  
+`Foo=bar`

--- a/cmd/conduit-docs/README.md
+++ b/cmd/conduit-docs/README.md
@@ -3,6 +3,12 @@
 `conduit-docts` is a utility used to generate markdown files from Conduit plugin config structs.  
 It's usage is designed around `//go:generate`, which should be run on each plugin's `*.go` config file.
 
+### File Names
+The output file name will be the go package name suffixed with `.md`
+
+To override the output filename, use a comment beginning with `//Name: ` The remaining portion of the comment will be
+suffixed with `.md` and used as the file name.
+
 ### Converting structs to graphs
 The structs within the file will be turned into a graph listing the yaml key, the type of the entry, and
 using the comment above each field as a description.

--- a/cmd/conduit-docs/main.go
+++ b/cmd/conduit-docs/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+// generateMd takes the path of a file containing a struct definition named "Config", and an output directory,
+// and writes a markdown file to the outputDir containing mkdocs-style documentation for the Config struct
+func generateMd(configPath string, outputDir string) error {
+	// parse the config file
+	bytes, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+	fset := token.NewFileSet()
+	pf, err := parser.ParseFile(fset, configPath, bytes, parser.ParseComments)
+	// _ = ast.Print(fset, pf)
+	if err != nil {
+		return err
+	}
+	md := ""
+	for _, decl := range pf.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		typeTok, ok := genDecl.Specs[0].(*ast.TypeSpec)
+		if !ok {
+			continue
+		}
+		structType, ok := typeTok.Type.(*ast.StructType)
+		if !ok {
+			continue
+		}
+
+		md = md + processConfig(structType, typeTok.Name.Name)
+	}
+	err = os.MkdirAll(outputDir, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	docPath := path.Join(outputDir, pf.Name.Name+".md")
+	return os.WriteFile(docPath, []byte(md), os.ModePerm)
+}
+
+type tableEntry struct {
+	key         string
+	valueType   string
+	description string
+}
+
+func (t tableEntry) renderMd() string {
+	return "| " + t.key + " | " + t.valueType + " | " + t.description + " |"
+}
+
+func renderConfigTable(typeName string, entries []tableEntry) string {
+	header := "| key | type | description |\n|---|---|---|"
+	table := []string{header}
+	for _, entry := range entries {
+		table = append(table, entry.renderMd())
+	}
+	return strings.Join(table, "\n")
+}
+
+func processConfig(configStruct *ast.StructType, structName string) string {
+	var tableEntries []tableEntry
+	for _, field := range configStruct.Fields.List {
+		// TODO We don't handle embedded structs
+		comment := strings.ReplaceAll(field.Doc.Text(), "\n", " ")
+		tag := field.Tag.Value
+		var valueType string
+		ident, ok := field.Type.(*ast.Ident)
+		if ok {
+			valueType = ident.Name
+		}
+		selExpr, ok := field.Type.(*ast.SelectorExpr)
+		if ok {
+			valueType = selExpr.X.(*ast.Ident).Name + "." + selExpr.Sel.Name
+		}
+		tableEntries = append(tableEntries, tableEntry{
+			key:         tag,
+			valueType:   valueType,
+			description: comment,
+		})
+	}
+	return renderConfigTable(structName, tableEntries)
+}
+
+func main() {
+	usage := "USAGE: //go:generate conduit-docs <path-to-output-dir>"
+	// go:generate conduit-docs [path]
+	if len(os.Args) == 2 {
+		err := generateMd(os.Getenv("GOFILE"), os.Args[1])
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	fmt.Println(usage)
+	os.Exit(1)
+}

--- a/cmd/conduit-docs/main.go
+++ b/cmd/conduit-docs/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 )
 
+const namePrefix = "Name: "
 const headerPrefix = "Header\n"
 const footerPrefix = "Footer\n"
 
@@ -31,6 +32,7 @@ func generateMd(configPath string, outputDir string) error {
 	var body string
 	var title string
 	var examples string
+	var fileName string
 	// Process freestanding comments into docs sections
 	for _, comm := range pf.Comments {
 		if strings.HasPrefix(comm.Text(), headerPrefix) {
@@ -38,6 +40,10 @@ func generateMd(configPath string, outputDir string) error {
 		}
 		if strings.HasPrefix(comm.Text(), footerPrefix) {
 			examples = strings.TrimPrefix(comm.Text(), footerPrefix)
+		}
+		if strings.HasPrefix(comm.Text(), namePrefix) {
+			fileName = strings.TrimSuffix(strings.TrimPrefix(comm.Text(), namePrefix), "\n")
+			fmt.Println(fileName)
 		}
 	}
 	// Process struct decls into tables describing their fields
@@ -61,7 +67,10 @@ func generateMd(configPath string, outputDir string) error {
 	if err != nil {
 		return err
 	}
-	docPath := path.Join(outputDir, pf.Name.Name+".md")
+	if fileName == "" {
+		fileName = pf.Name.Name
+	}
+	docPath := path.Join(outputDir, fileName+".md")
 	return os.WriteFile(docPath, []byte(title+body+examples), os.ModePerm)
 }
 

--- a/cmd/conduit-docs/main.go
+++ b/cmd/conduit-docs/main.go
@@ -24,7 +24,7 @@ func generateMd(configPath string, outputDir string) error {
 	}
 	fset := token.NewFileSet()
 	pf, err := parser.ParseFile(fset, configPath, bytes, parser.ParseComments)
-	_ = ast.Print(fset, pf)
+	// _ = ast.Print(fset, pf)
 	if err != nil {
 		return err
 	}

--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -9,6 +9,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
 
 	"github.com/algorand/indexer/cmd/conduit/internal/list"
 	"github.com/algorand/indexer/conduit"
@@ -177,6 +178,17 @@ func makeInitCmd() *cobra.Command {
 }
 
 func main() {
+	// Hidden command to generate docs in a given directory
+	// conduit generate-docs [path]
+	if len(os.Args) == 3 && os.Args[1] == "generate-docs" {
+		err := doc.GenMarkdownTree(conduitCmd, os.Args[2])
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	if err := conduitCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/conduit/plugins/exporters/filewriter/file_exporter_config.go
+++ b/conduit/plugins/exporters/filewriter/file_exporter_config.go
@@ -1,5 +1,7 @@
 package filewriter
 
+//go:generate conduit-docs ../../../../conduit-docs/
+
 // Config specific to the file exporter
 type Config struct {
 	// BlocksDir is an optional path to a directory where block data should be

--- a/conduit/plugins/exporters/filewriter/file_exporter_config.go
+++ b/conduit/plugins/exporters/filewriter/file_exporter_config.go
@@ -2,6 +2,8 @@ package filewriter
 
 //go:generate conduit-docs ../../../../conduit-docs/
 
+//Name: conduit_exporters_filewriter
+
 // Config specific to the file exporter
 type Config struct {
 	/* <code>blocks-dir</code> is an optional path to a directory where block data should be

--- a/conduit/plugins/exporters/filewriter/file_exporter_config.go
+++ b/conduit/plugins/exporters/filewriter/file_exporter_config.go
@@ -4,16 +4,21 @@ package filewriter
 
 // Config specific to the file exporter
 type Config struct {
-	// BlocksDir is an optional path to a directory where block data should be
-	// stored. The directory is created if it doesn't exist. If no directory is
-	// provided the default plugin data directory is used.
+	/* <code>blocks-dir</code> is an optional path to a directory where block data should be
+	stored.<br/>
+	The directory is created if it doesn't exist.<br/>
+	If no directory is provided the default plugin data directory is used.
+	*/
 	BlocksDir string `yaml:"block-dir"`
-	// FilenamePattern is the format used to write block files. It uses go
-	// string formatting and should accept one number for the round.
-	// If the file has a '.gz' extension, blocks will be gzipped.
-	// Default: "%[1]d_block.json"
+	/* <code>filename-pattern</code> is the format used to write block files. It uses go
+	string formatting and should accept one number for the round.<br/>
+	If the file has a '.gz' extension, blocks will be gzipped.
+	Default:
+
+		"%[1]d_block.json"
+	*/
 	FilenamePattern string `yaml:"filename-pattern"`
-	// DropCertificate is used to remove the vote certificate from the block data before writing files.
+	// <code>drop-certificate</code> is used to remove the vote certificate from the block data before writing files.
 	DropCertificate bool `yaml:"drop-certificate"`
 
 	// TODO: compression level - Default, Fastest, Best compression, etc

--- a/conduit/plugins/exporters/postgresql/postgresql_exporter_config.go
+++ b/conduit/plugins/exporters/postgresql/postgresql_exporter_config.go
@@ -1,5 +1,7 @@
 package postgresql
 
+//go:generate conduit-docs ../../../../conduit-docs/
+
 import (
 	"github.com/algorand/indexer/conduit/plugins/exporters/postgresql/util"
 )

--- a/conduit/plugins/exporters/postgresql/postgresql_exporter_config.go
+++ b/conduit/plugins/exporters/postgresql/postgresql_exporter_config.go
@@ -10,16 +10,18 @@ import (
 
 // ExporterConfig specific to the postgresql exporter
 type ExporterConfig struct {
-	// Pgsql connection string
-	// See https://github.com/jackc/pgconn for more details
+	/* <code>connectionstring</code> is the Postgresql connection string<br/>
+	See https://github.com/jackc/pgconn for more details
+	*/
 	ConnectionString string `yaml:"connection-string"`
-	// Maximum connection number for connection pool
-	// This means the total number of active queries that can be running
-	// concurrently can never be more than this
+	/* <code>max-conn</code> specifies the maximum connection number for the connection pool.<br/>
+	This means the total number of active queries that can be running concurrently can never be more than this.
+	*/
 	MaxConn uint32 `yaml:"max-conn"`
-	// The test flag will replace an actual DB connection being created via the connection string,
-	// with a mock DB for unit testing.
+	/* <code>test</code> will replace an actual DB connection being created via the connection string,
+	with a mock DB for unit testing.
+	*/
 	Test bool `yaml:"test"`
-	// Delete has the configuration for data pruning.
+	// <code>delete-task</code> is the configuration for data pruning.
 	Delete util.PruneConfigurations `yaml:"delete-task"`
 }

--- a/conduit/plugins/exporters/postgresql/postgresql_exporter_config.go
+++ b/conduit/plugins/exporters/postgresql/postgresql_exporter_config.go
@@ -6,6 +6,8 @@ import (
 	"github.com/algorand/indexer/conduit/plugins/exporters/postgresql/util"
 )
 
+//Name: conduit_exporters_postgresql
+
 // serde for converting an ExporterConfig to/from a PostgresqlExporterConfig
 
 // ExporterConfig specific to the postgresql exporter

--- a/conduit/plugins/importers/algod/algod_importer_config.go
+++ b/conduit/plugins/importers/algod/algod_importer_config.go
@@ -1,5 +1,7 @@
 package algodimporter
 
+//go:generate conduit-docs ../../../../conduit-docs/
+
 // Config specific to the algod importer
 type Config struct {
 	// Algod netaddr string

--- a/conduit/plugins/importers/algod/algod_importer_config.go
+++ b/conduit/plugins/importers/algod/algod_importer_config.go
@@ -4,8 +4,8 @@ package algodimporter
 
 // Config specific to the algod importer
 type Config struct {
-	// Algod netaddr string
+	// <code>netaddr</code> is the Algod network address. It must be either an <code>http</code> or <code>https</code> URL.
 	NetAddr string `yaml:"netaddr"`
-	// Algod rest endpoint token
+	// <code>token</code> is the Algod API endpoint token.
 	Token string `yaml:"token"`
 }

--- a/conduit/plugins/importers/algod/algod_importer_config.go
+++ b/conduit/plugins/importers/algod/algod_importer_config.go
@@ -2,6 +2,8 @@ package algodimporter
 
 //go:generate conduit-docs ../../../../conduit-docs/
 
+//Name: conduit_importers_algod
+
 // Config specific to the algod importer
 type Config struct {
 	// <code>netaddr</code> is the Algod network address. It must be either an <code>http</code> or <code>https</code> URL.

--- a/conduit/plugins/importers/filereader/filereader_config.go
+++ b/conduit/plugins/importers/filereader/filereader_config.go
@@ -1,5 +1,7 @@
 package fileimporter
 
+//go:generate conduit-docs ../../../../conduit-docs/
+
 import "time"
 
 // Config specific to the file importer

--- a/conduit/plugins/importers/filereader/filereader_config.go
+++ b/conduit/plugins/importers/filereader/filereader_config.go
@@ -6,16 +6,22 @@ import "time"
 
 // Config specific to the file importer
 type Config struct {
-	// BlocksDir is the path to a directory where block data is stored.
+	// <code>block-dir</code> is the path to a directory where block data is stored.
 	BlocksDir string `yaml:"block-dir"`
-	// RetryDuration controls the delay between checks when the importer has
-	// caught up and is waiting for new blocks to appear.
+	/* <code>retry-duration</code> controls the delay between checks when the importer has caught up and is waiting for new blocks to appear.<br/>
+	The input duration will be interpreted in nanoseconds.
+	*/
 	RetryDuration time.Duration `yaml:"retry-duration"`
-	// RetryCount controls the number of times to check for a missing block
-	// before generating an error. The retry count and retry duration should
-	// be configured according the expected round time.
+	/* <code>retry-count</code> controls the number of times to check for a missing block
+	before generating an error. The retry count and retry duration should
+	be configured according the expected round time.
+	*/
 	RetryCount uint64 `yaml:"retry-count"`
-	// FilenamePattern is the format used to find block files. It uses go string formatting and should accept one number for the round.
+	/* <code>filename-pattern</code> is the format used to find block files. It uses go string formatting and should accept one number for the round.
+	The default pattern is
+
+	"%[1]d_block.json"
+	*/
 	FilenamePattern string `yaml:"filename-pattern"`
 
 	// TODO: Option to delete files after processing them

--- a/conduit/plugins/importers/filereader/filereader_config.go
+++ b/conduit/plugins/importers/filereader/filereader_config.go
@@ -4,6 +4,8 @@ package fileimporter
 
 import "time"
 
+//Name: conduit_importers_filereader
+
 // Config specific to the file importer
 type Config struct {
 	// <code>block-dir</code> is the path to a directory where block data is stored.

--- a/conduit/plugins/processors/blockprocessor/config.go
+++ b/conduit/plugins/processors/blockprocessor/config.go
@@ -1,12 +1,18 @@
 package blockprocessor
 
+//go:generate conduit-docs ../../../../conduit-docs/
+
 // Config configuration for a block processor
 type Config struct {
 	// Catchpoint to initialize the local ledger to
 	Catchpoint string `yaml:"catchpoint"`
 
-	LedgerDir    string `yaml:"ledger-dir"`
+	// Ledger directory
+	LedgerDir string `yaml:"ledger-dir"`
+	// Algod data directory
 	AlgodDataDir string `yaml:"algod-data-dir"`
-	AlgodToken   string `yaml:"algod-token"`
-	AlgodAddr    string `yaml:"algod-addr"`
+	// Algod token
+	AlgodToken string `yaml:"algod-token"`
+	// Algod address
+	AlgodAddr string `yaml:"algod-addr"`
 }

--- a/conduit/plugins/processors/blockprocessor/config.go
+++ b/conduit/plugins/processors/blockprocessor/config.go
@@ -2,6 +2,12 @@ package blockprocessor
 
 //go:generate conduit-docs ../../../../conduit-docs/
 
+/*Header
+## The <code>block_processor</code> Plugin
+This plugin runs a local ledger, processing blocks passed to it, and adding
+
+*/
+
 // Config configuration for a block processor
 type Config struct {
 	/* <code>catchpoint</code> to initialize the local ledger to.<br/>
@@ -19,3 +25,17 @@ type Config struct {
 	// <code>algod-addr</code> is the address of the Algod server
 	AlgodAddr string `yaml:"algod-addr"`
 }
+
+/*Footer
+
+### Example Configs
+
+
+```yaml
+config:
+  - any:
+    - tag: ""
+	  expression: ""
+	  expression-type: ""
+```
+*/

--- a/conduit/plugins/processors/blockprocessor/config.go
+++ b/conduit/plugins/processors/blockprocessor/config.go
@@ -2,6 +2,8 @@ package blockprocessor
 
 //go:generate conduit-docs ../../../../conduit-docs/
 
+//Name: conduit_processors_blockevaluator
+
 /*Header
 ## The <code>block_processor</code> Plugin
 This plugin runs a local ledger, processing blocks passed to it, and adding

--- a/conduit/plugins/processors/blockprocessor/config.go
+++ b/conduit/plugins/processors/blockprocessor/config.go
@@ -4,15 +4,18 @@ package blockprocessor
 
 // Config configuration for a block processor
 type Config struct {
-	// Catchpoint to initialize the local ledger to
+	/* <code>catchpoint</code> to initialize the local ledger to.<br/>
+	For more data on ledger catchpoints, see the
+	<a hre=https://developer.algorand.org/docs/run-a-node/operations/catchup/>Algorand developer docs</a>
+	*/
 	Catchpoint string `yaml:"catchpoint"`
 
-	// Ledger directory
+	// <code>ledger-dir</code> is the directory which contains the ledger.
 	LedgerDir string `yaml:"ledger-dir"`
-	// Algod data directory
+	// <code>algod-data-dir</code> is the algod data directory.
 	AlgodDataDir string `yaml:"algod-data-dir"`
-	// Algod token
+	// <code>algod-token</code> is the API token for Algod usage.
 	AlgodToken string `yaml:"algod-token"`
-	// Algod address
+	// <code>algod-addr</code> is the address of the Algod server
 	AlgodAddr string `yaml:"algod-addr"`
 }

--- a/conduit/plugins/processors/filterprocessor/config.go
+++ b/conduit/plugins/processors/filterprocessor/config.go
@@ -1,4 +1,7 @@
+// Package filterprocessor docs
 package filterprocessor
+
+//go:generate conduit-docs ../../../../conduit-docs/
 
 import (
 	"github.com/algorand/indexer/conduit/plugins/processors/filterprocessor/expression"
@@ -16,6 +19,13 @@ type SubConfig struct {
 
 // Config configuration for the filter processor
 type Config struct {
-	// Filters are a list of SubConfig objects with an operation acting as the string key in the map
+	/* Filters are a list of SubConfig objects with an operation acting as the string key in the map
+
+	filters:
+		- [any,all,none]:
+			expression: ""
+			expression-type: ""
+			tag: ""
+	*/
 	Filters []map[string][]SubConfig `yaml:"filters"`
 }

--- a/conduit/plugins/processors/filterprocessor/config.go
+++ b/conduit/plugins/processors/filterprocessor/config.go
@@ -7,6 +7,8 @@ import (
 	"github.com/algorand/indexer/conduit/plugins/processors/filterprocessor/expression"
 )
 
+//Name: conduit_processors_filter
+
 // SubConfig is the configuration needed for each additional filter
 type SubConfig struct {
 	/* <code>tag</code> is the tag of the struct to analyze.<br/>

--- a/conduit/plugins/processors/filterprocessor/config.go
+++ b/conduit/plugins/processors/filterprocessor/config.go
@@ -9,17 +9,31 @@ import (
 
 // SubConfig is the configuration needed for each additional filter
 type SubConfig struct {
-	// FilterTag the tag of the struct to analyze
+	/* <code>tag</code> is the tag of the struct to analyze.<br/>
+	It can be of the form `txn.*` where the specific ending is determined by the field you wish to filter on.<br/>
+	It can also be a field in the ApplyData.
+	*/
 	FilterTag string `yaml:"tag"`
-	// ExpressionType the type of expression to search for (i.e. "exact" or "regex")
+	/* <code>expression-type</code> is the type of comparison applied between the field, identified by the tag, and the expression.<br/>
+	<ul>
+		<li>exact</li>
+		<li>regex</li>
+		<li>less-than</li>
+		<li>less-than-equal</li>
+		<li>greater-than</li>
+		<li>great-than-equal</li>
+		<li>equal</li>
+		<li>not-equal</li>
+	</ul>
+	*/
 	ExpressionType expression.FilterType `yaml:"expression-type"`
-	// Expression the expression to search
+	// <code>expression</code> is the user-supplied part of the search or comparison.
 	Expression string `yaml:"expression"`
 }
 
 // Config configuration for the filter processor
 type Config struct {
-	/* Filters are a list of SubConfig objects with an operation acting as the string key in the map
+	/* <code>filters</code> are a list of SubConfig objects with an operation acting as the string key in the map
 
 	filters:
 		- [any,all,none]:


### PR DESCRIPTION
## Summary

Adds a hidden command to conduit which will generate the cobra CLI docs.

Also adds a new `conduit-docs` command which will be used via `go:generate` on config files to generate the markdown pages for our developer portal.  
This portion is still WIP, I'll include renders of some of the more interesting configs people can see what they look like for a given revision.

For now I've just got the config graphs working. For example, the filter processor page is as follows:




Sample docs page generated with `conduit-docs`. Also see https://github.com/algorand/docs/pull/964 for the docs pages.
![Screenshot 2022-12-20 at 9 26 27 AM](https://user-images.githubusercontent.com/10753834/208729810-e3af1b9c-14ba-4b38-aaa6-a4b263bfc7d9.png)


