### PR TITLE
filter-processor: move reflection into generated code

### DIFF
--- a/conduit/plugins/processors/filterprocessor/expression/expression.go
+++ b/conduit/plugins/processors/filterprocessor/expression/expression.go
@@ -32,19 +32,16 @@ const (
 	NotEqualToFilter FilterType = "not-equal"
 )
 
-// TypeToFunctionMap maps the expression-type with the needed function for the expression.
-// For instance the exact or regex expression-type might need the String() function
-// A blank string means a function is not required
-// Can't make this const because there are no constant maps in go...
-var TypeToFunctionMap = map[FilterType]string{
-	ExactFilter:            "String",
-	RegexFilter:            "String",
-	LessThanFilter:         "",
-	LessThanEqualFilter:    "",
-	GreaterThanFilter:      "",
-	GreaterThanEqualFilter: "",
-	EqualToFilter:          "",
-	NotEqualToFilter:       "",
+// TypeMap contains all the expression types for validation.
+var TypeMap = map[FilterType]interface{}{
+	ExactFilter:            struct{}{},
+	RegexFilter:            struct{}{},
+	LessThanFilter:         struct{}{},
+	LessThanEqualFilter:    struct{}{},
+	GreaterThanFilter:      struct{}{},
+	GreaterThanEqualFilter: struct{}{},
+	EqualToFilter:          struct{}{},
+	NotEqualToFilter:       struct{}{},
 }
 
 // Expression the expression interface

--- a/conduit/plugins/processors/filterprocessor/fields/generated_signed_txn_map.go
+++ b/conduit/plugins/processors/filterprocessor/fields/generated_signed_txn_map.go
@@ -3,236 +3,211 @@
 package fields
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/algorand/go-algorand/data/transactions"
 )
 
-// SignedTxnFunc takes a tag and associated SignedTxnInBlock and returns the value
+// LookupFieldByTag takes a tag and associated SignedTxnInBlock and returns the value
 // referenced by the tag.  An error is returned if the tag does not exist
-func SignedTxnFunc(tag string, input *transactions.SignedTxnInBlock) (interface{}, error) {
-
+func LookupFieldByTag(tag string, input *transactions.SignedTxnInBlock) (interface{}, error) {
 	switch tag {
 	case "aca":
-		return &input.SignedTxnWithAD.ApplyData.AssetClosingAmount, nil
+		value := input.SignedTxnWithAD.ApplyData.AssetClosingAmount
+		return &value, nil
 	case "apid":
-		return &input.SignedTxnWithAD.ApplyData.ApplicationID, nil
+		value := uint64(input.SignedTxnWithAD.ApplyData.ApplicationID)
+		return &value, nil
 	case "ca":
-		return &input.SignedTxnWithAD.ApplyData.ClosingAmount, nil
+		value := uint64(input.SignedTxnWithAD.ApplyData.ClosingAmount.Raw)
+		return &value, nil
 	case "caid":
-		return &input.SignedTxnWithAD.ApplyData.ConfigAsset, nil
-	case "dt":
-		return &input.SignedTxnWithAD.ApplyData.EvalDelta, nil
-	case "dt.gd":
-		return &input.SignedTxnWithAD.ApplyData.EvalDelta.GlobalDelta, nil
-	case "dt.itx":
-		return &input.SignedTxnWithAD.ApplyData.EvalDelta.InnerTxns, nil
-	case "dt.ld":
-		return &input.SignedTxnWithAD.ApplyData.EvalDelta.LocalDeltas, nil
-	case "dt.lg":
-		return &input.SignedTxnWithAD.ApplyData.EvalDelta.Logs, nil
+		value := uint64(input.SignedTxnWithAD.ApplyData.ConfigAsset)
+		return &value, nil
 	case "hgh":
-		return &input.HasGenesisHash, nil
+		value := fmt.Sprintf("%t", input.HasGenesisHash)
+		return &value, nil
 	case "hgi":
-		return &input.HasGenesisID, nil
-	case "lsig":
-		return &input.SignedTxnWithAD.SignedTxn.Lsig, nil
-	case "lsig.arg":
-		return &input.SignedTxnWithAD.SignedTxn.Lsig.Args, nil
-	case "lsig.l":
-		return &input.SignedTxnWithAD.SignedTxn.Lsig.Logic, nil
-	case "lsig.msig":
-		return &input.SignedTxnWithAD.SignedTxn.Lsig.Msig, nil
-	case "lsig.msig.subsig":
-		return &input.SignedTxnWithAD.SignedTxn.Lsig.Msig.Subsigs, nil
+		value := fmt.Sprintf("%t", input.HasGenesisID)
+		return &value, nil
 	case "lsig.msig.thr":
-		return &input.SignedTxnWithAD.SignedTxn.Lsig.Msig.Threshold, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Lsig.Msig.Threshold)
+		return &value, nil
 	case "lsig.msig.v":
-		return &input.SignedTxnWithAD.SignedTxn.Lsig.Msig.Version, nil
-	case "lsig.sig":
-		return &input.SignedTxnWithAD.SignedTxn.Lsig.Sig, nil
-	case "msig":
-		return &input.SignedTxnWithAD.SignedTxn.Msig, nil
-	case "msig.subsig":
-		return &input.SignedTxnWithAD.SignedTxn.Msig.Subsigs, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Lsig.Msig.Version)
+		return &value, nil
 	case "msig.thr":
-		return &input.SignedTxnWithAD.SignedTxn.Msig.Threshold, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Msig.Threshold)
+		return &value, nil
 	case "msig.v":
-		return &input.SignedTxnWithAD.SignedTxn.Msig.Version, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Msig.Version)
+		return &value, nil
 	case "rc":
-		return &input.SignedTxnWithAD.ApplyData.CloseRewards, nil
+		value := uint64(input.SignedTxnWithAD.ApplyData.CloseRewards.Raw)
+		return &value, nil
 	case "rr":
-		return &input.SignedTxnWithAD.ApplyData.ReceiverRewards, nil
+		value := uint64(input.SignedTxnWithAD.ApplyData.ReceiverRewards.Raw)
+		return &value, nil
 	case "rs":
-		return &input.SignedTxnWithAD.ApplyData.SenderRewards, nil
+		value := uint64(input.SignedTxnWithAD.ApplyData.SenderRewards.Raw)
+		return &value, nil
 	case "sgnr":
-		return &input.SignedTxnWithAD.SignedTxn.AuthAddr, nil
-	case "sig":
-		return &input.SignedTxnWithAD.SignedTxn.Sig, nil
-	case "txn":
-		return &input.SignedTxnWithAD.SignedTxn.Txn, nil
+		value := input.SignedTxnWithAD.SignedTxn.AuthAddr.String()
+		return &value, nil
 	case "txn.aamt":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.AssetAmount, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.AssetAmount
+		return &value, nil
 	case "txn.aclose":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.AssetCloseTo, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.AssetCloseTo.String()
+		return &value, nil
 	case "txn.afrz":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetFreezeTxnFields.AssetFrozen, nil
+		value := fmt.Sprintf("%t", input.SignedTxnWithAD.SignedTxn.Txn.AssetFreezeTxnFields.AssetFrozen)
+		return &value, nil
 	case "txn.amt":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount, nil
-	case "txn.apaa":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.ApplicationArgs, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount.Raw)
+		return &value, nil
 	case "txn.apan":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.OnCompletion, nil
-	case "txn.apap":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.ApprovalProgram, nil
-	case "txn.apar":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.OnCompletion)
+		return &value, nil
 	case "txn.apar.am":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.MetadataHash, nil
+		value := base64.StdEncoding.EncodeToString(input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.MetadataHash[:])
+		return &value, nil
 	case "txn.apar.an":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.AssetName, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.AssetName
+		return &value, nil
 	case "txn.apar.au":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.URL, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.URL
+		return &value, nil
 	case "txn.apar.c":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Clawback, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Clawback.String()
+		return &value, nil
 	case "txn.apar.dc":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Decimals, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Decimals)
+		return &value, nil
 	case "txn.apar.df":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.DefaultFrozen, nil
+		value := fmt.Sprintf("%t", input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.DefaultFrozen)
+		return &value, nil
 	case "txn.apar.f":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Freeze, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Freeze.String()
+		return &value, nil
 	case "txn.apar.m":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Manager, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Manager.String()
+		return &value, nil
 	case "txn.apar.r":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Reserve, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Reserve.String()
+		return &value, nil
 	case "txn.apar.t":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Total, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Total
+		return &value, nil
 	case "txn.apar.un":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.UnitName, nil
-	case "txn.apas":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.ForeignAssets, nil
-	case "txn.apat":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.Accounts, nil
-	case "txn.apbx":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.Boxes, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.UnitName
+		return &value, nil
 	case "txn.apep":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.ExtraProgramPages, nil
-	case "txn.apfa":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.ForeignApps, nil
-	case "txn.apgs":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.GlobalStateSchema, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.ExtraProgramPages)
+		return &value, nil
 	case "txn.apgs.nbs":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.GlobalStateSchema.NumByteSlice, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.GlobalStateSchema.NumByteSlice
+		return &value, nil
 	case "txn.apgs.nui":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.GlobalStateSchema.NumUint, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.GlobalStateSchema.NumUint
+		return &value, nil
 	case "txn.apid":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.ApplicationID, nil
-	case "txn.apls":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.LocalStateSchema, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.ApplicationID)
+		return &value, nil
 	case "txn.apls.nbs":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.LocalStateSchema.NumByteSlice, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.LocalStateSchema.NumByteSlice
+		return &value, nil
 	case "txn.apls.nui":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.LocalStateSchema.NumUint, nil
-	case "txn.apsu":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.ClearStateProgram, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.ApplicationCallTxnFields.LocalStateSchema.NumUint
+		return &value, nil
 	case "txn.arcv":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.AssetReceiver, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.AssetReceiver.String()
+		return &value, nil
 	case "txn.asnd":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.AssetSender, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.AssetSender.String()
+		return &value, nil
 	case "txn.caid":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.ConfigAsset, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.ConfigAsset)
+		return &value, nil
 	case "txn.close":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.CloseRemainderTo, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.CloseRemainderTo.String()
+		return &value, nil
 	case "txn.fadd":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetFreezeTxnFields.FreezeAccount, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetFreezeTxnFields.FreezeAccount.String()
+		return &value, nil
 	case "txn.faid":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetFreezeTxnFields.FreezeAsset, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.AssetFreezeTxnFields.FreezeAsset)
+		return &value, nil
 	case "txn.fee":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.Header.Fee, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.Header.Fee.Raw)
+		return &value, nil
 	case "txn.fv":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.Header.FirstValid, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.Header.FirstValid)
+		return &value, nil
 	case "txn.gen":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.Header.GenesisID, nil
-	case "txn.gh":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.Header.GenesisHash, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.Header.GenesisID
+		return &value, nil
 	case "txn.grp":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.Header.Group, nil
+		value := base64.StdEncoding.EncodeToString(input.SignedTxnWithAD.SignedTxn.Txn.Header.Group[:])
+		return &value, nil
 	case "txn.lv":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.Header.LastValid, nil
-	case "txn.lx":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.Header.Lease, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.Header.LastValid)
+		return &value, nil
 	case "txn.nonpart":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.Nonparticipation, nil
+		value := fmt.Sprintf("%t", input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.Nonparticipation)
+		return &value, nil
 	case "txn.note":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.Header.Note, nil
+		value := base64.StdEncoding.EncodeToString(input.SignedTxnWithAD.SignedTxn.Txn.Header.Note[:])
+		return &value, nil
 	case "txn.rcv":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Receiver, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Receiver.String()
+		return &value, nil
 	case "txn.rekey":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.Header.RekeyTo, nil
-	case "txn.selkey":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.SelectionPK, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.Header.RekeyTo.String()
+		return &value, nil
 	case "txn.snd":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.Header.Sender, nil
-	case "txn.sp":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof, nil
-	case "txn.sp.P":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.PartProofs, nil
-	case "txn.sp.P.hsh":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.PartProofs.HashFactory, nil
-	case "txn.sp.P.hsh.t":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.PartProofs.HashFactory.HashType, nil
-	case "txn.sp.P.pth":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.PartProofs.Path, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.Header.Sender.String()
+		return &value, nil
 	case "txn.sp.P.td":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.PartProofs.TreeDepth, nil
-	case "txn.sp.S":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.SigProofs, nil
-	case "txn.sp.S.hsh":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.SigProofs.HashFactory, nil
-	case "txn.sp.S.hsh.t":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.SigProofs.HashFactory.HashType, nil
-	case "txn.sp.S.pth":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.SigProofs.Path, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.PartProofs.TreeDepth)
+		return &value, nil
 	case "txn.sp.S.td":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.SigProofs.TreeDepth, nil
-	case "txn.sp.c":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.SigCommit, nil
-	case "txn.sp.pr":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.PositionsToReveal, nil
-	case "txn.sp.r":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.Reveals, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.SigProofs.TreeDepth)
+		return &value, nil
 	case "txn.sp.v":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.MerkleSignatureSaltVersion, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.MerkleSignatureSaltVersion)
+		return &value, nil
 	case "txn.sp.w":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.SignedWeight, nil
-	case "txn.spmsg":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.Message, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.SignedWeight
+		return &value, nil
 	case "txn.spmsg.P":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.Message.LnProvenWeight, nil
-	case "txn.spmsg.b":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.Message.BlockHeadersCommitment, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.Message.LnProvenWeight
+		return &value, nil
 	case "txn.spmsg.f":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.Message.FirstAttestedRound, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.Message.FirstAttestedRound
+		return &value, nil
 	case "txn.spmsg.l":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.Message.LastAttestedRound, nil
-	case "txn.spmsg.v":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.Message.VotersCommitment, nil
-	case "txn.sprfkey":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.StateProofPK, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.Message.LastAttestedRound
+		return &value, nil
 	case "txn.sptype":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProofType, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProofType)
+		return &value, nil
 	case "txn.type":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.Type, nil
+		value := string(input.SignedTxnWithAD.SignedTxn.Txn.Type)
+		return &value, nil
 	case "txn.votefst":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.VoteFirst, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.VoteFirst)
+		return &value, nil
 	case "txn.votekd":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.VoteKeyDilution, nil
-	case "txn.votekey":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.VotePK, nil
+		value := input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.VoteKeyDilution
+		return &value, nil
 	case "txn.votelst":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.VoteLast, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.VoteLast)
+		return &value, nil
 	case "txn.xaid":
-		return &input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.XferAsset, nil
+		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.XferAsset)
+		return &value, nil
 	default:
 		return nil, fmt.Errorf("unknown tag: %s", tag)
 	}

--- a/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
@@ -70,7 +70,6 @@ func TestMakeFieldSearcher(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, searcher)
 	assert.Equal(t, searcher.Tag, tag)
-	assert.Equal(t, searcher.MethodToCall, expression.TypeToFunctionMap[expressionType])
 
 	searcher, err = MakeFieldSearcher(exp, "made-up-expression-type", sampleExpressionStr)
 	assert.Error(t, err)
@@ -81,20 +80,16 @@ func TestMakeFieldSearcher(t *testing.T) {
 // TestCheckTagExistsAndHasCorrectFunction tests that the check tag exists and function relation works
 func TestCheckTagExistsAndHasCorrectFunction(t *testing.T) {
 	// check that something that doesn't exist throws an error
-	err := checkTagExistsAndHasCorrectFunction("exact", "SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.LoreumIpsum.SDF")
+	err := checkTagAndExpressionExist("exact", "SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.LoreumIpsum.SDF")
 	assert.ErrorContains(t, err, "does not exist in transactions")
 
-	err = checkTagExistsAndHasCorrectFunction("exact", "LoreumIpsum")
+	err = checkTagAndExpressionExist("exact", "LoreumIpsum")
 	assert.ErrorContains(t, err, "does not exist in transactions")
-
-	// Fee does not have a "String" Function so we cant use exact with it.
-	err = checkTagExistsAndHasCorrectFunction("exact", "txn.fee")
-	assert.ErrorContains(t, err, "does not contain the needed method")
 
 	// a made up expression type should throw an error
-	err = checkTagExistsAndHasCorrectFunction("made-up-expression-type", "sgnr")
+	err = checkTagAndExpressionExist("made-up-expression-type", "sgnr")
 	assert.ErrorContains(t, err, "is not supported")
 
-	err = checkTagExistsAndHasCorrectFunction("exact", "sgnr")
+	err = checkTagAndExpressionExist("exact", "sgnr")
 	assert.NoError(t, err)
 }

--- a/conduit/plugins/processors/filterprocessor/filter_processor.go
+++ b/conduit/plugins/processors/filterprocessor/filter_processor.go
@@ -85,12 +85,12 @@ func (a *FilterProcessor) Init(ctx context.Context, _ data.InitProvider, cfg plu
 
 			for _, subConfig := range subConfigs {
 
-				t, err := fields.SignedTxnFunc(subConfig.FilterTag, &transactions.SignedTxnInBlock{})
+				t, err := fields.LookupFieldByTag(subConfig.FilterTag, &transactions.SignedTxnInBlock{})
 				if err != nil {
 					return err
 				}
 
-				// We need the Elem() here because SignedTxnFunc returns a pointer underneath the interface{}
+				// We need the Elem() here because LookupFieldByTag returns a pointer underneath the interface{}
 				targetKind := reflect.TypeOf(t).Elem().Kind()
 
 				exp, err := expression.MakeExpression(subConfig.ExpressionType, subConfig.Expression, targetKind)

--- a/conduit/plugins/processors/filterprocessor/gen/generate.go
+++ b/conduit/plugins/processors/filterprocessor/gen/generate.go
@@ -195,7 +195,6 @@ func recursiveTagFields(theStruct interface{}, output map[string]StructField, ta
 
 			fullTag := strings.Join(append(tagLevel, tagValue), ".")
 			if ignoreTags[fullTag] {
-				fmt.Printf("Skipping tag: %s\n", fullTag)
 				continue
 			}
 			sf := StructField{
@@ -228,9 +227,9 @@ import (
 func LookupFieldByTag(tag string, input *transactions.SignedTxnInBlock) (interface{}, error) {
 	switch tag {
 {{ range .StructFields }}	case "{{ .TagPath }}":
-		return {{ ReturnValue . "input" }}
+		return {{ ReturnValue . "input" }}, nil
 {{ end }}default:
-		return nil, fmt.Errorf(\"unknown tag: %s\", tag)
+		return nil, fmt.Errorf("unknown tag: %s", tag)
 	}
 }
 `

--- a/conduit/plugins/processors/filterprocessor/gen/generate.go
+++ b/conduit/plugins/processors/filterprocessor/gen/generate.go
@@ -8,23 +8,84 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/algorand/go-algorand-sdk/v2/types"
+	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/transactions"
 )
 
-const InputName = "input"
-
 type StructField struct {
-	Tag      string
-	Path     string
-	CastPre  string
-	CastPost string
+	TagPath    string
+	FieldPath  string
+	CastPrefix string
+	CastPost   string
 }
 
-func (sf StructField) toReturnValue(varName string) string {
-	return fmt.Sprintf("%s(%s.%s)%s", sf.CastPre, varName, sf.Path, sf.CastPost)
+func ReturnValue(sf StructField, varName string) string {
+	return fmt.Sprintf("%s%s.%s%s", sf.CastPrefix, varName, sf.FieldPath, sf.CastPost)
 }
 
-func Cast(t reflect.StructField) (pre string, post string, err error) {
+func noCast(t reflect.StructField) bool {
+	switch reflect.New(t.Type).Elem().Interface().(type) {
+	case uint64:
+		return true
+	case int64:
+		return true
+	case string:
+		return true
+	}
+	return false
+}
+
+func simpleCast(t reflect.StructField) string {
+	switch reflect.New(t.Type).Elem().Interface().(type) {
+	// unsigned
+	case uint:
+		return "uint64"
+	case uint8:
+		return "uint64"
+	case uint16:
+		return "uint64"
+	case uint32:
+		return "uint64"
+	// signed
+	case int:
+		return "int64"
+	case int8:
+		return "int64"
+	case int16:
+		return "int64"
+	case int32:
+		return "int64"
+	// alias
+	case types.MicroAlgos:
+		// SDK microalgo does not need ".Raw"
+		return "uint64"
+
+	}
+	return ""
+
+}
+
+func CastParts(t reflect.StructField) (prefix, postfix string, err error) {
+	if noCast(t) {
+		return
+	}
+
+	if simple := simpleCast(t); simple != "" {
+		prefix = fmt.Sprintf("%s(", simple)
+		postfix = ")"
+		return
+	}
+
+	// all the rest... custom things
+	switch reflect.New(t.Type).Elem().Interface().(type) {
+	case basics.MicroAlgos:
+		prefix = "uint64("
+		postfix = ".Raw)"
+	default:
+		prefix = "NOT "
+		postfix = " HANDLED"
+	}
 	return
 }
 
@@ -58,11 +119,11 @@ func recursiveTagFields(theStruct interface{}, output map[string]StructField, ta
 
 			fullTag := strings.Join(append(tagLevel, tagValue), ".")
 			sf := StructField{
-				Tag:  fullTag,
-				Path: strings.Join(append(fieldLevel, name), "."),
+				TagPath:   fullTag,
+				FieldPath: strings.Join(append(fieldLevel, name), "."),
 			}
 			var err error
-			sf.CastPre, sf.CastPost, err = Cast(field)
+			sf.CastPrefix, sf.CastPost, err = CastParts(field)
 			if err != nil {
 				return fmt.Errorf("problem casting %s: %s", fullTag, err)
 			}
@@ -94,12 +155,11 @@ import (
 
 // LookupFieldByTag takes a tag and associated SignedTxnInBlock and returns the value 
 // referenced by the tag.  An error is returned if the tag does not exist
-func LookupFieldByTag(tag string, {{ .InputName }} *transactions.SignedTxnInBlock) (interface{}, error) {
+func LookupFieldByTag(tag string, input *transactions.SignedTxnInBlock) (interface{}, error) {
 	switch tag {
-{{ range .StructFields }}	case "{{ .Tag }}":
-		return &{{ .Path }}
-{{ end }}
-	default:
+{{ range .StructFields }}	case "{{ .TagPath }}":
+		return {{ ReturnValue . "input" }}
+{{ end }}default:
 		return nil, fmt.Errorf(\"unknown tag: %s\", tag)
 	}
 }
@@ -120,18 +180,26 @@ func main() {
 		packageName = "NULL"
 	}
 
+	// Initialize template, no point to continue if there is a problem with it.
+	ut, err := template.
+		New("LookupFieldByTag").
+		Funcs(map[string]interface{}{
+			"ReturnValue": ReturnValue,
+		}).
+		Parse(templateStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse template string: %s", err)
+		os.Exit(1)
+	}
+
+	// Process fields.
 	fields, err := getFields(transactions.SignedTxnInBlock{})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to get fields for struct: %s", err)
 		os.Exit(1)
 	}
 
-	ut, err := template.New("LookupFieldByTag").Parse(templateStr)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to parse template string: %s", err)
-		os.Exit(1)
-	}
-
+	// Setup writer to stdout or file.
 	var outputWriter io.Writer
 	if outputFilepath == "" {
 		outputWriter = os.Stdout
@@ -145,106 +213,19 @@ func main() {
 		outputWriter = fout
 	}
 
+	// Prepare template inputs.
 	data := struct {
 		StructFields map[string]StructField
-		InputName    string
 		PackageName  string
 	}{
 		StructFields: fields,
-		InputName:    InputName,
 		PackageName:  packageName,
 	}
+
+	// Process template and write results.
 	err = ut.Execute(outputWriter, data)
-}
-
-/*
-// usage:
-// go run generate.go packagename outputfile
-func main() {
-
-	var packageName string
-	var outputFilepath string
-
-	if len(os.Args) == 3 {
-		packageName = os.Args[1]
-		outputFilepath = os.Args[2]
-	}
-
-	if packageName == "" {
-		packageName = "NULL"
-	}
-
-	output := getFields(transactions.SignedTxnInBlock{})
-
-	var err error
-	var bb bytes.Buffer
-
-	initialStr := `// Code generated via go generate. DO NOT EDIT.
-
-package %s
-
-import (
-	"fmt"
-
-	"github.com/algorand/go-algorand/data/transactions"
-)
-
-// SignedTxnFunc takes a tag and associated SignedTxnInBlock and returns the value
-// referenced by the tag.  An error is returned if the tag does not exist
-func SignedTxnFunc(tag string, input *transactions.SignedTxnInBlock) (interface{}, error) {
-
-`
-	_, err = fmt.Fprintf(&bb, initialStr, packageName)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write to %s: %v\n", outputFilepath, err)
+		fmt.Fprintf(os.Stderr, "Template execute failure: %s", err)
 		os.Exit(1)
-	}
-
-	keys := []string{}
-
-	for k := range output {
-		keys = append(keys, k)
-	}
-
-	sort.Strings(keys)
-
-	_, err = fmt.Fprintf(&bb, "switch tag {\n")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write to %s: %v\n", outputFilepath, err)
-		os.Exit(1)
-	}
-
-	for _, k := range keys {
-		fmt.Fprintf(&bb, "case \"%s\":\nreturn &input.%s, nil\n", k, output[k].Path)
-	}
-
-	//nolint:govet
-	_, err = bb.WriteString("default:\n" +
-		"return nil, fmt.Errorf(\"unknown tag: %s\", tag)\n" +
-		"}\n}")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to write to %s: %v\n", outputFilepath, err)
-		os.Exit(1)
-	}
-
-	bbuf, err := format.Source(bb.Bytes())
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "formatting error: %v", err)
-		os.Exit(1)
-	}
-
-	outputStr := string(bbuf)
-
-	if outputFilepath == "" {
-		fmt.Printf("%s", outputStr)
-	} else {
-		fout, err := os.Create(outputFilepath)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "cannot open %s for writing: %v\n", outputFilepath, err)
-			os.Exit(1)
-		}
-		defer fout.Close()
-		fmt.Fprintf(fout, "%s", outputStr)
 	}
 }
-*/

--- a/conduit/plugins/processors/filterprocessor/gen/generate_test.go
+++ b/conduit/plugins/processors/filterprocessor/gen/generate_test.go
@@ -1,0 +1,1 @@
+package main

--- a/conduit/plugins/processors/filterprocessor/gen/internal/utils.go
+++ b/conduit/plugins/processors/filterprocessor/gen/internal/utils.go
@@ -1,0 +1,16 @@
+package internal
+
+import "fmt"
+
+// StructField is used to pass data from the inner reflection analysis to the code generation.
+type StructField struct {
+	TagPath    string
+	FieldPath  string
+	CastPrefix string
+	CastPost   string
+}
+
+// ReturnValue builds a return value given a variable to wrap parts around.
+func ReturnValue(sf StructField, varName string) string {
+	return fmt.Sprintf("%s%s.%s%s", sf.CastPrefix, varName, sf.FieldPath, sf.CastPost)
+}


### PR DESCRIPTION
## Summary

These changes focus on updating the generated `SignedTxnFunc` function.
* Renamed to `LookupFieldByTag`.
* Cast return values to `uint64`, `int64` and `string`. 
* Do not allow sub-tags. i.e. previously `txn` was a valid tag, now only leaves are allowed such as `txn.fee`.
* Base64 encode "data" types like the note field, previously they were silently unsupported.
* Disallow unsupported types like slices (i.e. foreign accounts, app arguments) and maps (i.e. eval delta values).
* Minor refactoring outside the generate function (i.e. the `String()` function can no longer be called, because it happens inside the generated code).
* Adds initial support for switching to the SDK transaction type.

Followup:
* Because there are now only 3 types returned much of the code can be simplified.
* Stop using pointers in generated code. It is currently required because the reflect packages widely at runtime.
* Convert integration style tests to unit tests (i.e. there are no Searcher unit tests, they all begin with creating a processor).

## Test Plan

There are extensive unit tests to cover regressions.