### PR TITLE
FilterProcessor performance improvement and minor refactoring.

### DIFF
--- a/conduit/plugins/processors/filterprocessor/expression/expression.go
+++ b/conduit/plugins/processors/filterprocessor/expression/expression.go
@@ -5,8 +5,6 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
-
-	"github.com/algorand/go-algorand/data/basics"
 )
 
 // FilterType is the type of the filter (i.e. const, regex, etc)
@@ -99,19 +97,6 @@ func MakeExpression(expressionType FilterType, expressionSearchStr string, targe
 			var exp Expression
 
 			switch targetKind {
-			case reflect.TypeOf(basics.MicroAlgos{}).Kind():
-				{
-					v, err := strconv.ParseUint(expressionSearchStr, 10, 64)
-					if err != nil {
-						return nil, err
-					}
-
-					exp = microAlgoExpression{
-						FilterValue: basics.MicroAlgos{Raw: v},
-						Op:          expressionType,
-					}
-				}
-
 			case reflect.Int64:
 				{
 					v, err := strconv.ParseInt(expressionSearchStr, 10, 64)

--- a/conduit/plugins/processors/filterprocessor/expression/expression.go
+++ b/conduit/plugins/processors/filterprocessor/expression/expression.go
@@ -2,7 +2,6 @@ package expression
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
 	"strconv"
 )
@@ -55,11 +54,11 @@ type regexExpression struct {
 }
 
 func (e regexExpression) Search(input interface{}) (bool, error) {
-	return e.Regex.MatchString(input.(string)), nil
+	return e.Regex.MatchString(fmt.Sprintf("%s", input)), nil
 }
 
 // MakeExpression creates an expression based on an expression type
-func MakeExpression(expressionType FilterType, expressionSearchStr string, targetKind reflect.Kind) (*Expression, error) {
+func MakeExpression(expressionType FilterType, expressionSearchStr string, target interface{}) (*Expression, error) {
 	switch expressionType {
 	case ExactFilter:
 		{
@@ -96,8 +95,8 @@ func MakeExpression(expressionType FilterType, expressionSearchStr string, targe
 		{
 			var exp Expression
 
-			switch targetKind {
-			case reflect.Int64:
+			switch targetType := target.(type) {
+			case int64:
 				{
 					v, err := strconv.ParseInt(expressionSearchStr, 10, 64)
 					if err != nil {
@@ -110,7 +109,7 @@ func MakeExpression(expressionType FilterType, expressionSearchStr string, targe
 					}
 				}
 
-			case reflect.Uint64:
+			case uint64:
 				{
 					v, err := strconv.ParseUint(expressionSearchStr, 10, 64)
 					if err != nil {
@@ -124,7 +123,7 @@ func MakeExpression(expressionType FilterType, expressionSearchStr string, targe
 				}
 
 			default:
-				return nil, fmt.Errorf("unknown target kind (%s) for filter type: %s", targetKind.String(), expressionType)
+				return nil, fmt.Errorf("unknown target kind (%T) for filter type: %s", targetType, expressionType)
 			}
 
 			return &exp, nil

--- a/conduit/plugins/processors/filterprocessor/expression/expression_test.go
+++ b/conduit/plugins/processors/filterprocessor/expression/expression_test.go
@@ -1,0 +1,119 @@
+package expression
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algorand/go-algorand/data/basics"
+)
+
+func TestExpression(t *testing.T) {
+	testcases := []struct {
+		name         string
+		input        interface{}
+		filterType   FilterType
+		searchString string
+		kind         interface{}
+		errorString  string
+		match        bool
+	}{
+		{
+			name:         "Alias 1 (2 < 4)",
+			input:        basics.AppIndex(2),
+			filterType:   LessThanFilter,
+			searchString: "4",
+			kind:         uint64(0),
+			errorString:  "",
+			match:        true,
+		},
+		{
+			name:         "Alias 2 (4 < 4)",
+			input:        basics.AppIndex(4),
+			filterType:   LessThanFilter,
+			searchString: "4",
+			kind:         uint64(0),
+			errorString:  "",
+			match:        false,
+		},
+		{
+			name:         "Alias 3 (4 <= 4)",
+			input:        basics.AppIndex(4),
+			filterType:   LessThanEqualFilter,
+			searchString: "4",
+			kind:         uint64(0),
+			errorString:  "",
+			match:        true,
+		},
+		{
+			name:         "Alias 4 (4 == 4)",
+			input:        basics.AppIndex(4),
+			filterType:   EqualToFilter,
+			searchString: "4",
+			kind:         uint64(0),
+			errorString:  "",
+			match:        true,
+		},
+		{
+			name:         "Alias 5 (4 == 5)",
+			input:        basics.AppIndex(4),
+			filterType:   EqualToFilter,
+			searchString: "5",
+			kind:         uint64(0),
+			errorString:  "",
+			match:        false,
+		},
+		{
+			name:         "Alias 6 (4 != 5)",
+			input:        basics.AppIndex(4),
+			filterType:   NotEqualToFilter,
+			searchString: "5",
+			kind:         uint64(0),
+			errorString:  "",
+			match:        true,
+		},
+		{
+			name:         "Alias 7 (4 > 20)",
+			input:        basics.AppIndex(4),
+			filterType:   GreaterThanFilter,
+			searchString: "20",
+			kind:         uint64(0),
+			errorString:  "",
+			match:        false,
+		},
+		{
+			name:         "Alias 8 (4 > 2)",
+			input:        basics.AppIndex(4),
+			filterType:   GreaterThanFilter,
+			searchString: "2",
+			kind:         uint64(0),
+			errorString:  "",
+			match:        true,
+		},
+		{
+			name:         "Alias 9 (4 >= 4)",
+			input:        basics.AppIndex(4),
+			filterType:   GreaterThanEqualFilter,
+			searchString: "4",
+			kind:         uint64(0),
+			errorString:  "",
+			match:        true,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			exp, err := MakeExpression(tc.filterType, tc.searchString, tc.kind)
+			require.NoError(t, err)
+
+			m, err := (*exp).Search(tc.input)
+			if tc.errorString != "" {
+				assert.ErrorContains(t, err, tc.errorString)
+				return
+			}
+			assert.Equal(t, tc.match, m)
+		})
+	}
+}

--- a/conduit/plugins/processors/filterprocessor/expression/numerical_expressions.go
+++ b/conduit/plugins/processors/filterprocessor/expression/numerical_expressions.go
@@ -3,39 +3,7 @@ package expression
 import (
 	"fmt"
 	"reflect"
-
-	"github.com/algorand/go-algorand/data/basics"
 )
-
-type microAlgoExpression struct {
-	FilterValue basics.MicroAlgos
-	Op          FilterType
-}
-
-func (m microAlgoExpression) Search(input interface{}) (bool, error) {
-
-	inputValue, ok := input.(basics.MicroAlgos)
-	if !ok {
-		return false, fmt.Errorf("supplied type (%s) was not microalgos", reflect.TypeOf(input).String())
-	}
-
-	switch m.Op {
-	case LessThanFilter:
-		return inputValue.Raw < m.FilterValue.Raw, nil
-	case LessThanEqualFilter:
-		return inputValue.Raw <= m.FilterValue.Raw, nil
-	case EqualToFilter:
-		return inputValue.Raw == m.FilterValue.Raw, nil
-	case NotEqualToFilter:
-		return inputValue.Raw != m.FilterValue.Raw, nil
-	case GreaterThanFilter:
-		return inputValue.Raw > m.FilterValue.Raw, nil
-	case GreaterThanEqualFilter:
-		return inputValue.Raw >= m.FilterValue.Raw, nil
-	default:
-		return false, fmt.Errorf("unknown op: %s", m.Op)
-	}
-}
 
 type int64NumericalExpression struct {
 	FilterValue int64
@@ -43,6 +11,17 @@ type int64NumericalExpression struct {
 }
 
 func (s int64NumericalExpression) Search(input interface{}) (bool, error) {
+	var inputValue int64
+
+	switch value := input.(type) {
+	case int64:
+		inputValue = value
+	case uint64:
+		inputValue = int64(value)
+	default:
+		return false, fmt.Errorf("unhandled numeric type: %s", reflect.TypeOf(input))
+	}
+
 	inputValue, ok := input.(int64)
 	if !ok {
 		// If the input interface{} isn't int64 but an alias for int64, we want to check that

--- a/conduit/plugins/processors/filterprocessor/expression/numerical_expressions.go
+++ b/conduit/plugins/processors/filterprocessor/expression/numerical_expressions.go
@@ -11,17 +11,6 @@ type int64NumericalExpression struct {
 }
 
 func (s int64NumericalExpression) Search(input interface{}) (bool, error) {
-	var inputValue int64
-
-	switch value := input.(type) {
-	case int64:
-		inputValue = value
-	case uint64:
-		inputValue = int64(value)
-	default:
-		return false, fmt.Errorf("unhandled numeric type: %s", reflect.TypeOf(input))
-	}
-
 	inputValue, ok := input.(int64)
 	if !ok {
 		// If the input interface{} isn't int64 but an alias for int64, we want to check that

--- a/conduit/plugins/processors/filterprocessor/fields/filter.go
+++ b/conduit/plugins/processors/filterprocessor/fields/filter.go
@@ -39,7 +39,7 @@ func (f Filter) SearchAndFilter(input data.BlockData) (data.BlockData, error) {
 
 			allFalse := true
 			for _, fs := range f.Searchers {
-				b, err := fs.search(txn)
+				b, err := fs.search(&txn)
 				if err != nil {
 					return data.BlockData{}, err
 				}
@@ -59,7 +59,7 @@ func (f Filter) SearchAndFilter(input data.BlockData) (data.BlockData, error) {
 	case anyFieldOperation:
 		for _, txn := range input.Payset {
 			for _, fs := range f.Searchers {
-				b, err := fs.search(txn)
+				b, err := fs.search(&txn)
 				if err != nil {
 					return data.BlockData{}, err
 				}
@@ -76,7 +76,7 @@ func (f Filter) SearchAndFilter(input data.BlockData) (data.BlockData, error) {
 
 			allTrue := true
 			for _, fs := range f.Searchers {
-				b, err := fs.search(txn)
+				b, err := fs.search(&txn)
 				if err != nil {
 					return data.BlockData{}, err
 				}

--- a/conduit/plugins/processors/filterprocessor/fields/generated_signed_txn_map.go
+++ b/conduit/plugins/processors/filterprocessor/fields/generated_signed_txn_map.go
@@ -18,7 +18,7 @@ func LookupFieldByTag(tag string, input *transactions.SignedTxnInBlock) (interfa
 	case "apid":
 		return &input.SignedTxnWithAD.ApplyData.ApplicationID, nil
 	case "ca":
-		return &input.SignedTxnWithAD.ApplyData.ClosingAmount, nil
+		return &input.SignedTxnWithAD.ApplyData.ClosingAmount.Raw, nil
 	case "caid":
 		return &input.SignedTxnWithAD.ApplyData.ConfigAsset, nil
 	case "dt":
@@ -60,11 +60,11 @@ func LookupFieldByTag(tag string, input *transactions.SignedTxnInBlock) (interfa
 	case "msig.v":
 		return &input.SignedTxnWithAD.SignedTxn.Msig.Version, nil
 	case "rc":
-		return &input.SignedTxnWithAD.ApplyData.CloseRewards, nil
+		return &input.SignedTxnWithAD.ApplyData.CloseRewards.Raw, nil
 	case "rr":
-		return &input.SignedTxnWithAD.ApplyData.ReceiverRewards, nil
+		return &input.SignedTxnWithAD.ApplyData.ReceiverRewards.Raw, nil
 	case "rs":
-		return &input.SignedTxnWithAD.ApplyData.SenderRewards, nil
+		return &input.SignedTxnWithAD.ApplyData.SenderRewards.Raw, nil
 	case "sgnr":
 		return &input.SignedTxnWithAD.SignedTxn.AuthAddr, nil
 	case "sig":
@@ -78,7 +78,7 @@ func LookupFieldByTag(tag string, input *transactions.SignedTxnInBlock) (interfa
 	case "txn.afrz":
 		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetFreezeTxnFields.AssetFrozen, nil
 	case "txn.amt":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount, nil
+		return &input.SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw, nil
 	case "txn.apaa":
 		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.ApplicationArgs, nil
 	case "txn.apan":
@@ -148,7 +148,7 @@ func LookupFieldByTag(tag string, input *transactions.SignedTxnInBlock) (interfa
 	case "txn.faid":
 		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetFreezeTxnFields.FreezeAsset, nil
 	case "txn.fee":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.Header.Fee, nil
+		return &input.SignedTxnWithAD.SignedTxn.Txn.Header.Fee.Raw, nil
 	case "txn.fv":
 		return &input.SignedTxnWithAD.SignedTxn.Txn.Header.FirstValid, nil
 	case "txn.gen":

--- a/conduit/plugins/processors/filterprocessor/fields/generated_signed_txn_map.go
+++ b/conduit/plugins/processors/filterprocessor/fields/generated_signed_txn_map.go
@@ -8,9 +8,9 @@ import (
 	"github.com/algorand/go-algorand/data/transactions"
 )
 
-// SignedTxnFunc takes a tag and associated SignedTxnInBlock and returns the value
+// LookupFieldByTag takes a tag and associated SignedTxnInBlock and returns the value
 // referenced by the tag.  An error is returned if the tag does not exist
-func SignedTxnFunc(tag string, input *transactions.SignedTxnInBlock) (interface{}, error) {
+func LookupFieldByTag(tag string, input *transactions.SignedTxnInBlock) (interface{}, error) {
 
 	switch tag {
 	case "aca":

--- a/conduit/plugins/processors/filterprocessor/fields/searcher.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher.go
@@ -24,10 +24,7 @@ func MakeSearcher(filterTag string, expressionType expression.FilterType, expres
 		return nil, err
 	}
 
-	// We need the Elem() here because LookupFieldByTag returns a pointer underneath the interface{}
-	targetKind := reflect.TypeOf(t).Elem().Kind()
-
-	exp, err := expression.MakeExpression(expressionType, expressionStr, targetKind)
+	exp, err := expression.MakeExpression(expressionType, expressionStr, t)
 	if err != nil {
 		return nil, fmt.Errorf("filter processor Init(): could not make expression with string %s for filter tag %s - %w", expressionStr, filterTag, err)
 	}
@@ -50,18 +47,7 @@ func (f Searcher) search(input *transactions.SignedTxnInBlock) (bool, error) {
 		return false, err
 	}
 
-	e := reflect.ValueOf(val).Elem()
-
-	var toSearch interface{}
-	if f.MethodToCall != "" {
-		// If there is a function, search what is returned
-		toSearch = e.MethodByName(f.MethodToCall).Call([]reflect.Value{})[0].Interface()
-	} else {
-		// Otherwise, get the original value
-		toSearch = e.Interface()
-	}
-
-	b, err := (*f.Exp).Search(toSearch)
+	b, err := (*f.Exp).Search(val)
 	if err != nil {
 		return false, err
 	}

--- a/conduit/plugins/processors/filterprocessor/fields/searcher.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher.go
@@ -18,12 +18,34 @@ type Searcher struct {
 	MethodToCall string
 }
 
+func MakeSearcher(filterTag string, expressionType expression.FilterType, expressionStr string) (*Searcher, error) {
+	t, err := LookupFieldByTag(filterTag, &transactions.SignedTxnInBlock{})
+	if err != nil {
+		return nil, err
+	}
+
+	// We need the Elem() here because LookupFieldByTag returns a pointer underneath the interface{}
+	targetKind := reflect.TypeOf(t).Elem().Kind()
+
+	exp, err := expression.MakeExpression(expressionType, expressionStr, targetKind)
+	if err != nil {
+		return nil, fmt.Errorf("filter processor Init(): could not make expression with string %s for filter tag %s - %w", expressionStr, filterTag, err)
+	}
+
+	searcher, err := MakeFieldSearcher(exp, expressionType, filterTag)
+	if err != nil {
+		return nil, fmt.Errorf("filter processor Init(): error making field searcher - %w", err)
+	}
+
+	return searcher, nil
+}
+
 // This function is ONLY to be used by the filter.field function.
 // The reason being is that without validation of the tag (which is provided by
 // MakeFieldSearcher) then this can panic
-func (f Searcher) search(input transactions.SignedTxnInBlock) (bool, error) {
+func (f Searcher) search(input *transactions.SignedTxnInBlock) (bool, error) {
 
-	val, err := SignedTxnFunc(f.Tag, &input)
+	val, err := LookupFieldByTag(f.Tag, input)
 	if err != nil {
 		return false, err
 	}
@@ -59,7 +81,7 @@ func checkTagExistsAndHasCorrectFunction(expressionType expression.FilterType, t
 		}
 	}()
 
-	val, err := SignedTxnFunc(tag, &transactions.SignedTxnInBlock{})
+	val, err := LookupFieldByTag(tag, &transactions.SignedTxnInBlock{})
 
 	if err != nil {
 		return fmt.Errorf("%s does not exist in transactions.SignedTxnInBlock struct", tag)

--- a/conduit/plugins/processors/filterprocessor/fields/searcher.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher.go
@@ -18,6 +18,7 @@ type Searcher struct {
 	MethodToCall string
 }
 
+// MakeSearcher constructs the searcher object from the SubConfig fields. They are split up here to avoid a circular dependency.
 func MakeSearcher(filterTag string, expressionType expression.FilterType, expressionStr string) (*Searcher, error) {
 	t, err := LookupFieldByTag(filterTag, &transactions.SignedTxnInBlock{})
 	if err != nil {

--- a/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -33,7 +34,7 @@ func TestInternalSearch(t *testing.T) {
 	assert.NoError(t, err)
 
 	result, err := searcher.search(
-		transactions.SignedTxnInBlock{
+		&transactions.SignedTxnInBlock{
 			SignedTxnWithAD: transactions.SignedTxnWithAD{
 				SignedTxn: transactions.SignedTxn{
 					AuthAddr: address1,
@@ -46,7 +47,7 @@ func TestInternalSearch(t *testing.T) {
 	assert.True(t, result)
 
 	result, err = searcher.search(
-		transactions.SignedTxnInBlock{
+		&transactions.SignedTxnInBlock{
 			SignedTxnWithAD: transactions.SignedTxnWithAD{
 				SignedTxn: transactions.SignedTxn{
 					AuthAddr: address2,
@@ -97,4 +98,25 @@ func TestCheckTagExistsAndHasCorrectFunction(t *testing.T) {
 
 	err = checkTagExistsAndHasCorrectFunction("exact", "sgnr")
 	assert.NoError(t, err)
+}
+
+func BenchmarkSearch(b *testing.B) {
+	var addr basics.Address
+	addr[0] = 0x01
+	s, err := MakeSearcher("sgnr", expression.ExactFilter, addr.String())
+	require.NoError(b, err)
+
+	stib := transactions.SignedTxnInBlock{
+		SignedTxnWithAD: transactions.SignedTxnWithAD{
+			SignedTxn: transactions.SignedTxn{
+				AuthAddr: addr,
+			},
+		},
+	}
+
+	// Ignore the setup cost above.
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		(*s).search(&stib)
+	}
 }

--- a/conduit/plugins/processors/filterprocessor/filter_processor.go
+++ b/conduit/plugins/processors/filterprocessor/filter_processor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed" // used to embed config
 	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 

--- a/conduit/plugins/processors/filterprocessor/filter_processor_test.go
+++ b/conduit/plugins/processors/filterprocessor/filter_processor_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
@@ -558,7 +559,7 @@ filters:
       expression: 4
 `, func(t *testing.T, output *data.BlockData) {
 
-			assert.Equal(t, len(output.Payset), 1)
+			require.Len(t, output.Payset, 1)
 			assert.Equal(t, output.Payset[0].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw, uint64(2))
 		},
 		},
@@ -570,7 +571,7 @@ filters:
       expression: 5
 `, func(t *testing.T, output *data.BlockData) {
 
-			assert.Equal(t, len(output.Payset), 2)
+			require.Len(t, output.Payset, 2)
 			assert.Equal(t, output.Payset[0].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw, uint64(4))
 			assert.Equal(t, output.Payset[1].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw, uint64(2))
 		},
@@ -584,7 +585,7 @@ filters:
       expression: 4
 `, func(t *testing.T, output *data.BlockData) {
 
-			assert.Equal(t, len(output.Payset), 2)
+			require.Len(t, output.Payset, 2)
 			assert.Equal(t, output.Payset[0].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw, uint64(4))
 			assert.Equal(t, output.Payset[1].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw, uint64(2))
 		},
@@ -597,7 +598,7 @@ filters:
       expression: 11
 `, func(t *testing.T, output *data.BlockData) {
 
-			assert.Equal(t, len(output.Payset), 1)
+			require.Len(t, output.Payset, 1)
 			assert.Equal(t, output.Payset[0].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw, uint64(11))
 		},
 		},
@@ -610,7 +611,7 @@ filters:
       expression: 11
 `, func(t *testing.T, output *data.BlockData) {
 
-			assert.Equal(t, len(output.Payset), 2)
+			require.Len(t, output.Payset, 2)
 			assert.Equal(t, output.Payset[0].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw, uint64(4))
 			assert.Equal(t, output.Payset[1].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw, uint64(2))
 		},
@@ -624,7 +625,7 @@ filters:
       expression: 4
 `, func(t *testing.T, output *data.BlockData) {
 
-			assert.Equal(t, len(output.Payset), 1)
+			require.Len(t, output.Payset, 1)
 			assert.Equal(t, output.Payset[0].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw, uint64(11))
 		},
 		},
@@ -636,7 +637,7 @@ filters:
       expression: 3
 `, func(t *testing.T, output *data.BlockData) {
 
-			assert.Equal(t, len(output.Payset), 2)
+			require.Len(t, output.Payset, 2)
 			assert.Equal(t, output.Payset[0].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw, uint64(4))
 			assert.Equal(t, output.Payset[1].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw, uint64(11))
 		},
@@ -650,7 +651,7 @@ filters:
       expression: 4
 `, func(t *testing.T, output *data.BlockData) {
 
-			assert.Equal(t, len(output.Payset), 2)
+			require.Len(t, output.Payset, 2)
 			assert.Equal(t, output.Payset[0].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw, uint64(4))
 			assert.Equal(t, output.Payset[1].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw, uint64(11))
 		},
@@ -706,7 +707,7 @@ filters:
 			)
 
 			output, err := fp.Process(bd)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			test.fxn(t, &output)
 		})
 	}

--- a/conduit/plugins/processors/filterprocessor/filter_processor_test.go
+++ b/conduit/plugins/processors/filterprocessor/filter_processor_test.go
@@ -590,7 +590,7 @@ filters:
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fp := &FilterProcessor{}
-			err = fp.Init(context.Background(), &conduit.PipelineInitProvider{}, plugins.MakePluginConfig(test.sampleCfgStr), logrus.New())
+			err := fp.Init(context.Background(), &conduit.PipelineInitProvider{}, plugins.MakePluginConfig(test.sampleCfgStr), logrus.New())
 			assert.ErrorContains(t, err, test.errorContainsStr)
 		})
 	}

--- a/conduit/plugins/processors/filterprocessor/filter_processor_test.go
+++ b/conduit/plugins/processors/filterprocessor/filter_processor_test.go
@@ -48,11 +48,8 @@ filters:
       expression: "` + sampleAddr2.String() + `"
 `
 
-	fpBuilder, err := processors.ProcessorBuilderByName(implementationName)
-	assert.NoError(t, err)
-
-	fp := fpBuilder.New()
-	err = fp.Init(context.Background(), &conduit.PipelineInitProvider{}, plugins.MakePluginConfig(sampleCfgStr), logrus.New())
+	fp := &FilterProcessor{}
+	err := fp.Init(context.Background(), &conduit.PipelineInitProvider{}, plugins.MakePluginConfig(sampleCfgStr), logrus.New())
 	assert.NoError(t, err)
 
 	bd := data.BlockData{}

--- a/conduit/plugins/processors/filterprocessor/gen/generate.go
+++ b/conduit/plugins/processors/filterprocessor/gen/generate.go
@@ -85,9 +85,9 @@ import (
 "github.com/algorand/go-algorand/data/transactions"
 )
 
-// SignedTxnFunc takes a tag and associated SignedTxnInBlock and returns the value 
+// LookupFieldByTag takes a tag and associated SignedTxnInBlock and returns the value 
 // referenced by the tag.  An error is returned if the tag does not exist
-func SignedTxnFunc(tag string, input *transactions.SignedTxnInBlock) (interface{}, error) {
+func LookupFieldByTag(tag string, input *transactions.SignedTxnInBlock) (interface{}, error) {
 
 `
 	_, err = fmt.Fprintf(&bb, initialStr, packageName)

--- a/conduit/plugins/processors/filterprocessor/gen/generate.go
+++ b/conduit/plugins/processors/filterprocessor/gen/generate.go
@@ -9,8 +9,13 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 )
+
+func toInterface(field reflect.StructField) interface{} {
+	return reflect.New(field.Type).Elem().Interface()
+}
 
 // recursiveTagFields recursively gets all field names in a struct
 // Output will contain a key of the full tag along with the fully qualified struct
@@ -35,7 +40,14 @@ func recursiveTagFields(theStruct interface{}, output map[string]string, tagLeve
 			}
 
 			fullTag := strings.Join(append(tagLevel, tagValue), ".")
-			output[fullTag] = strings.Join(append(fieldLevel, name), ".")
+
+			parts := append(fieldLevel, name)
+
+			// If the type is microalgo, compare against the raw value instead of the struct
+			if _, ok := toInterface(field).(basics.MicroAlgos); ok {
+				parts = append(parts, "Raw")
+			}
+			output[fullTag] = strings.Join(parts, ".")
 		}
 
 		if field.Type.Kind() == reflect.Struct {


### PR DESCRIPTION
## Summary

While looking into the filter processor I found a lot of opportunities to simplify the code and make it faster.

This PR is an initial pass has a few small changes:
* improve performance by passing a pointer instead of copying the transaction object.
* improve performance by using Sprintf("%s") instead of reflection.
* simplify code by handling the "MicroAlgo" type in the generator instead of at runtime.
* minor refactoring to unit tests. There are many integration style tests which could be converted to unit tests.

Runtime of the search function went from 1500ns to 575ns according to the benchmark.

## Test Plan

No functional changes, existing unit tests check for regressions in the refactoring.