### PR TITLE
performance: Add /v2/blocks benchmark

### DIFF
--- a/idb/postgres/internal/testing/testing.go
+++ b/idb/postgres/internal/testing/testing.go
@@ -28,7 +28,7 @@ func init() {
 
 // SetupPostgres starts a gnomock postgres DB then returns the database object,
 // the connection string and a shutdown function.
-func SetupPostgres(t *testing.T) (*pgxpool.Pool, string, func()) {
+func SetupPostgres(t testing.TB) (*pgxpool.Pool, string, func()) {
 	if testpg != "" {
 		// use non-docker Postgresql
 		connStr := testpg

--- a/idb/postgres/postgres_integration_common_test.go
+++ b/idb/postgres/postgres_integration_common_test.go
@@ -18,7 +18,7 @@ import (
 	pgtest "github.com/algorand/indexer/idb/postgres/internal/testing"
 )
 
-func setupIdbWithConnectionString(t *testing.T, connStr string, genesis sdk.Genesis) *IndexerDb {
+func setupIdbWithConnectionString(t testing.TB, connStr string, genesis sdk.Genesis) *IndexerDb {
 	idb, _, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
 	require.NoError(t, err)
 
@@ -28,7 +28,7 @@ func setupIdbWithConnectionString(t *testing.T, connStr string, genesis sdk.Gene
 	return idb
 }
 
-func setupIdb(t *testing.T, genesis sdk.Genesis) (*IndexerDb, func(), func(cert *rpcs.EncodedBlockCert) error, *ledger.Ledger) {
+func setupIdb(t testing.TB, genesis sdk.Genesis) (*IndexerDb, func(), func(cert *rpcs.EncodedBlockCert) error, *ledger.Ledger) {
 
 	_, connStr, shutdownFunc := pgtest.SetupPostgres(t)
 

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -343,8 +343,8 @@ func TestMultipleWriters(t *testing.T) {
 	assert.Equal(t, amt, balance)
 }
 
-// BenchmarkBlockTransactionsLimit benchmarks memory usage of the block endpoint when exceeding MaxTransactionsLimit.
-func BenchmarkBlockTransactionsLimit(b *testing.B) {
+// BenchmarkBlockTransactions benchmarks memory usage of the block endpoint.
+func BenchmarkBlockTransactions(b *testing.B) {
 	db, shutdownFunc, proc, l := setupIdb(b, test.MakeGenesisV2())
 	b.Cleanup(func() {
 		shutdownFunc()
@@ -380,8 +380,8 @@ func BenchmarkBlockTransactionsLimit(b *testing.B) {
 			innerTxns: 100,
 		},
 		{
-			testTxns:  1000,
-			innerTxns: 200,
+			testTxns:  250,
+			innerTxns: 250,
 		},
 	}
 
@@ -405,8 +405,7 @@ func BenchmarkBlockTransactionsLimit(b *testing.B) {
 		b.Run(fmt.Sprintf("/v2/blocks txns: %v innerTxns: %v", benchmark.testTxns, benchmark.innerTxns), func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				_, _, err = db.GetBlock(context.Background(), round, idb.GetBlockOptions{Transactions: true, MaxTransactionsLimit: benchmark.testTxns - 1})
-				require.Errorf(b, err, idb.MaxTransactionsError{}.Error())
+				_, _, _ = db.GetBlock(context.Background(), round, idb.GetBlockOptions{Transactions: true, MaxTransactionsLimit: 1000})
 			}
 		})
 	}


### PR DESCRIPTION

## Summary

The `/v2/blocks` endpoint consumes a large amount of memory when handling blocks with high transactions which have large numbers of inner transactions. This benchmarks memory usage of the API when processing different variations of transactions/inner transactions from a block.
