### PR TITLE
docs: Remove extra conduit-docs output.

### DIFF
--- a/cmd/conduit-docs/main.go
+++ b/cmd/conduit-docs/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -14,6 +15,8 @@ import (
 const namePrefix = "Name: "
 const headerPrefix = "Header\n"
 const footerPrefix = "Footer\n"
+
+var verbose bool
 
 // generateMd takes the path of a file containing a struct definition named "Config", and an output directory,
 // and writes a markdown file to the outputDir containing mkdocs-style documentation for the Config struct
@@ -43,7 +46,9 @@ func generateMd(configPath string, outputDir string) error {
 		}
 		if strings.HasPrefix(comm.Text(), namePrefix) {
 			fileName = strings.TrimSuffix(strings.TrimPrefix(comm.Text(), namePrefix), "\n")
-			fmt.Println(fileName)
+			if verbose {
+				fmt.Println(fileName)
+			}
 		}
 	}
 	// Process struct decls into tables describing their fields
@@ -115,10 +120,13 @@ func processConfig(configStruct *ast.StructType, structName string, fileBytes []
 }
 
 func main() {
+	flag.BoolVar(&verbose, "verbose", false, "Include additional terminal output.")
+	flag.Parse()
+
 	usage := "USAGE: //go:generate conduit-docs <path-to-output-dir>"
 	// go:generate conduit-docs [path]
-	if len(os.Args) == 2 {
-		err := generateMd(os.Getenv("GOFILE"), os.Args[1])
+	if len(flag.Args()) == 1 {
+		err := generateMd(os.Getenv("GOFILE"), flag.Arg(0))
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/cmd/conduit-docs/main.go
+++ b/cmd/conduit-docs/main.go
@@ -16,8 +16,6 @@ const namePrefix = "Name: "
 const headerPrefix = "Header\n"
 const footerPrefix = "Footer\n"
 
-var verbose bool
-
 // generateMd takes the path of a file containing a struct definition named "Config", and an output directory,
 // and writes a markdown file to the outputDir containing mkdocs-style documentation for the Config struct
 func generateMd(configPath string, outputDir string) error {
@@ -46,9 +44,6 @@ func generateMd(configPath string, outputDir string) error {
 		}
 		if strings.HasPrefix(comm.Text(), namePrefix) {
 			fileName = strings.TrimSuffix(strings.TrimPrefix(comm.Text(), namePrefix), "\n")
-			if verbose {
-				fmt.Println(fileName)
-			}
 		}
 	}
 	// Process struct decls into tables describing their fields
@@ -120,7 +115,6 @@ func processConfig(configStruct *ast.StructType, structName string, fileBytes []
 }
 
 func main() {
-	flag.BoolVar(&verbose, "verbose", false, "Include additional terminal output.")
 	flag.Parse()
 
 	usage := "USAGE: //go:generate conduit-docs <path-to-output-dir>"


### PR DESCRIPTION
 ## Summary

The conduit-docs output looked out of place, this adds a verbose option so that it is suppressed by default.

## Test Plan

Run 'make'