### PR TITLE
API: Skip inner transaction fetching when possible.

### DIFF
--- a/idb/idb.go
+++ b/idb/idb.go
@@ -198,6 +198,9 @@ type GetBlockOptions struct {
 
 // TransactionFilter is a parameter object with all the transaction filter options.
 type TransactionFilter struct {
+	// SkipOptimization is used for testing to ensure the parameters are not modified.
+	SkipOptimization bool
+
 	// Address filtering transactions for one Address will
 	// return transactions newest-first proceding into the
 	// past. Paging through such results can be achieved by

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -1151,7 +1151,7 @@ func TestNonDisplayableUTF8(t *testing.T) {
 
 			// Test 3: transaction results properly serialized
 			// Transaction results also return the inner txn acfg
-			txnRows, _ := db.Transactions(context.Background(), idb.TransactionFilter{})
+			txnRows, _ := db.Transactions(context.Background(), idb.TransactionFilter{SkipOptimization: true})
 			num = 0
 			for row := range txnRows {
 				require.NoError(t, row.Error)
@@ -1948,7 +1948,8 @@ func TestBadTxnJsonEncoding(t *testing.T) {
 	{
 		offset := uint64(rootIntra)
 		tf := idb.TransactionFilter{
-			Offset: &offset,
+			SkipOptimization: true,
+			Offset:           &offset,
 		}
 		rowsCh, _ := db.Transactions(context.Background(), tf)
 
@@ -1962,7 +1963,8 @@ func TestBadTxnJsonEncoding(t *testing.T) {
 	{
 		offset := uint64(rootIntra) + 1
 		tf := idb.TransactionFilter{
-			Offset: &offset,
+			SkipOptimization: true,
+			Offset:           &offset,
 		}
 		rowsCh, _ := db.Transactions(context.Background(), tf)
 
@@ -2078,7 +2080,7 @@ func TestTransactionsTxnAhead(t *testing.T) {
 		require.NoError(t, err)
 	}
 	{
-		rowsCh, _ := db.Transactions(context.Background(), idb.TransactionFilter{})
+		rowsCh, _ := db.Transactions(context.Background(), idb.TransactionFilter{SkipOptimization: true})
 		_, ok := <-rowsCh
 		assert.False(t, ok)
 	}
@@ -2092,7 +2094,7 @@ func TestTransactionsTxnAhead(t *testing.T) {
 		require.NoError(t, err)
 	}
 	{
-		rowsCh, _ := db.Transactions(context.Background(), idb.TransactionFilter{})
+		rowsCh, _ := db.Transactions(context.Background(), idb.TransactionFilter{SkipOptimization: true})
 		row, ok := <-rowsCh
 		require.True(t, ok)
 		require.NoError(t, row.Error)

--- a/idb/postgres/postgres_test.go
+++ b/idb/postgres/postgres_test.go
@@ -1,0 +1,56 @@
+package postgres
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/algorand/indexer/idb"
+)
+
+func Test_txnFilterOptimization(t *testing.T) {
+	tests := []struct {
+		name     string
+		arg      idb.TransactionFilter
+		rootOnly bool
+	}{
+		{
+			name:     "basic",
+			arg:      idb.TransactionFilter{},
+			rootOnly: true,
+		},
+		{
+			name:     "rounds",
+			arg:      idb.TransactionFilter{MinRound: 100, MaxRound: 101, Limit: 100},
+			rootOnly: true,
+		},
+		{
+			name:     "date",
+			arg:      idb.TransactionFilter{AfterTime: time.Unix(100000, 100), Limit: 100},
+			rootOnly: true,
+		},
+		{
+			name:     "token",
+			arg:      idb.TransactionFilter{NextToken: "test", Limit: 100},
+			rootOnly: true,
+		},
+		{
+			name:     "address",
+			arg:      idb.TransactionFilter{Address: []byte{0x10, 0x11, 0x12}, Limit: 100},
+			rootOnly: false,
+		},
+		{
+			name:     "type",
+			arg:      idb.TransactionFilter{TypeEnum: idb.TypeEnumPay, Limit: 100},
+			rootOnly: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s(%t)", tt.name, tt.rootOnly), func(t *testing.T) {
+			optimized := txnFilterOptimization(tt.arg)
+			assert.Equal(t, tt.rootOnly, optimized.ReturnRootTxnsOnly)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

If contiguous transactions are being returned, there is no need to fetch the inner transactions. This is significantly easier for postgres to process and in some cases yields significantly less redundant data.

## Test Plan

New unit tests. Manually tested pagination comparing results before and after this change.