### PR TITLE
encoding: Use LenientDecode for genesis objects from algod

### DIFF
--- a/conduit/plugins/exporters/filewriter/file_exporter_test.go
+++ b/conduit/plugins/exporters/filewriter/file_exporter_test.go
@@ -168,7 +168,7 @@ func TestExporterReceive(t *testing.T) {
 		assert.FileExists(t, path)
 
 		var blockData data.BlockData
-		err := util.DecodeFromFile(path, &blockData)
+		err := util.DecodeFromFile(path, &blockData, true)
 		require.Equal(t, basics.Round(i), blockData.BlockHeader.Round)
 		require.NoError(t, err)
 		require.NotNil(t, blockData.Certificate)
@@ -200,7 +200,7 @@ func TestPatternOverride(t *testing.T) {
 		assert.FileExists(t, path)
 
 		var blockData data.BlockData
-		err := util.DecodeFromFile(path, &blockData)
+		err := util.DecodeFromFile(path, &blockData, true)
 		require.Equal(t, basics.Round(i), blockData.BlockHeader.Round)
 		require.NoError(t, err)
 		require.NotNil(t, blockData.Certificate)
@@ -226,7 +226,7 @@ func TestDropCertificate(t *testing.T) {
 		path := fmt.Sprintf("%s/%s", tempdir, filename)
 		assert.FileExists(t, path)
 		var blockData data.BlockData
-		err := util.DecodeFromFile(path, &blockData)
+		err := util.DecodeFromFile(path, &blockData, true)
 		assert.NoError(t, err)
 		assert.Nil(t, blockData.Certificate)
 	}

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -89,7 +89,8 @@ func (algodImp *algodImporter) Init(ctx context.Context, cfg plugins.PluginConfi
 
 	genesis := sdk.Genesis{}
 
-	err = json.Decode([]byte(genesisResponse), &genesis)
+	// Don't fail on unknown properties here since the go-algorand and SDK genesis types differ slightly
+	err = json.LenientDecode([]byte(genesisResponse), &genesis)
 	if err != nil {
 		return nil, err
 	}

--- a/conduit/plugins/importers/filereader/filereader.go
+++ b/conduit/plugins/importers/filereader/filereader.go
@@ -72,7 +72,7 @@ func (r *fileReader) Init(ctx context.Context, cfg plugins.PluginConfig, logger 
 
 	genesisFile := path.Join(r.cfg.BlocksDir, "genesis.json")
 	var genesis sdk.Genesis
-	err = util.DecodeFromFile(genesisFile, &genesis)
+	err = util.DecodeFromFile(genesisFile, &genesis, false)
 	if err != nil {
 		return nil, fmt.Errorf("Init(): failed to process genesis file: %w", err)
 	}
@@ -98,7 +98,7 @@ func (r *fileReader) GetBlock(rnd uint64) (data.BlockData, error) {
 		filename := path.Join(r.cfg.BlocksDir, fmt.Sprintf(r.cfg.FilenamePattern, rnd))
 		var blockData data.BlockData
 		start := time.Now()
-		err := util.DecodeFromFile(filename, &blockData)
+		err := util.DecodeFromFile(filename, &blockData, false)
 		if err != nil && errors.Is(err, fs.ErrNotExist) {
 			// If the file read failed because the file didn't exist, wait before trying again
 			if attempts == 0 {

--- a/util/test/mock_algod.go
+++ b/util/test/mock_algod.go
@@ -63,7 +63,10 @@ func BlockResponder(reqPath string, w http.ResponseWriter) bool {
 func GenesisResponder(reqPath string, w http.ResponseWriter) bool {
 	if strings.Contains(reqPath, "/genesis") {
 		w.WriteHeader(http.StatusOK)
-		genesis := &bookkeeping.Genesis{}
+		genesis := &bookkeeping.Genesis{
+			Comment: "",
+			DevMode: true,
+		}
 		blockbytes := protocol.EncodeJSON(*genesis)
 		_, _ = w.Write(blockbytes)
 		return true

--- a/util/util.go
+++ b/util/util.go
@@ -57,7 +57,7 @@ func EncodeToFile(filename string, v interface{}, pretty bool) error {
 }
 
 // DecodeFromFile is used to decode a file to an object.
-func DecodeFromFile(filename string, v interface{}) error {
+func DecodeFromFile(filename string, v interface{}, strict bool) error {
 	// Streaming into the decoder was slow.
 	fileBytes, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -74,8 +74,12 @@ func DecodeFromFile(filename string, v interface{}) error {
 		}
 		reader = gz
 	}
+	var handle *codec.JsonHandle = json.LenientCodecHandle
+	if strict {
+		handle = json.CodecHandle
+	}
 
-	enc := codec.NewDecoder(reader, json.CodecHandle)
+	enc := codec.NewDecoder(reader, handle)
 	return enc.Decode(v)
 }
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -30,7 +30,7 @@ func TestEncodeToAndFromFile(t *testing.T) {
 		require.NoError(t, err)
 		require.FileExists(t, pretty)
 		var testDecode test
-		err = DecodeFromFile(pretty, &testDecode)
+		err = DecodeFromFile(pretty, &testDecode, false)
 		require.Equal(t, data, testDecode)
 
 		// Check the pretty printing
@@ -45,7 +45,7 @@ func TestEncodeToAndFromFile(t *testing.T) {
 		require.NoError(t, err)
 		require.FileExists(t, small)
 		var testDecode test
-		err = DecodeFromFile(small, &testDecode)
+		err = DecodeFromFile(small, &testDecode, false)
 		require.Equal(t, data, testDecode)
 	}
 
@@ -56,7 +56,7 @@ func TestEncodeToAndFromFile(t *testing.T) {
 		require.NoError(t, err)
 		require.FileExists(t, small)
 		var testDecode test
-		err = DecodeFromFile(small, &testDecode)
+		err = DecodeFromFile(small, &testDecode, false)
 		require.Equal(t, data, testDecode)
 	}
 }


### PR DESCRIPTION

## Summary

The py-algorand-sdk uses sandbox to launch indexer, and has been hitting failures such as [this one](https://app.circleci.com/pipelines/github/algorand/py-algorand-sdk/1172/workflows/cf2ee38b-8be9-4899-81df-e9e3e2ec0ba1/jobs/5997).

It is due to [this change](https://github.com/algorand/indexer/commit/f56ae83fa3259710e840e681e45d4bfef7ec7d9b#diff-cc2152c5941ca76fdb35ad52ce46b45e7d4c5a3dee1e9f900bf9a1397db6d4b9R92) which uses the SDK's strict json decoder to convert from genesis bytes to the SDK's genesis type. 

The different fields in go-algorand's Genesis type which are not present in the SDK type (`Comment`, and `DevMode`) cause the decode failure.

I've made decoding of the genesis type in Indexer lenient against unknown fields for now.

## Test Plan

Added some fields to the mock algod we use. In the future these will need to be changed to just use bytes instead of the go-algorand Genesis type. But for the short term these test the fix.
