### PR TITLE
tests: Add a way to pause the e2e docker container for debugging.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,15 @@ integration: cmd/algorand-indexer/algorand-indexer
 	curl -s https://algorand-testdata.s3.amazonaws.com/indexer/test_blockdata/create_destroy.tar.bz2 -o test/blockdata/create_destroy.tar.bz2
 	test/postgres_integration_test.sh
 
+# note: when running e2e tests manually be sure to set the e2e filename:
+# 	'export CI_E2E_FILENAME=rel-nightly'
+# To keep the container running at exit set 'export EXTRA="--keep-alive"',
+# once the container is paused use 'docker exec <id> bash' to inspect temp
+# files in `/tmp/*/'
 e2e: cmd/algorand-indexer/algorand-indexer conduit-docs
 	cd e2e_tests/docker/indexer/ && docker-compose build --build-arg GO_IMAGE=${GO_IMAGE} && docker-compose up --exit-code-from e2e
 
+# note: when running e2e tests manually be sure to set the e2e filename: 'export CI_E2E_FILENAME=rel-nightly'
 e2e-conduit: conduit
 	cd third_party/go-algorand && make install
 	export PATH=$(PATH):$(shell go env GOPATH)/bin; pip3 install e2e_tests/ && e2econduit --s3-source-net ${CI_E2E_FILENAME} --conduit-bin cmd/conduit/conduit

--- a/e2e_tests/docker/indexer/Dockerfile
+++ b/e2e_tests/docker/indexer/Dockerfile
@@ -25,4 +25,4 @@ RUN pip3 install ./
 ENV INDEXER_DATA="${HOME}/indexer/"
 WORKDIR /opt/go/indexer
 # Run test script
-ENTRYPOINT ["/bin/bash", "-c", "sleep 5 && e2elive --connection-string \"$CONNECTION_STRING\" --s3-source-net \"$CI_E2E_FILENAME\" --indexer-bin /opt/go/indexer/cmd/algorand-indexer/algorand-indexer --indexer-port 9890"]
+ENTRYPOINT ["/bin/bash", "-c", "sleep 5 && e2elive $EXTRA --connection-string \"$CONNECTION_STRING\" --s3-source-net \"$CI_E2E_FILENAME\" --indexer-bin /opt/go/indexer/cmd/algorand-indexer/algorand-indexer --indexer-port 9890"]

--- a/e2e_tests/docker/indexer/docker-compose.yml
+++ b/e2e_tests/docker/indexer/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     environment:
       CONNECTION_STRING: "host=e2e-db port=5432 user=algorand password=algorand dbname=indexer_db sslmode=disable"
       CI_E2E_FILENAME: "${CI_E2E_FILENAME}"
+      # Add --keep-alive to this variable to pause the container on an error
+      EXTRA: "${EXTRA}"
 
   e2e-db:
     image: "postgres:13-alpine"

--- a/e2e_tests/src/e2e_indexer/e2elive.py
+++ b/e2e_tests/src/e2e_indexer/e2elive.py
@@ -132,6 +132,7 @@ def main():
         for root, dirs, files in os.walk(tempnet):
             for f in files:
                 if f == "node.log":
+                    found = True
                     p = os.path.join(root, f)
                     logger.error("found node.log: {}".format(p))
                     with open(p) as nf:


### PR DESCRIPTION
## Summary

I frequently find myself wanting to inspect the e2elive temp files in the docker container. These changes allow you to do so by setting `export EXTRA=--keep-alive` prior to running `make e2e`.

## Test Plan

Manual testing.