### PR TITLE
tech debt: Rename and simplify app log transactions query.

### DIFF
--- a/api/converter_utils.go
+++ b/api/converter_utils.go
@@ -253,7 +253,10 @@ func txnRowToTransaction(row idb.TxnRow) (generated.Transaction, error) {
 	}
 
 	var stxn *sdk.SignedTxnWithAD
-	if row.Txn != nil {
+	if row.RootTxn != nil && row.Txn != nil {
+		// see postgres.go:yieldTxnsThreadSimple
+		return generated.Transaction{}, fmt.Errorf("%d:%d Txn and RootTxn should be mutually exclusive", row.Round, row.Intra)
+	} else if row.Txn != nil {
 		stxn = row.Txn
 	} else if row.RootTxn != nil {
 		stxn = row.RootTxn

--- a/api/converter_utils.go
+++ b/api/converter_utils.go
@@ -246,6 +246,7 @@ type rowData struct {
 }
 
 // txnRowToTransaction parses the idb.TxnRow and generates the appropriate generated.Transaction object.
+// If the TxnRow contains a RootTxn, the generated.Transaction object will be the root txn.
 func txnRowToTransaction(row idb.TxnRow) (generated.Transaction, error) {
 	if row.Error != nil {
 		return generated.Transaction{}, row.Error
@@ -283,12 +284,7 @@ func txnRowToTransaction(row idb.TxnRow) (generated.Transaction, error) {
 		Sig:      sigToTransactionSig(stxn.Sig),
 	}
 
-	var txid string
-	if row.Extra.RootIntra.Present {
-		txid = row.Extra.RootTxid
-	} else {
-		txid = crypto.TransactionIDString(stxn.Txn)
-	}
+	txid := crypto.TransactionIDString(stxn.Txn)
 	txn.Id = &txid
 	txn.Signature = &sig
 

--- a/api/converter_utils.go
+++ b/api/converter_utils.go
@@ -287,7 +287,12 @@ func txnRowToTransaction(row idb.TxnRow) (generated.Transaction, error) {
 		Sig:      sigToTransactionSig(stxn.Sig),
 	}
 
-	txid := crypto.TransactionIDString(stxn.Txn)
+	var txid string
+	if row.Extra.RootIntra.Present {
+		txid = row.Extra.RootTxid
+	} else {
+		txid = crypto.TransactionIDString(stxn.Txn)
+	}
 	txn.Id = &txid
 	txn.Signature = &sig
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -1451,10 +1451,9 @@ func (si *ServerImplementation) fetchTransactions(ctx context.Context, filter id
 				return err
 			}
 
-			// The root txn has already been added.
-			// If we also want to return inner txns, we cannot deduplicate the
-			// results as inner txns all share the same txn ID as its root txn.
-			if _, ok := rootTxnDedupeMap[*tx.Id]; ok {
+			// The root txn only needs to be added once, so remove duplicates unless
+			// we are including inner transactions (which use the root txid).
+			if _, ok := rootTxnDedupeMap[*tx.Id]; ok && !filter.IncludeInnerTxns {
 				continue
 			}
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -732,7 +732,7 @@ func (si *ServerImplementation) LookupApplicationLogsByID(ctx echo.Context, appl
 	filter.AddressRole = idb.AddressRoleSender
 	// If there is a match on an inner transaction, return the inner txn's logs
 	// instead of the root txn's logs.
-	filter.IncludeInnerTxns = true
+	filter.SkipInnerTransactionConversion = true
 
 	err = validateTransactionFilter(&filter)
 	if err != nil {
@@ -1453,7 +1453,7 @@ func (si *ServerImplementation) fetchTransactions(ctx context.Context, filter id
 
 			// The root txn only needs to be added once, so remove duplicates unless
 			// we are including inner transactions (which use the root txid).
-			if _, ok := rootTxnDedupeMap[*tx.Id]; ok && !filter.IncludeInnerTxns {
+			if _, ok := rootTxnDedupeMap[*tx.Id]; ok && !filter.SkipInnerTransactionConversion {
 				continue
 			}
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -732,7 +732,7 @@ func (si *ServerImplementation) LookupApplicationLogsByID(ctx echo.Context, appl
 	filter.AddressRole = idb.AddressRoleSender
 	// If there is a match on an inner transaction, return the inner txn's logs
 	// instead of the root txn's logs.
-	filter.SkipRootTxnJoin = true
+	filter.IncludeInnerTxns = true
 
 	err = validateTransactionFilter(&filter)
 	if err != nil {

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -732,7 +732,7 @@ func (si *ServerImplementation) LookupApplicationLogsByID(ctx echo.Context, appl
 	filter.AddressRole = idb.AddressRoleSender
 	// If there is a match on an inner transaction, return the inner txn's logs
 	// instead of the root txn's logs.
-	filter.ReturnInnerTxnOnly = true
+	filter.SkipRootTxnJoin = true
 
 	err = validateTransactionFilter(&filter)
 	if err != nil {
@@ -1451,15 +1451,10 @@ func (si *ServerImplementation) fetchTransactions(ctx context.Context, filter id
 				return err
 			}
 
-			// Do not return inner transactions.
-			if tx.Id == nil {
-				continue
-			}
-
 			// The root txn has already been added.
 			// If we also want to return inner txns, we cannot deduplicate the
 			// results as inner txns all share the same txn ID as its root txn.
-			if _, ok := rootTxnDedupeMap[*tx.Id]; ok && !filter.ReturnInnerTxnOnly {
+			if _, ok := rootTxnDedupeMap[*tx.Id]; ok {
 				continue
 			}
 

--- a/api/handlers_e2e_test.go
+++ b/api/handlers_e2e_test.go
@@ -1313,6 +1313,7 @@ func TestLookupInnerLogs(t *testing.T) {
 			require.NotNil(t, response.LogData)
 			ld := *response.LogData
 			require.Equal(t, 1, len(ld))
+			require.Equal(t, appCall.Txn.ID().String(), ld[0].Txid)
 			require.Equal(t, len(tc.logs), len(ld[0].Logs))
 			for i, log := range ld[0].Logs {
 				require.Equal(t, []byte(tc.logs[i]), log)
@@ -1415,6 +1416,7 @@ func TestLookupMultiInnerLogs(t *testing.T) {
 
 			logCount := 0
 			for txnIndex, result := range ld {
+				require.Equal(t, appCall.Txn.ID().String(), result.Txid)
 				for logIndex, log := range result.Logs {
 					require.Equal(t, []byte(tc.logs[txnIndex*2+logIndex]), log)
 					logCount++

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -8,6 +8,10 @@ import (
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand-sdk/types"
+
+	"github.com/algorand/indexer/idb"
 )
 
 func TestCallWithTimeoutTimesOut(t *testing.T) {
@@ -44,4 +48,12 @@ func TestCallWithTimeoutExitsWhenHandlerFinishes(t *testing.T) {
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, callError)
+}
+
+func TestInvalidTxnRow(t *testing.T) {
+	stxn := types.SignedTxnWithAD{}
+	invalidRow := idb.TxnRow{Txn: &stxn, RootTxn: &stxn}
+	_, err := txnRowToTransaction(invalidRow)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "Txn and RootTxn should be mutually exclusive")
 }

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -241,12 +241,12 @@ type TransactionFilter struct {
 	Limit uint64
 
 	// If this flag is set to true, then the query returns inner transactions
-	// instead of resolving them as the root transaction.
-	IncludeInnerTxns bool
+	// instead of converting them to the root transaction.
+	SkipInnerTransactionConversion bool
 
 	// If this flag is set to true, then the query only returns root
 	// transactions and skips matching or returning inner transactions.
-	ReturnRootTxnsOnly bool
+	SkipInnerTransactions bool
 
 	// If this flag is set to true, then the query returns the block excluding
 	// the transactions

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -240,9 +240,9 @@ type TransactionFilter struct {
 
 	Limit uint64
 
-	// If this flag is set to true, then the query does not attach the root
-	// transaction to inner transactions.
-	SkipRootTxnJoin bool
+	// If this flag is set to true, then the query returns inner transactions
+	// instead of resolving them as the root transaction.
+	IncludeInnerTxns bool
 
 	// If this flag is set to true, then the query only returns root
 	// transactions and skips matching or returning inner transactions.

--- a/idb/idb.go
+++ b/idb/idb.go
@@ -240,12 +240,12 @@ type TransactionFilter struct {
 
 	Limit uint64
 
-	// If this flag is set to true, then the query returns the inner txn
-	// instead of the root txn.
-	ReturnInnerTxnOnly bool
+	// If this flag is set to true, then the query does not attach the root
+	// transaction to inner transactions.
+	SkipRootTxnJoin bool
 
-	// If this flag is set to true, then the query returns only root txns
-	// and no inner txns
+	// If this flag is set to true, then the query only returns root
+	// transactions and skips matching or returning inner transactions.
 	ReturnRootTxnsOnly bool
 
 	// If this flag is set to true, then the query returns the block excluding

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -673,7 +673,7 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 	}
 
 	// If returnInnerTxnOnly flag is false, then return the root transaction
-	if tf.SkipRootTxnJoin || tf.ReturnRootTxnsOnly {
+	if tf.IncludeInnerTxns || tf.ReturnRootTxnsOnly {
 		query = "SELECT t.round, t.intra, t.txn, NULL, t.extra, t.asset, h.realtime FROM txn t JOIN block_header h ON t.round = h.round"
 	} else {
 		query = "SELECT t.round, t.intra, t.txn, root.txn, t.extra, t.asset, h.realtime FROM txn t JOIN block_header h ON t.round = h.round"
@@ -684,7 +684,7 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 	}
 
 	// join in the root transaction if the returnInnerTxnOnly flag is false
-	if !(tf.SkipRootTxnJoin || tf.ReturnRootTxnsOnly) {
+	if !(tf.IncludeInnerTxns || tf.ReturnRootTxnsOnly) {
 		query += " LEFT OUTER JOIN txn root ON t.round = root.round AND (t.extra->>'root-intra')::int = root.intra"
 	}
 

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -672,7 +672,7 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 		whereParts = append(whereParts, "t.txid IS NOT NULL")
 	}
 
-	// If returnInnerTxnOnly flag is false, then return the root transaction
+	// If these flags are true, return the root transaction
 	if tf.SkipInnerTransactionConversion || tf.SkipInnerTransactions {
 		query = "SELECT t.round, t.intra, t.txn, NULL, t.extra, t.asset, h.realtime FROM txn t JOIN block_header h ON t.round = h.round"
 	} else {
@@ -683,7 +683,7 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 		query += " JOIN txn_participation p ON t.round = p.round AND t.intra = p.intra"
 	}
 
-	// join in the root transaction if the returnInnerTxnOnly flag is false
+	// join in the root transaction if needed
 	if !(tf.SkipInnerTransactionConversion || tf.SkipInnerTransactions) {
 		query += " LEFT OUTER JOIN txn root ON t.round = root.round AND (t.extra->>'root-intra')::int = root.intra"
 	}

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -467,7 +467,7 @@ func (db *IndexerDb) GetBlock(ctx context.Context, round uint64, options idb.Get
 
 	if options.Transactions {
 		out := make(chan idb.TxnRow, 1)
-		query, whereArgs, err := buildTransactionQuery(idb.TransactionFilter{Round: &round, Limit: options.MaxTransactionsLimit + 1, ReturnRootTxnsOnly: true})
+		query, whereArgs, err := buildTransactionQuery(idb.TransactionFilter{Round: &round, Limit: options.MaxTransactionsLimit + 1, SkipInnerTransactions: true})
 		if err != nil {
 			err = fmt.Errorf("txn query err %v", err)
 			out <- idb.TxnRow{Error: err}
@@ -668,12 +668,12 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 	if tf.RekeyTo != nil && (*tf.RekeyTo) {
 		whereParts = append(whereParts, "(t.txn -> 'txn' -> 'rekey') IS NOT NULL")
 	}
-	if tf.ReturnRootTxnsOnly {
+	if tf.SkipInnerTransactions {
 		whereParts = append(whereParts, "t.txid IS NOT NULL")
 	}
 
 	// If returnInnerTxnOnly flag is false, then return the root transaction
-	if tf.IncludeInnerTxns || tf.ReturnRootTxnsOnly {
+	if tf.SkipInnerTransactionConversion || tf.SkipInnerTransactions {
 		query = "SELECT t.round, t.intra, t.txn, NULL, t.extra, t.asset, h.realtime FROM txn t JOIN block_header h ON t.round = h.round"
 	} else {
 		query = "SELECT t.round, t.intra, t.txn, root.txn, t.extra, t.asset, h.realtime FROM txn t JOIN block_header h ON t.round = h.round"
@@ -684,7 +684,7 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 	}
 
 	// join in the root transaction if the returnInnerTxnOnly flag is false
-	if !(tf.IncludeInnerTxns || tf.ReturnRootTxnsOnly) {
+	if !(tf.SkipInnerTransactionConversion || tf.SkipInnerTransactions) {
 		query += " LEFT OUTER JOIN txn root ON t.round = root.round AND (t.extra->>'root-intra')::int = root.intra"
 	}
 
@@ -746,7 +746,7 @@ func txnFilterOptimization(tf idb.TransactionFilter) idb.TransactionFilter {
 		OffsetGT:   tf.OffsetGT,
 	}
 	if reflect.DeepEqual(tf, defaults) {
-		tf.ReturnRootTxnsOnly = true
+		tf.SkipInnerTransactions = true
 	}
 	return tf
 }

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -673,10 +673,10 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 	}
 
 	// If returnInnerTxnOnly flag is false, then return the root transaction
-	if !(tf.ReturnInnerTxnOnly || tf.ReturnRootTxnsOnly) {
-		query = "SELECT t.round, t.intra, t.txn, root.txn, t.extra, t.asset, h.realtime FROM txn t JOIN block_header h ON t.round = h.round"
-	} else {
+	if tf.SkipRootTxnJoin || tf.ReturnRootTxnsOnly {
 		query = "SELECT t.round, t.intra, t.txn, NULL, t.extra, t.asset, h.realtime FROM txn t JOIN block_header h ON t.round = h.round"
+	} else {
+		query = "SELECT t.round, t.intra, t.txn, root.txn, t.extra, t.asset, h.realtime FROM txn t JOIN block_header h ON t.round = h.round"
 	}
 
 	if joinParticipation {
@@ -684,7 +684,7 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 	}
 
 	// join in the root transaction if the returnInnerTxnOnly flag is false
-	if !(tf.ReturnInnerTxnOnly || tf.ReturnRootTxnsOnly) {
+	if !(tf.SkipRootTxnJoin || tf.ReturnRootTxnsOnly) {
 		query += " LEFT OUTER JOIN txn root ON t.round = root.round AND (t.extra->>'root-intra')::int = root.intra"
 	}
 

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -1694,25 +1694,25 @@ func TestSearchForInnerTransactionReturnsRootTransaction(t *testing.T) {
 			name:        "match on root, inner, and inner-inners, return inners",
 			matches:     3,
 			returnInner: true,
-			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumApplication, ReturnInnerTxnOnly: true},
+			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumApplication, SkipRootTxnJoin: true},
 		},
 		{
 			name:        "match on inner, return inners",
 			matches:     1,
 			returnInner: true,
-			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumPay, ReturnInnerTxnOnly: true},
+			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumPay, SkipRootTxnJoin: true},
 		},
 		{
 			name:        "match on inner-inner, return inners",
 			matches:     1,
 			returnInner: true,
-			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumAssetTransfer, ReturnInnerTxnOnly: true},
+			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumAssetTransfer, SkipRootTxnJoin: true},
 		},
 		{
 			name:        "match all, return inners",
 			matches:     5,
 			returnInner: true,
-			filter:      idb.TransactionFilter{Address: appAddr[:], ReturnInnerTxnOnly: true},
+			filter:      idb.TransactionFilter{Address: appAddr[:], SkipRootTxnJoin: true},
 		},
 	}
 
@@ -1747,8 +1747,8 @@ func TestSearchForInnerTransactionReturnsRootTransaction(t *testing.T) {
 			// When: searching for a transaction that matches part of the transaction.
 			results, _ := db.Transactions(context.Background(), tc.filter)
 
-			// Then: only the root transaction should be returned if the ReturnInnerTxnOnly flag is true.
-			// Else if ReturnInnerTxnOnly is false, then the inner txn should be returned.
+			// Then: only the root transaction should be returned if the SkipRootTxnJoin flag is true.
+			// Else if SkipRootTxnJoin is false, then the inner txn should be returned.
 			num := 0
 			for result := range results {
 				num++

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -1694,25 +1694,25 @@ func TestSearchForInnerTransactionReturnsRootTransaction(t *testing.T) {
 			name:        "match on root, inner, and inner-inners, return inners",
 			matches:     3,
 			returnInner: true,
-			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumApplication, IncludeInnerTxns: true},
+			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumApplication, SkipInnerTransactionConversion: true},
 		},
 		{
 			name:        "match on inner, return inners",
 			matches:     1,
 			returnInner: true,
-			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumPay, IncludeInnerTxns: true},
+			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumPay, SkipInnerTransactionConversion: true},
 		},
 		{
 			name:        "match on inner-inner, return inners",
 			matches:     1,
 			returnInner: true,
-			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumAssetTransfer, IncludeInnerTxns: true},
+			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumAssetTransfer, SkipInnerTransactionConversion: true},
 		},
 		{
 			name:        "match all, return inners",
 			matches:     5,
 			returnInner: true,
-			filter:      idb.TransactionFilter{Address: appAddr[:], IncludeInnerTxns: true},
+			filter:      idb.TransactionFilter{Address: appAddr[:], SkipInnerTransactionConversion: true},
 		},
 	}
 
@@ -1747,8 +1747,8 @@ func TestSearchForInnerTransactionReturnsRootTransaction(t *testing.T) {
 			// When: searching for a transaction that matches part of the transaction.
 			results, _ := db.Transactions(context.Background(), tc.filter)
 
-			// Then: only the root transaction should be returned if the IncludeInnerTxns flag is true.
-			// Else if IncludeInnerTxns is false, then the inner txn should be returned.
+			// Then: only the root transaction should be returned if the SkipInnerTransactionConversion flag is true.
+			// Else if SkipInnerTransactionConversion is false, then the inner txn should be returned.
 			num := 0
 			for result := range results {
 				num++

--- a/idb/postgres/postgres_integration_test.go
+++ b/idb/postgres/postgres_integration_test.go
@@ -1694,25 +1694,25 @@ func TestSearchForInnerTransactionReturnsRootTransaction(t *testing.T) {
 			name:        "match on root, inner, and inner-inners, return inners",
 			matches:     3,
 			returnInner: true,
-			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumApplication, SkipRootTxnJoin: true},
+			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumApplication, IncludeInnerTxns: true},
 		},
 		{
 			name:        "match on inner, return inners",
 			matches:     1,
 			returnInner: true,
-			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumPay, SkipRootTxnJoin: true},
+			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumPay, IncludeInnerTxns: true},
 		},
 		{
 			name:        "match on inner-inner, return inners",
 			matches:     1,
 			returnInner: true,
-			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumAssetTransfer, SkipRootTxnJoin: true},
+			filter:      idb.TransactionFilter{Address: appAddr[:], TypeEnum: idb.TypeEnumAssetTransfer, IncludeInnerTxns: true},
 		},
 		{
 			name:        "match all, return inners",
 			matches:     5,
 			returnInner: true,
-			filter:      idb.TransactionFilter{Address: appAddr[:], SkipRootTxnJoin: true},
+			filter:      idb.TransactionFilter{Address: appAddr[:], IncludeInnerTxns: true},
 		},
 	}
 
@@ -1747,8 +1747,8 @@ func TestSearchForInnerTransactionReturnsRootTransaction(t *testing.T) {
 			// When: searching for a transaction that matches part of the transaction.
 			results, _ := db.Transactions(context.Background(), tc.filter)
 
-			// Then: only the root transaction should be returned if the SkipRootTxnJoin flag is true.
-			// Else if SkipRootTxnJoin is false, then the inner txn should be returned.
+			// Then: only the root transaction should be returned if the IncludeInnerTxns flag is true.
+			// Else if IncludeInnerTxns is false, then the inner txn should be returned.
 			num := 0
 			for result := range results {
 				num++

--- a/idb/postgres/postgres_test.go
+++ b/idb/postgres/postgres_test.go
@@ -50,7 +50,7 @@ func Test_txnFilterOptimization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s(%t)", tt.name, tt.rootOnly), func(t *testing.T) {
 			optimized := txnFilterOptimization(tt.arg)
-			assert.Equal(t, tt.rootOnly, optimized.ReturnRootTxnsOnly)
+			assert.Equal(t, tt.rootOnly, optimized.SkipInnerTransactions)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Rename `ReturnInnerTxnOnly` to `IncludeInnerTxns`, because you could still match on the root transaction.

I was torn between calling this variable `IncludeInnerTxns` and `SkipRootTxnJoin`, in the end I chose the former because it's closer to the behavior we want where the latter is the implementation.

## Test Plan

Existing regression tests.