### PR TITLE
local ledger: Ignore duplicate genesis block adds.

### DIFF
--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -190,6 +190,10 @@ func (db *IndexerDb) AddBlock(vb *ledgercore.ValidatedBlock) error {
 			return fmt.Errorf("AddBlock() err: %w", err)
 		}
 		if block.Round() != basics.Round(importstate.NextRoundToAccount) {
+			// Ignore repeat attempts to add genesis file.
+			if block.Round() == 0 {
+				return nil
+			}
 			return fmt.Errorf(
 				"AddBlock() adding block round %d but next round to account is %d",
 				block.Round(), importstate.NextRoundToAccount)


### PR DESCRIPTION
## Summary

This PR fixes https://github.com/algorand/sandbox/issues/163

When connecting to a devmode network it is easy for the ledger to be stuck at round 0 while waiting for a new block to be added. There is a bug during the Indexer startup routing which causes the genesis block to be added a second time when the ledger is on round 0, even though the database has already loaded that round.

    A better fix for this bug is to modify the MakeProcessor function to
    skip adding the genesis block when we are beyond round 0. That is a
    larger change and is obsolete on develop, so I opted for the simple
    check in this commit.

## Test Plan

Manual testing with sandbox and dev mode.
