### PR TITLE
e2e-tests: Add more log files on failure

### DIFF
--- a/e2e_tests/src/e2e_indexer/e2elive.py
+++ b/e2e_tests/src/e2e_indexer/e2elive.py
@@ -129,17 +129,18 @@ def main():
     except Exception:
         logger.error("failed to start private network, looking for node.log")
         found = False
+        log_files = ("node.log", "algod-err.log",)
         for root, dirs, files in os.walk(tempnet):
             for f in files:
-                if f == "node.log":
+                if f in log_files:
                     found = True
                     p = os.path.join(root, f)
-                    logger.error("found node.log: {}".format(p))
+                    logger.error("Found {}: {}".format(f, p))
                     with open(p) as nf:
                         for line in nf:
                             logger.error("   {}".format(line))
         if found is False:
-            logger.error("unable to find node.log")
+            logger.error("Unable to find log file")
         raise
 
     atexitrun(["goal", "network", "stop", "-r", tempnet])


### PR DESCRIPTION
Adds `algod-err.log` to the set of files that will be output to stdout on indexer e2e test failure.

This shows more useful information such as the line below:
```
e2e_1     | ERROR:e2e_indexer.e2elive:   time="2023-02-04T00:38:19.370572 +0000" level=fatal msg="Cannot load config: unexpected config version: 27" file=main.go function=main.run line=164
```

## Test Plan
Current nightly tests are failing:

```
e2e_1     | INFO:e2e_common.util:s3://algorand-testdata/indexer/e2e4/fa2f8089/rel-nightly.tar.bz2 -> /tmp/tmpjtl_egpo/rel-nightly.tar.bz2
e2e_1     | ERROR:e2e_common.util:cmd failed (1) 'goal' 'network' 'start' '-r' '/tmp/tmpjtl_egpo/net'
e2e_1     | output from 'goal' 'network' 'start' '-r' '/tmp/tmpjtl_egpo/net':
e2e_1     | Error starting deployed network: node exited with an error code, check node.log for more details : exit status 1
e2e_1     | 
e2e_1     | 
e2e_1     | ERROR:e2e_indexer.e2elive:failed to start private network, looking for node.log
e2e_1     | ERROR:e2e_indexer.e2elive:Found algod-err.log: /tmp/tmpjtl_egpo/net/Primary/algod-err.log
e2e_1     | ERROR:e2e_indexer.e2elive:   time="2023-02-04T00:38:19.370488 +0000" level=error msg="[Stack] goroutine 1 [running]:\nruntime/debug.Stack()\n\truntime/debug/stack.go:24 +0x88\ngithub.com/algorand/go-algorand/logging.logger.Fatalf({0x40005c69a0, 0x4000116010}, {0x1428f94, 0x16}, {0x4000114580, 0x1, 0x1})\n\tgithub.com/algorand/go-algorand/logging/log.go:244 +0x3c\nmain.run()\n\tgithub.com/algorand/go-algorand/cmd/algod/main.go:164 +0x9dc\nmain.main()\n\tgithub.com/algorand/go-algorand/cmd/algod/main.go:61 +0x84\n" file=main.go function=main.run line=164
e2e_1     | 
e2e_1     | ERROR:e2e_indexer.e2elive:   time="2023-02-04T00:38:19.370572 +0000" level=fatal msg="Cannot load config: unexpected config version: 27" file=main.go function=main.run line=164
e2e_1     | 
e2e_1     | ERROR:e2e_indexer.e2elive:Found algod-err.log: /tmp/tmpjtl_egpo/net/Node/algod-err.log
e2e_1     | Traceback (most recent call last):
e2e_1     |   File "/usr/local/bin/e2elive", line 8, in <module>
e2e_1     |     sys.exit(main())
e2e_1     |   File "/usr/local/lib/python3.9/dist-packages/e2e_indexer/e2elive.py", line 128, in main
e2e_1     |     xrun(["goal", "network", "start", "-r", tempnet])
e2e_1     |   File "/usr/local/lib/python3.9/dist-packages/e2e_common/util.py", line 114, in xrun
e2e_1     |     raise Exception("error: cmd failed: {}".format(cmdr))
e2e_1     | Exception: error: cmd failed: 'goal' 'network' 'start' '-r' '/tmp/tmpjtl_egpo/net'
```
