### PR TITLE
docs: Run conduit-docs directly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,8 @@ export GO_IMAGE = golang:$(shell go version | cut -d ' ' -f 3 | tail -c +3 )
 # This is the default target, build everything:
 all: conduit cmd/algorand-indexer/algorand-indexer go-algorand idb/postgres/internal/schema/setup_postgres_sql.go idb/mocks/IndexerDb.go
 
-conduit: go-algorand conduit-docs
+conduit: go-algorand
 	go generate ./... && cd cmd/conduit && go build -ldflags="${GOLDFLAGS}"
-
-conduit-docs:
-	go install ./cmd/conduit-docs/
 
 cmd/algorand-indexer/algorand-indexer: idb/postgres/internal/schema/setup_postgres_sql.go go-algorand
 	cd cmd/algorand-indexer && go build -ldflags="${GOLDFLAGS}"
@@ -57,7 +54,7 @@ package: go-algorand
 	misc/release.py --host-only --outdir $(PKG_DIR)
 
 # used in travis test builds; doesn't verify that tag and .version match
-fakepackage: go-algorand conduit-docs
+fakepackage: go-algorand
 	rm -rf $(PKG_DIR)
 	mkdir -p $(PKG_DIR)
 	misc/release.py --host-only --outdir $(PKG_DIR) --fake-release
@@ -82,10 +79,10 @@ integration: cmd/algorand-indexer/algorand-indexer
 # To keep the container running at exit set 'export EXTRA="--keep-alive"',
 # once the container is paused use 'docker exec <id> bash' to inspect temp
 # files in `/tmp/*/'
-e2e: cmd/algorand-indexer/algorand-indexer conduit-docs
+e2e: cmd/algorand-indexer/algorand-indexer
 	cd e2e_tests/docker/indexer/ && docker-compose build --build-arg GO_IMAGE=${GO_IMAGE} && docker-compose up --exit-code-from e2e
 
-e2e-nightly: cmd/algorand-indexer/algorand-indexer conduit-docs
+e2e-nightly: cmd/algorand-indexer/algorand-indexer
 	cd e2e_tests/docker/indexer/ && docker-compose build --build-arg GO_IMAGE=${GO_IMAGE} --build-arg CHANNEL=nightly && docker-compose up --exit-code-from e2e
 
 # note: when running e2e tests manually be sure to set the e2e filename: 'export CI_E2E_FILENAME=rel-nightly'
@@ -124,4 +121,4 @@ indexer-v-algod: nightly-setup indexer-v-algod-swagger nightly-teardown
 update-submodule:
 	git submodule update --remote
 
-.PHONY: all test e2e integration fmt lint deploy sign test-package package fakepackage cmd/algorand-indexer/algorand-indexer idb/mocks/IndexerDb.go go-algorand indexer-v-algod conduit conduit-docs
+.PHONY: all test e2e integration fmt lint deploy sign test-package package fakepackage cmd/algorand-indexer/algorand-indexer idb/mocks/IndexerDb.go go-algorand indexer-v-algod conduit

--- a/cmd/conduit-docs/README.md
+++ b/cmd/conduit-docs/README.md
@@ -1,6 +1,6 @@
 ## conduit-docs
 
-`conduit-docts` is a utility used to generate markdown files from Conduit plugin config structs.  
+`conduit-docs` is a utility used to generate markdown files from Conduit plugin config structs.  
 It's usage is designed around `//go:generate`, which should be run on each plugin's `*.go` config file.
 
 ### File Names
@@ -18,7 +18,7 @@ For example,
 ```go
 package example 
 
-//go:generate conduit-docs output-dir
+//go:generate go run ../../../../cmd/conduit-docs/main.go ../../../../conduit-docs/
 
 type Config struct {
 	// description field of the graph
@@ -49,7 +49,7 @@ So the following config,
 ```go
 package example 
 
-//go:generate conduit-docs output-dir
+//go:generate go run ../../../../cmd/conduit-docs/main.go ../../../../conduit-docs/
 
 /*Header
 ## Config Documentation

--- a/conduit/plugins/exporters/filewriter/file_exporter_config.go
+++ b/conduit/plugins/exporters/filewriter/file_exporter_config.go
@@ -1,6 +1,6 @@
 package filewriter
 
-//go:generate conduit-docs ../../../../conduit-docs/
+//go:generate go run ../../../../cmd/conduit-docs/main.go ../../../../conduit-docs/
 
 //Name: conduit_exporters_filewriter
 

--- a/conduit/plugins/exporters/postgresql/postgresql_exporter_config.go
+++ b/conduit/plugins/exporters/postgresql/postgresql_exporter_config.go
@@ -1,6 +1,6 @@
 package postgresql
 
-//go:generate conduit-docs ../../../../conduit-docs/
+//go:generate go run ../../../../cmd/conduit-docs/main.go ../../../../conduit-docs/
 
 import (
 	"github.com/algorand/indexer/conduit/plugins/exporters/postgresql/util"

--- a/conduit/plugins/importers/algod/algod_importer_config.go
+++ b/conduit/plugins/importers/algod/algod_importer_config.go
@@ -1,6 +1,6 @@
 package algodimporter
 
-//go:generate conduit-docs ../../../../conduit-docs/
+//go:generate go run ../../../../cmd/conduit-docs/main.go ../../../../conduit-docs/
 
 //Name: conduit_importers_algod
 

--- a/conduit/plugins/importers/filereader/filereader_config.go
+++ b/conduit/plugins/importers/filereader/filereader_config.go
@@ -1,6 +1,6 @@
 package fileimporter
 
-//go:generate conduit-docs ../../../../conduit-docs/
+//go:generate go run ../../../../cmd/conduit-docs/main.go ../../../../conduit-docs/
 
 import "time"
 

--- a/conduit/plugins/processors/blockprocessor/config.go
+++ b/conduit/plugins/processors/blockprocessor/config.go
@@ -1,6 +1,6 @@
 package blockprocessor
 
-//go:generate conduit-docs ../../../../conduit-docs/
+//go:generate go run ../../../../cmd/conduit-docs/main.go ../../../../conduit-docs/
 
 //Name: conduit_processors_blockevaluator
 

--- a/conduit/plugins/processors/filterprocessor/config.go
+++ b/conduit/plugins/processors/filterprocessor/config.go
@@ -1,7 +1,7 @@
 // Package filterprocessor docs
 package filterprocessor
 
-//go:generate conduit-docs ../../../../conduit-docs/
+//go:generate go run ../../../../cmd/conduit-docs/main.go ../../../../conduit-docs/
 
 import (
 	"github.com/algorand/indexer/conduit/plugins/processors/filterprocessor/expression"


### PR DESCRIPTION
## Summary

Avoid the requirement to install `conduit-docs` and have `$GOPATH/bin` on your $PATH by running conduit-docs directly.