### PR TITLE
API: Separate max transactions param from max block txns param

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,36 +181,38 @@ If the maximum number of connections/active queries is reached, subsequent conne
 
 Settings can be provided from the command line, a configuration file, or an environment variable
 
-| Command Line Flag (long)      | (short) | Config File                   | Environment Variable                  |
-|-------------------------------|---------|-------------------------------|---------------------------------------|
-| postgres                      | P       | postgres-connection-string    | INDEXER_POSTGRES_CONNECTION_STRING    |
-| data-dir                      | i       | data                          | INDEXER_DATA                          |
-| pidfile                       |         | pidfile                       | INDEXER_PIDFILE                       |
-| algod                         | d       | algod-data-dir                | INDEXER_ALGOD_DATA_DIR / ALGORAND_DATA|
-| algod-net                     |         | algod-address                 | INDEXER_ALGOD_ADDRESS                 |
-| algod-token                   |         | algod-token                   | INDEXER_ALGOD_TOKEN                   |
-| server                        | S       | server-address                | INDEXER_SERVER_ADDRESS                |
-| no-algod                      |         | no-algod                      | INDEXER_NO_ALGOD                      |
-| token                         | t       | api-token                     | INDEXER_API_TOKEN                     |
-| metrics-mode                  |         | metrics-mode                  | INDEXER_METRICS_MODE                  |
-| logfile                       | f       | logfile                       | INDEXER_LOGFILE                       |
-| loglevel                      | l       | loglevel                      | INDEXER_LOGLEVEL                      |
-| max-conn                      |         | max-conn                      | INDEXER_MAX_CONN                      |
-| write-timeout                 |         | write-timeout                 | INDEXER_WRITE_TIMEOUT                 |
-| read-timeout                  |         | read-timeout                  | INDEXER_READ_TIMEOUT                  |
-| max-api-resources-per-account |         | max-api-resources-per-account | INDEXER_MAX_API_RESOURCES_PER_ACCOUNT |
-| max-transactions-limit        |         | max-transactions-limit        | INDEXER_MAX_TRANSACTIONS_LIMIT        |
-| default-transactions-limit    |         | default-transactions-limit    | INDEXER_DEFAULT_TRANSACTIONS_LIMIT    |
-| max-accounts-limit            |         | max-accounts-limit            | INDEXER_MAX_ACCOUNTS_LIMIT            |
-| default-accounts-limit        |         | default-accounts-limit        | INDEXER_DEFAULT_ACCOUNTS_LIMIT        |
-| max-assets-limit              |         | max-assets-limit              | INDEXER_MAX_ASSETS_LIMIT              |
-| default-assets-limit          |         | default-assets-limit          | INDEXER_DEFAULT_ASSETS_LIMIT          |
-| max-balances-limit            |         | max-balances-limit            | INDEXER_MAX_BALANCES_LIMIT            |
-| default-balances-limit        |         | default-balances-limit        | INDEXER_DEFAULT_BALANCES_LIMIT        |
-| max-applications-limit        |         | max-applications-limit        | INDEXER_MAX_APPLICATIONS_LIMIT        |
-| default-applications-limit    |         | default-applications-limit    | INDEXER_DEFAULT_APPLICATIONS_LIMIT    |
-| enable-all-parameters         |         | enable-all-parameters         | INDEXER_ENABLE_ALL_PARAMETERS         |
-| catchpoint                    |         | catchpoint                    | INDEXER_CATCHPOINT                    |
+| Command Line Flag (long)         | (short) | Config File                      | Environment Variable                     |
+|----------------------------------|---------|----------------------------------|------------------------------------------|
+| postgres                         | P       | postgres-connection-string       | INDEXER_POSTGRES_CONNECTION_STRING       |
+| data-dir                         | i       | data                             | INDEXER_DATA                             |
+| pidfile                          |         | pidfile                          | INDEXER_PIDFILE                          |
+| algod                            | d       | algod-data-dir                   | INDEXER_ALGOD_DATA_DIR / ALGORAND_DATA   |
+| algod-net                        |         | algod-address                    | INDEXER_ALGOD_ADDRESS                    |
+| algod-token                      |         | algod-token                      | INDEXER_ALGOD_TOKEN                      |
+| server                           | S       | server-address                   | INDEXER_SERVER_ADDRESS                   |
+| no-algod                         |         | no-algod                         | INDEXER_NO_ALGOD                         |
+| token                            | t       | api-token                        | INDEXER_API_TOKEN                        |
+| metrics-mode                     |         | metrics-mode                     | INDEXER_METRICS_MODE                     |
+| logfile                          | f       | logfile                          | INDEXER_LOGFILE                          |
+| loglevel                         | l       | loglevel                         | INDEXER_LOGLEVEL                         |
+| max-conn                         |         | max-conn                         | INDEXER_MAX_CONN                         |
+| write-timeout                    |         | write-timeout                    | INDEXER_WRITE_TIMEOUT                    |
+| read-timeout                     |         | read-timeout                     | INDEXER_READ_TIMEOUT                     |
+| max-api-resources-per-account    |         | max-api-resources-per-account    | INDEXER_MAX_API_RESOURCES_PER_ACCOUNT    |
+| max-transactions-limit           |         | max-transactions-limit           | INDEXER_MAX_TRANSACTIONS_LIMIT           |
+| default-transactions-limit       |         | default-transactions-limit       | INDEXER_DEFAULT_TRANSACTIONS_LIMIT       |
+| max-block-transactions-limit     |         | max-block-transactions-limit     | INDEXER_MAX_BLOCK_TRANSACTIONS_LIMIT     |
+| default-block-transactions-limit |         | default-block-transactions-limit | INDEXER_DEFAULT_BLOCK_TRANSACTIONS_LIMIT |
+| max-accounts-limit               |         | max-accounts-limit               | INDEXER_MAX_ACCOUNTS_LIMIT               |
+| default-accounts-limit           |         | default-accounts-limit           | INDEXER_DEFAULT_ACCOUNTS_LIMIT           |
+| max-assets-limit                 |         | max-assets-limit                 | INDEXER_MAX_ASSETS_LIMIT                 |
+| default-assets-limit             |         | default-assets-limit             | INDEXER_DEFAULT_ASSETS_LIMIT             |
+| max-balances-limit               |         | max-balances-limit               | INDEXER_MAX_BALANCES_LIMIT               |
+| default-balances-limit           |         | default-balances-limit           | INDEXER_DEFAULT_BALANCES_LIMIT           |
+| max-applications-limit           |         | max-applications-limit           | INDEXER_MAX_APPLICATIONS_LIMIT           |
+| default-applications-limit       |         | default-applications-limit       | INDEXER_DEFAULT_APPLICATIONS_LIMIT       |
+| enable-all-parameters            |         | enable-all-parameters            | INDEXER_ENABLE_ALL_PARAMETERS            |
+| catchpoint                       |         | catchpoint                       | INDEXER_CATCHPOINT                       |
 
 ## Command line
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -927,12 +927,12 @@ func (si *ServerImplementation) LookupBlock(ctx echo.Context, roundNumber uint64
 	}
 
 	options := idb.GetBlockOptions{
-		Transactions:         !(boolOrDefault(params.HeaderOnly)),
-		MaxTransactionsLimit: si.opts.MaxTransactionsLimit,
+		Transactions:              !(boolOrDefault(params.HeaderOnly)),
+		MaxBlockTransactionsLimit: si.opts.MaxTransactionsLimit,
 	}
 
 	blk, err := si.fetchBlock(ctx.Request().Context(), roundNumber, options)
-	var maxErr idb.MaxTransactionsError
+	var maxErr idb.MaxBlockTransactionsError
 	if errors.As(err, &maxErr) {
 		return badRequest(ctx, errTransactionsLimitReached)
 	}

--- a/api/handlers_e2e_test.go
+++ b/api/handlers_e2e_test.go
@@ -43,6 +43,9 @@ var defaultOpts = ExtraOptions{
 	MaxTransactionsLimit:     10000,
 	DefaultTransactionsLimit: 1000,
 
+	MaxBlockTransactionsLimit:     0,
+	DefaultBlockTransactionsLimit: 0,
+
 	MaxAccountsLimit:     1000,
 	DefaultAccountsLimit: 100,
 

--- a/api/server.go
+++ b/api/server.go
@@ -54,6 +54,12 @@ type ExtraOptions struct {
 	MaxTransactionsLimit     uint64
 	DefaultTransactionsLimit uint64
 
+	// Block Transactions. This parameter specifically tunes the number of transactions returned from the /v2/blocks
+	// endpoint. We've broken this into a separate parameter to maintain backwards compatibility w/ MaxTransactionsLimit
+	// which is used in /v2/transactions, and not in /v2/blocks.
+	MaxBlockTransactionsLimit     uint64
+	DefaultBlockTransactionsLimit uint64
+
 	// Accounts
 	MaxAccountsLimit     uint64
 	DefaultAccountsLimit uint64

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -59,41 +59,43 @@ func GetConfigFromDataDir(dataDirectory string, configFilename string, configFil
 }
 
 type daemonConfig struct {
-	flags                     *pflag.FlagSet
-	algodDataDir              string
-	algodAddr                 string
-	algodToken                string
-	daemonServerAddr          string
-	noAlgod                   bool
-	developerMode             bool
-	allowMigration            bool
-	metricsMode               string
-	tokenString               string
-	writeTimeout              time.Duration
-	readTimeout               time.Duration
-	maxConn                   uint32
-	maxAPIResourcesPerAccount uint32
-	maxTransactionsLimit      uint32
-	defaultTransactionsLimit  uint32
-	maxAccountsLimit          uint32
-	defaultAccountsLimit      uint32
-	maxAssetsLimit            uint32
-	defaultAssetsLimit        uint32
-	maxBoxesLimit             uint32
-	defaultBoxesLimit         uint32
-	maxBalancesLimit          uint32
-	defaultBalancesLimit      uint32
-	maxApplicationsLimit      uint32
-	defaultApplicationsLimit  uint32
-	enableAllParameters       bool
-	indexerDataDir            string
-	initLedger                bool
-	catchpoint                string
-	cpuProfile                string
-	pidFilePath               string
-	configFile                string
-	suppliedAPIConfigFile     string
-	genesisJSONPath           string
+	flags                         *pflag.FlagSet
+	algodDataDir                  string
+	algodAddr                     string
+	algodToken                    string
+	daemonServerAddr              string
+	noAlgod                       bool
+	developerMode                 bool
+	allowMigration                bool
+	metricsMode                   string
+	tokenString                   string
+	writeTimeout                  time.Duration
+	readTimeout                   time.Duration
+	maxConn                       uint32
+	maxAPIResourcesPerAccount     uint32
+	maxTransactionsLimit          uint32
+	defaultTransactionsLimit      uint32
+	maxBlockTransactionsLimit     uint32
+	defaultBlockTransactionsLimit uint32
+	maxAccountsLimit              uint32
+	defaultAccountsLimit          uint32
+	maxAssetsLimit                uint32
+	defaultAssetsLimit            uint32
+	maxBoxesLimit                 uint32
+	defaultBoxesLimit             uint32
+	maxBalancesLimit              uint32
+	defaultBalancesLimit          uint32
+	maxApplicationsLimit          uint32
+	defaultApplicationsLimit      uint32
+	enableAllParameters           bool
+	indexerDataDir                string
+	initLedger                    bool
+	catchpoint                    string
+	cpuProfile                    string
+	pidFilePath                   string
+	configFile                    string
+	suppliedAPIConfigFile         string
+	genesisJSONPath               string
 }
 
 // DaemonCmd creates the main cobra command, initializes flags, and viper aliases
@@ -130,6 +132,8 @@ func DaemonCmd() *cobra.Command {
 	cfg.flags.Uint32VarP(&cfg.maxAPIResourcesPerAccount, "max-api-resources-per-account", "", 1000, "set the maximum total number of resources (created assets, created apps, asset holdings, and application local state) per account that will be allowed in REST API lookupAccountByID and searchForAccounts responses before returning a 400 Bad Request. Set zero for no limit")
 	cfg.flags.Uint32VarP(&cfg.maxTransactionsLimit, "max-transactions-limit", "", 10000, "set the maximum allowed Limit parameter for querying transactions")
 	cfg.flags.Uint32VarP(&cfg.defaultTransactionsLimit, "default-transactions-limit", "", 1000, "set the default Limit parameter for querying transactions, if none is provided")
+	cfg.flags.Uint32VarP(&cfg.maxBlockTransactionsLimit, "max-block-transactions-limit", "", 0, "set the maximum allowed Limit parameter for transactions returned per block, defaults to unlimited (0)")
+	cfg.flags.Uint32VarP(&cfg.defaultBlockTransactionsLimit, "default-block-transactions-limit", "", 0, "set the default Limit parameter for transactions returned per block, if none is provided defaults to unlimited (0)")
 	cfg.flags.Uint32VarP(&cfg.maxAccountsLimit, "max-accounts-limit", "", 1000, "set the maximum allowed Limit parameter for querying accounts")
 	cfg.flags.Uint32VarP(&cfg.defaultAccountsLimit, "default-accounts-limit", "", 100, "set the default Limit parameter for querying accounts, if none is provided")
 	cfg.flags.Uint32VarP(&cfg.maxAssetsLimit, "max-assets-limit", "", 1000, "set the maximum allowed Limit parameter for querying assets")
@@ -455,6 +459,8 @@ func makeOptions(daemonConfig *daemonConfig) (options api.ExtraOptions) {
 	options.MaxAPIResourcesPerAccount = uint64(daemonConfig.maxAPIResourcesPerAccount)
 	options.MaxTransactionsLimit = uint64(daemonConfig.maxTransactionsLimit)
 	options.DefaultTransactionsLimit = uint64(daemonConfig.defaultTransactionsLimit)
+	options.MaxBlockTransactionsLimit = uint64(daemonConfig.maxBlockTransactionsLimit)
+	options.DefaultBlockTransactionsLimit = uint64(daemonConfig.defaultBlockTransactionsLimit)
 	options.MaxAccountsLimit = uint64(daemonConfig.maxAccountsLimit)
 	options.DefaultAccountsLimit = uint64(daemonConfig.defaultAccountsLimit)
 	options.MaxAssetsLimit = uint64(daemonConfig.maxAssetsLimit)

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -191,9 +191,9 @@ type IndexerDb interface {
 type GetBlockOptions struct {
 	// setting Transactions to true suggests requesting to receive the transactions themselves from the GetBlock query
 	Transactions bool
-	// if len of the results from buildTransactionQuery is greater than MaxTransactionsLimit, return an error
+	// if len of the results from buildTransactionQuery is greater than MaxBlockTransactionsLimit, return an error
 	// indicating that the header-only flag should be enabled
-	MaxTransactionsLimit uint64
+	MaxBlockTransactionsLimit uint64
 }
 
 // TransactionFilter is a parameter object with all the transaction filter options.
@@ -427,10 +427,10 @@ type NetworkState struct {
 	GenesisHash crypto.Digest `codec:"genesis-hash"`
 }
 
-// MaxTransactionsError records the error when transaction counts exceeds MaxTransactionsLimit.
-type MaxTransactionsError struct {
+// MaxBlockTransactionsError records the error when transaction counts exceeds MaxBlockTransactionsLimit.
+type MaxBlockTransactionsError struct {
 }
 
-func (e MaxTransactionsError) Error() string {
-	return "number of transactions exceeds MaxTransactionsLimit"
+func (e MaxBlockTransactionsError) Error() string {
+	return "number of transactions exceeds MaxBlockTransactionsLimit"
 }

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -487,7 +487,7 @@ func (db *IndexerDb) GetBlock(ctx context.Context, round uint64, options idb.Get
 			results = append(results, txrow)
 		}
 		if options.MaxBlockTransactionsLimit != 0 && uint64(len(results)) > options.MaxBlockTransactionsLimit {
-			return sdk.BlockHeader{}, nil, idb.MaxBlockTransactionsError{}
+			return bookkeeping.BlockHeader{}, nil, idb.MaxBlockTransactionsError{}
 		}
 		transactions = results
 	}

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -375,7 +375,7 @@ func TestBlockWithTransactions(t *testing.T) {
 	//////////
 	// When // We call GetBlock and Transactions
 	//////////
-	_, txnRows0, err := db.GetBlock(context.Background(), round, idb.GetBlockOptions{Transactions: true, MaxTransactionsLimit: 100})
+	_, txnRows0, err := db.GetBlock(context.Background(), round, idb.GetBlockOptions{Transactions: true, MaxBlockTransactionsLimit: 100})
 	require.NoError(t, err)
 
 	rowsCh, _ := db.Transactions(context.Background(), idb.TransactionFilter{Round: &round})


### PR DESCRIPTION
## Summary

In #1241 we started using the `MaxTransactionsLimit` parameter to limit the number of transactions returned in the `/v2/block` API. That caused users who expected to receive the whole block to start getting errors when blocks with high numbers of txns were requested.

In order to enable users to set this limit but also enable those who would like to retrieve the entire block at once, I've set this limit to unlimited by default.

Since the `MaxTransactionsLimit` parameter was also previously being used in the `/v2/transactions` endpoint, I've separated the param to a new config option which will only control transactions returned in blocks.  


