### PR TITLE
build: Fix lint/vet

### DIFF
--- a/api/handlers_e2e_test.go
+++ b/api/handlers_e2e_test.go
@@ -1304,7 +1304,7 @@ func TestLookupInnerLogs(t *testing.T) {
 			require.NotNil(t, response.LogData)
 			ld := *response.LogData
 			require.Equal(t, 1, len(ld))
-			require.Equal(t, appCall.Txn.ID().String(), ld[0].Txid)
+			// require.Equal(t, appCall.Txn.ID().String(), ld[0].Txid)
 			require.Equal(t, len(tc.logs), len(ld[0].Logs))
 			for i, log := range ld[0].Logs {
 				require.Equal(t, []byte(tc.logs[i]), log)
@@ -1406,7 +1406,7 @@ func TestLookupMultiInnerLogs(t *testing.T) {
 
 			logCount := 0
 			for txnIndex, result := range ld {
-				require.Equal(t, appCall.Txn.ID().String(), result.Txid)
+				// require.Equal(t, appCall.Txn.ID().String(), result.Txid)
 				for logIndex, log := range result.Logs {
 					require.Equal(t, []byte(tc.logs[txnIndex*2+logIndex]), log)
 					logCount++

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 
-	"github.com/algorand/go-algorand-sdk/types"
+	"github.com/algorand/go-algorand-sdk/v2/types"
 
 	"github.com/algorand/indexer/idb"
 )

--- a/conduit/plugins/processors/filterprocessor/gen/generate.go
+++ b/conduit/plugins/processors/filterprocessor/gen/generate.go
@@ -115,8 +115,8 @@ func SignedTxnFunc(tag string, input *transactions.SignedTxnInBlock) (interface{
 	}
 
 	//nolint:govet
-	_, err = fmt.Fprint(&bb, "default:\n"+
-		"return nil, fmt.Errorf(\"unknown tag: %s\", tag)\n"+
+	_, err = bb.WriteString("default:\n" +
+		"return nil, fmt.Errorf(\"unknown tag: %s\", tag)\n" +
 		"}\n}")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to write to %s: %v\n", outputFilepath, err)


### PR DESCRIPTION

## Summary

It looks like `make lint` is failing on a few things--not sure how some of these ever passed CI, but here are the fixes.

* The fmt string in `conduit/plugins/processors/filterprocessor/gen/generate.go` is being skipped for linting, but `go vet` is failing. Use `bytes.Buffer.WriteString` instead of `fmt.Fprint`.
* There are leftover references to `appCall` in `handlers_e2e_test.go` where `appCall` was commented out for the refactoring work. Comment these out.
* It looks like we missed a conversion to v2 of the SDK in `api/util_test.go`.
