### PR TITLE
bugfix: Reject empty genesis file.

### DIFF
--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -96,7 +96,7 @@ func (algodImp *algodImporter) Init(ctx context.Context, cfg plugins.PluginConfi
 		return nil, err
 	}
 	if reflect.DeepEqual(genesis, sdk.Genesis{}) {
-		return nil, errors.New
+		return nil, fmt.Errorf("unable to fetch genesis file from API at %s", algodImp.cfg.NetAddr)
 	}
 
 	return &genesis, err

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -5,6 +5,7 @@ import (
 	_ "embed" // used to embed config
 	"fmt"
 	"net/url"
+	"reflect"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -93,6 +94,9 @@ func (algodImp *algodImporter) Init(ctx context.Context, cfg plugins.PluginConfi
 	err = json.LenientDecode([]byte(genesisResponse), &genesis)
 	if err != nil {
 		return nil, err
+	}
+	if reflect.DeepEqual(genesis, sdk.Genesis{}) {
+		return nil, errors.New
 	}
 
 	return &genesis, err

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 
+	sdk "github.com/algorand/go-algorand-sdk/v2/types"
+
 	"github.com/algorand/indexer/conduit/plugins"
 	"github.com/algorand/indexer/conduit/plugins/importers"
 	"github.com/algorand/indexer/util/test"
@@ -51,6 +53,15 @@ func TestInitSuccess(t *testing.T) {
 	_, err := testImporter.Init(ctx, plugins.MakePluginConfig("netaddr: "+ts.URL), logger)
 	assert.NoError(t, err)
 	assert.NotEqual(t, testImporter, nil)
+	testImporter.Close()
+}
+
+func TestInitGenesisFailure(t *testing.T) {
+	ts := test.NewAlgodServer(test.MakeGenesisResponder(sdk.Genesis{}))
+	testImporter = New()
+	_, err := testImporter.Init(ctx, plugins.MakePluginConfig("netaddr: "+ts.URL), logger)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "unable to fetch genesis file")
 	testImporter.Close()
 }
 

--- a/util/test/mock_algod.go
+++ b/util/test/mock_algod.go
@@ -11,7 +11,6 @@ import (
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/common/models"
 	"github.com/algorand/go-algorand-sdk/v2/encoding/msgpack"
 	"github.com/algorand/go-algorand-sdk/v2/types"
-
 	"github.com/algorand/go-algorand/protocol"
 )
 
@@ -63,8 +62,8 @@ func BlockResponder(reqPath string, w http.ResponseWriter) bool {
 	return false
 }
 
+// MakeGenesisResponder returns a responder that will provide a specific genesis response.
 func MakeGenesisResponder(genesis types.Genesis) func(reqPath string, w http.ResponseWriter) bool {
-	// GenesisResponder handles /v2/genesis requests and returns an empty Genesis object
 	return func(reqPath string, w http.ResponseWriter) bool {
 		if strings.Contains(reqPath, "/genesis") {
 			w.WriteHeader(http.StatusOK)
@@ -76,6 +75,7 @@ func MakeGenesisResponder(genesis types.Genesis) func(reqPath string, w http.Res
 	}
 }
 
+// GenesisResponder handles /v2/genesis requests and returns an empty Genesis object
 var GenesisResponder = MakeGenesisResponder(types.Genesis{
 	Comment: "",
 	DevMode: true,

--- a/util/test/mock_algod.go
+++ b/util/test/mock_algod.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/algod"
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/common/models"
-	"github.com/algorand/go-algorand/data/basics"
-	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/algorand/go-algorand-sdk/v2/encoding/msgpack"
+	"github.com/algorand/go-algorand-sdk/v2/types"
+
 	"github.com/algorand/go-algorand/protocol"
-	"github.com/algorand/go-algorand/rpcs"
 )
 
 // AlgodHandler is used to handle http requests to a mock algod server
@@ -50,8 +50,12 @@ func MockAClient(handler *AlgodHandler) (*algod.Client, error) {
 func BlockResponder(reqPath string, w http.ResponseWriter) bool {
 	if strings.Contains(reqPath, "v2/blocks/") {
 		rnd, _ := strconv.Atoi(path.Base(reqPath))
-		blk := rpcs.EncodedBlockCert{Block: bookkeeping.Block{BlockHeader: bookkeeping.BlockHeader{Round: basics.Round(rnd)}}}
-		blockbytes := protocol.Encode(&blk)
+		type EncodedBlock struct {
+			_struct struct{}    `codec:""`
+			Block   types.Block `codec:"block"`
+		}
+		blk := EncodedBlock{Block: types.Block{BlockHeader: types.BlockHeader{Round: types.Round(rnd)}}}
+		blockbytes := msgpack.Encode(&blk)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(blockbytes)
 		return true
@@ -59,20 +63,23 @@ func BlockResponder(reqPath string, w http.ResponseWriter) bool {
 	return false
 }
 
-// GenesisResponder handles /v2/genesis requests and returns an empty Genesis object
-func GenesisResponder(reqPath string, w http.ResponseWriter) bool {
-	if strings.Contains(reqPath, "/genesis") {
-		w.WriteHeader(http.StatusOK)
-		genesis := &bookkeeping.Genesis{
-			Comment: "",
-			DevMode: true,
+func MakeGenesisResponder(genesis types.Genesis) func(reqPath string, w http.ResponseWriter) bool {
+	// GenesisResponder handles /v2/genesis requests and returns an empty Genesis object
+	return func(reqPath string, w http.ResponseWriter) bool {
+		if strings.Contains(reqPath, "/genesis") {
+			w.WriteHeader(http.StatusOK)
+			blockbytes := protocol.EncodeJSON(&genesis)
+			_, _ = w.Write(blockbytes)
+			return true
 		}
-		blockbytes := protocol.EncodeJSON(*genesis)
-		_, _ = w.Write(blockbytes)
-		return true
+		return false
 	}
-	return false
 }
+
+var GenesisResponder = MakeGenesisResponder(types.Genesis{
+	Comment: "",
+	DevMode: true,
+})
 
 // BlockAfterResponder handles /v2/wait-for-block-after requests and returns an empty NodeStatus object
 func BlockAfterResponder(reqPath string, w http.ResponseWriter) bool {


### PR DESCRIPTION
## Summary

The go SDK was returning a bad genesis file, and the lenient decoder was allowing an empty genesis file to be returned. Add another check to make sure this sort of bad genesis file does not slip through. In the future the go SDK would properly return an error.

Workaround for this bug:
https://github.com/algorand/go-algorand-sdk/pull/461

## Test Plan

New unit test.