### PR TITLE
API: Hotfix block endpoint

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -1359,11 +1359,6 @@ func (si *ServerImplementation) fetchBlock(ctx context.Context, round uint64, op
 
 		results := make([]generated.Transaction, 0)
 		for _, txrow := range transactions {
-			// Do not include inner transactions.
-			if txrow.RootTxn != nil {
-				continue
-			}
-
 			tx, err := txnRowToTransaction(txrow)
 			if err != nil {
 				return err

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -240,6 +240,10 @@ type TransactionFilter struct {
 	// instead of the root txn.
 	ReturnInnerTxnOnly bool
 
+	// If this flag is set to true, then the query returns only root txns
+	// and no inner txns
+	ReturnRootTxnsOnly bool
+
 	// If this flag is set to true, then the query returns the block excluding
 	// the transactions
 	HeaderOnly bool

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -663,7 +663,7 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 	}
 
 	// If returnInnerTxnOnly flag is false, then return the root transaction
-	if !tf.ReturnInnerTxnOnly && !tf.ReturnRootTxnsOnly {
+	if !(tf.ReturnInnerTxnOnly || tf.ReturnRootTxnsOnly) {
 		query = "SELECT t.round, t.intra, t.txn, root.txn, t.extra, t.asset, h.realtime FROM txn t JOIN block_header h ON t.round = h.round"
 	} else {
 		query = "SELECT t.round, t.intra, t.txn, NULL, t.extra, t.asset, h.realtime FROM txn t JOIN block_header h ON t.round = h.round"
@@ -674,7 +674,7 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 	}
 
 	// join in the root transaction if the returnInnerTxnOnly flag is false
-	if !tf.ReturnInnerTxnOnly || !tf.ReturnRootTxnsOnly {
+	if !(tf.ReturnInnerTxnOnly || tf.ReturnRootTxnsOnly) {
 		query += " LEFT OUTER JOIN txn root ON t.round = root.round AND (t.extra->>'root-intra')::int = root.intra"
 	}
 

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -663,7 +663,7 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 	}
 
 	// If returnInnerTxnOnly flag is false, then return the root transaction
-	if !tf.ReturnInnerTxnOnly {
+	if !tf.ReturnInnerTxnOnly && !tf.ReturnRootTxnsOnly {
 		query = "SELECT t.round, t.intra, t.txn, root.txn, t.extra, t.asset, h.realtime FROM txn t JOIN block_header h ON t.round = h.round"
 	} else {
 		query = "SELECT t.round, t.intra, t.txn, NULL, t.extra, t.asset, h.realtime FROM txn t JOIN block_header h ON t.round = h.round"
@@ -674,7 +674,7 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 	}
 
 	// join in the root transaction if the returnInnerTxnOnly flag is false
-	if !tf.ReturnInnerTxnOnly && !tf.ReturnRootTxnsOnly {
+	if !tf.ReturnInnerTxnOnly || !tf.ReturnRootTxnsOnly {
 		query += " LEFT OUTER JOIN txn root ON t.round = root.round AND (t.extra->>'root-intra')::int = root.intra"
 	}
 

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -674,7 +674,7 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 	}
 
 	// join in the root transaction if the returnInnerTxnOnly flag is false
-	if !tf.ReturnInnerTxnOnly || tf.ReturnRootTxnsOnly {
+	if !tf.ReturnInnerTxnOnly && !tf.ReturnRootTxnsOnly {
 		query += " LEFT OUTER JOIN txn root ON t.round = root.round AND (t.extra->>'root-intra')::int = root.intra"
 	}
 


### PR DESCRIPTION
#1395 Shows more details. 

At a high level, the SQL used to fetch transactions for the `/v2/blocks` endpoint balloons the amount of memory usage when the block contains large numbers of inner transactions. These inner transactions end up getting discarded anyways after the query returns and is deserialized. This patch improves the query and memory usage by only fetching root transactions to begin with.

## Test Plan

Ran benchmarks from #1396 to get memory usage data. The result of a block containing 250 transactions, each of which has 250 inner transactions, w/ a `MaxTransactionsLimit` set to the default of 1000 shows pre-patch memory usage around  9GB, and post-patch memory usage around 2GB.

Before patch:
```
BenchmarkBlockTransactions//v2/blocks_txns:_250_innerTxns:_250-10         	       1	9067736792 ns/op	3213189536 B/op	 2537356 allocs/op
```

After patch:
```
BenchmarkBlockTransactions//v2/blocks_txns:_250_innerTxns:_250-10         	       1	2378328417 ns/op	800444504 B/op	  633329 allocs/op
```
