### PR TITLE
tests: Update e2e dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ commands:
           no_output_timeout: 15m
       - run: make test-generate
       - run: make fakepackage
-      - run: make e2e
+      - run: make e2e-nightly
       - run: make e2e-conduit
 
   run_indexer_vs_algod:

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ integration: cmd/algorand-indexer/algorand-indexer
 e2e: cmd/algorand-indexer/algorand-indexer conduit-docs
 	cd e2e_tests/docker/indexer/ && docker-compose build --build-arg GO_IMAGE=${GO_IMAGE} && docker-compose up --exit-code-from e2e
 
+e2e-nightly: cmd/algorand-indexer/algorand-indexer conduit-docs
+	cd e2e_tests/docker/indexer/ && docker-compose build --build-arg GO_IMAGE=${GO_IMAGE} --build-arg CHANNEL=nightly && docker-compose up --exit-code-from e2e
+
 # note: when running e2e tests manually be sure to set the e2e filename: 'export CI_E2E_FILENAME=rel-nightly'
 e2e-conduit: conduit
 	cd third_party/go-algorand && make install

--- a/api/handlers_e2e_test.go
+++ b/api/handlers_e2e_test.go
@@ -1306,7 +1306,7 @@ func TestLookupInnerLogs(t *testing.T) {
 			require.NotNil(t, response.LogData)
 			ld := *response.LogData
 			require.Equal(t, 1, len(ld))
-			// require.Equal(t, appCall.Txn.ID().String(), ld[0].Txid)
+			require.Equal(t, appCall.Txn.ID().String(), ld[0].Txid)
 			require.Equal(t, len(tc.logs), len(ld[0].Logs))
 			for i, log := range ld[0].Logs {
 				require.Equal(t, []byte(tc.logs[i]), log)
@@ -1410,7 +1410,7 @@ func TestLookupMultiInnerLogs(t *testing.T) {
 
 			logCount := 0
 			for txnIndex, result := range ld {
-				// require.Equal(t, appCall.Txn.ID().String(), result.Txid)
+				require.Equal(t, appCall.Txn.ID().String(), result.Txid)
 				for logIndex, log := range result.Logs {
 					require.Equal(t, []byte(tc.logs[txnIndex*2+logIndex]), log)
 					logCount++

--- a/api/handlers_e2e_test.go
+++ b/api/handlers_e2e_test.go
@@ -1306,7 +1306,7 @@ func TestLookupInnerLogs(t *testing.T) {
 			require.NotNil(t, response.LogData)
 			ld := *response.LogData
 			require.Equal(t, 1, len(ld))
-			require.Equal(t, appCall.Txn.ID().String(), ld[0].Txid)
+			// require.Equal(t, appCall.Txn.ID().String(), ld[0].Txid)
 			require.Equal(t, len(tc.logs), len(ld[0].Logs))
 			for i, log := range ld[0].Logs {
 				require.Equal(t, []byte(tc.logs[i]), log)
@@ -1410,7 +1410,7 @@ func TestLookupMultiInnerLogs(t *testing.T) {
 
 			logCount := 0
 			for txnIndex, result := range ld {
-				require.Equal(t, appCall.Txn.ID().String(), result.Txid)
+				// require.Equal(t, appCall.Txn.ID().String(), result.Txid)
 				for logIndex, log := range result.Logs {
 					require.Equal(t, []byte(tc.logs[txnIndex*2+logIndex]), log)
 					logCount++

--- a/e2e_tests/docker/indexer/Dockerfile
+++ b/e2e_tests/docker/indexer/Dockerfile
@@ -1,12 +1,13 @@
 ARG GO_IMAGE=golang:1.14.7
 FROM $GO_IMAGE
+ARG CHANNEL=stable
 
 RUN echo "Go image: $GO_IMAGE"
 
 # Misc dependencies
 ENV HOME /opt
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y apt-utils curl git git-core bsdmainutils python3 python3-pip make bash libtool libboost-math-dev libffi-dev
+RUN apt-get update && apt-get install -y apt-utils curl git git-core bsdmainutils python3 python3-pip make bash libtool libboost-math-dev libffi-dev wget
 
 # Setup files for test
 RUN mkdir -p /opt/go/indexer
@@ -14,8 +15,9 @@ COPY . /opt/go/indexer
 WORKDIR /opt/go/indexer
 RUN rm -f $HOME/go/bin/algod
 RUN rm -f /opt/go/indexer/cmd/algorand-indexer/algorand-indexer
-WORKDIR /opt/go/indexer/third_party/go-algorand
-RUN make install
+WORKDIR /opt/go/node
+RUN wget https://raw.githubusercontent.com/algorand/go-algorand/rel/stable/cmd/updater/update.sh && chmod 744 update.sh
+RUN ./update.sh -i -c $CHANNEL -n -d ./ -p /go/bin/
 WORKDIR /opt/go/indexer
 RUN make
 ENV PATH="${HOME}/go/bin/:${PATH}"


### PR DESCRIPTION


## Summary

Changed the indexer e2e tests to download and install the go-algorand binaries via the updater script. Also updated the circleCI config to run the nightly tests using the nightly binaries--whereas the regular tests will use the stable binaries.

The conduit e2e tests will need separate changes as well--I'd like to wait on those until we land all of the follower node changes/tests.

## Test Plan

`make e2e-nightly`
