### PR TITLE
db: Remove AccountTotals from metastate

### DIFF
--- a/idb/postgres/internal/encoding/encoding.go
+++ b/idb/postgres/internal/encoding/encoding.go
@@ -639,22 +639,6 @@ func DecodeMigrationState(data []byte) (types.MigrationState, error) {
 	return state, nil
 }
 
-// EncodeAccountTotals encodes account totals into json.
-func EncodeAccountTotals(totals *ledgercore.AccountTotals) []byte {
-	return encodeJSON(totals)
-}
-
-// DecodeAccountTotals decodes account totals from json.
-func DecodeAccountTotals(data []byte) (ledgercore.AccountTotals, error) {
-	var res ledgercore.AccountTotals
-	err := DecodeJSON(data, &res)
-	if err != nil {
-		return ledgercore.AccountTotals{}, err
-	}
-
-	return res, nil
-}
-
 // EncodeNetworkState encodes network metastate into json.
 func EncodeNetworkState(state *types.NetworkState) []byte {
 	return encodeJSON(state)

--- a/idb/postgres/internal/encoding/encoding_test.go
+++ b/idb/postgres/internal/encoding/encoding_test.go
@@ -1,7 +1,6 @@
 package encoding
 
 import (
-	"math/rand"
 	"reflect"
 	"testing"
 
@@ -464,36 +463,6 @@ func TestSpecialAddressesEncoding(t *testing.T) {
 	specialNew, err := DecodeSpecialAddresses(buf)
 	require.NoError(t, err)
 	assert.Equal(t, special, specialNew)
-}
-
-// Test that encoding of AccountTotals is as expected and that decoding results in the
-// same object.
-func TestAccountTotalsEncoding(t *testing.T) {
-	random := rand.New(rand.NewSource(1))
-	totals := ledgercore.AccountTotals{
-		Online: ledgercore.AlgoCount{
-			Money:       basics.MicroAlgos{Raw: random.Uint64()},
-			RewardUnits: random.Uint64(),
-		},
-		Offline: ledgercore.AlgoCount{
-			Money:       basics.MicroAlgos{Raw: random.Uint64()},
-			RewardUnits: random.Uint64(),
-		},
-		NotParticipating: ledgercore.AlgoCount{
-			Money:       basics.MicroAlgos{Raw: random.Uint64()},
-			RewardUnits: random.Uint64(),
-		},
-		RewardsLevel: random.Uint64(),
-	}
-
-	buf := EncodeAccountTotals(&totals)
-
-	expectedString := `{"notpart":{"mon":3916589616287113937,"rwd":6334824724549167320},"offline":{"mon":15352856648520921629,"rwd":13260572831089785859},"online":{"mon":5577006791947779410,"rwd":8674665223082153551},"rwdlvl":9828766684487745566}`
-	assert.Equal(t, expectedString, string(buf))
-
-	totalsNew, err := DecodeAccountTotals(buf)
-	require.NoError(t, err)
-	assert.Equal(t, totals, totalsNew)
 }
 
 func TestTxnExtra(t *testing.T) {

--- a/idb/postgres/internal/schema/metastate.go
+++ b/idb/postgres/internal/schema/metastate.go
@@ -5,7 +5,6 @@ const (
 	StateMetastateKey           = "state"
 	MigrationMetastateKey       = "migration"
 	SpecialAccountsMetastateKey = "accounts"
-	AccountTotals               = "totals"
 	NetworkMetaStateKey         = "network"
 	DeleteStatusKey             = "pruned"
 )

--- a/idb/postgres/internal/writer/writer.go
+++ b/idb/postgres/internal/writer/writer.go
@@ -37,7 +37,6 @@ const (
 	deleteAccountAppStmtName           = "delete_account_app"
 	upsertAppBoxStmtName               = "upsert_app_box"
 	deleteAppBoxStmtName               = "delete_app_box"
-	updateAccountTotalsStmtName        = "update_account_totals"
 )
 
 var statements = map[string]string{
@@ -115,8 +114,6 @@ var statements = map[string]string{
 		ON CONFLICT (app, name) DO UPDATE SET
 		value = EXCLUDED.value`,
 	deleteAppBoxStmtName: `DELETE FROM app_box WHERE app = $1 and name = $2`,
-	updateAccountTotalsStmtName: `UPDATE metastate SET v = $1 WHERE k = '` +
-		schema.AccountTotals + `'`,
 }
 
 // Writer is responsible for writing blocks and accounting state deltas to the database.
@@ -379,7 +376,6 @@ func (w *Writer) AddBlock(block *sdk.Block, delta ledgercore.StateDelta) error {
 			return fmt.Errorf("AddBlock() err on boxes: %w", err)
 		}
 	}
-	batch.Queue(updateAccountTotalsStmtName, encoding.EncodeAccountTotals(&delta.Totals))
 
 	results := w.tx.SendBatch(context.Background(), &batch)
 	// Clean the results off the connection's queue. Without this, weird things happen.

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -1866,28 +1866,6 @@ func TestNonUTF8Logs(t *testing.T) {
 	}
 }
 
-// Test that LoadGenesis writes account totals.
-func TestLoadGenesisAccountTotals(t *testing.T) {
-	_, connStr, shutdownFunc := pgtest.SetupPostgres(t)
-	defer shutdownFunc()
-
-	db, _, err := OpenPostgres(connStr, idb.IndexerDbOptions{}, nil)
-	require.NoError(t, err)
-	defer db.Close()
-
-	err = db.LoadGenesis(test.MakeGenesisV2())
-	require.NoError(t, err)
-
-	json, err := db.getMetastate(context.Background(), nil, schema.AccountTotals)
-	require.NoError(t, err)
-
-	ret, err := encoding.DecodeAccountTotals([]byte(json))
-	require.NoError(t, err)
-
-	assert.Equal(
-		t, basics.MicroAlgos{Raw: 4 * 1000 * 1000 * 1000 * 1000}, ret.Offline.Money)
-}
-
 func TestTxnAssetID(t *testing.T) {
 	db, shutdownFunc, proc, l := setupIdb(t, test.MakeGenesisV2())
 	defer shutdownFunc()


### PR DESCRIPTION


## Summary

Resolves #1349  
Removes the AccountTotals from the metastate table. These are not referenced by any API, so it should be a no-op from the end user standpoint.

I've removed the related tests which reference this.