### PR TITLE
tech-debt: Update submodule, e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       go_version:
         type: string
     environment:
-      CI_E2E_FILENAME: "faab6dcf/rel-nightly"
+      CI_E2E_FILENAME: "fa6ad40d/rel-nightly"
     steps:
       - go/install:
           version: << parameters.go_version >>

--- a/e2e_tests/src/e2e_common/util.py
+++ b/e2e_tests/src/e2e_common/util.py
@@ -164,18 +164,6 @@ def firstFromS3Prefix(
     haystack = []
     found_needle = False
 
-    def report():
-        print(
-            f"""Hello from firstFromS3Prefix() !!!!
-        I finished searching for the needle {desired_filename} in the AWS S3 path {bucket}/{prefix}.
-        haystack={haystack}
-        len(haystack)={len(haystack)}
-        found_needle={found_needle}
-"""
-        )
-
-    atexit.register(report)
-
     response = s3.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=100)
     if (not response.get("KeyCount")) or ("Contents" not in response):
         raise Exception("nothing found in s3://{}/{}".format(bucket, prefix))
@@ -193,7 +181,8 @@ def firstFromS3Prefix(
             found_needle = True
             break
 
-    logger.warning("file not found in s3://{}/{}".format(bucket, prefix))
+    if not found_needle:
+        logger.warning("file {} not found in s3://{}/{}".format(desired_filename, bucket, prefix))
     return found_needle
 
 


### PR DESCRIPTION


## Summary
Updates the submodule to the most recent nightly build.

Also removed the needle in the haystack logging because it seems to cause more confusion than help. Updated the logging to still provide the same set of information. And I updated the circle CI rel-nightly e2e build tar to pull from.

## Test Plan

Ran `e2elive` locally against the updated rel-nightly tar.
