### PR TITLE
daemon: Remove bp from indexer daemon

### DIFF
--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -21,7 +21,6 @@ import (
 	"github.com/algorand/indexer/conduit/pipeline"
 	_ "github.com/algorand/indexer/conduit/plugins/exporters/postgresql"
 	_ "github.com/algorand/indexer/conduit/plugins/importers/algod"
-	_ "github.com/algorand/indexer/conduit/plugins/processors/blockprocessor"
 	"github.com/algorand/indexer/config"
 	"github.com/algorand/indexer/fetcher"
 	"github.com/algorand/indexer/idb"
@@ -380,18 +379,7 @@ func makeConduitConfig(dCfg *daemonConfig, nextRound uint64) pipeline.Config {
 			Config: map[string]interface{}{
 				"netaddr": dCfg.algodAddr,
 				"token":   dCfg.algodToken,
-			},
-		},
-		Processors: []pipeline.NameConfigPair{
-			{
-				Name: "block_evaluator",
-				Config: map[string]interface{}{
-					"catchpoint":     dCfg.catchpoint,
-					"data-dir":       dCfg.indexerDataDir,
-					"algod-data-dir": dCfg.algodDataDir,
-					"algod-token":    dCfg.algodToken,
-					"algod-addr":     dCfg.algodAddr,
-				},
+				"mode":    "follower",
 			},
 		},
 		Exporter: pipeline.NameConfigPair{


### PR DESCRIPTION


## Summary
Removes the block_processor from the indexer daemon. Sets the algod_importer to run in follower mode.

This will make indexer backwards incompatible w/ versions of algod prior to the upcoming release, and will also remove the ability to run indexer against an algod archival node which is not also running w/ `EnableFollowMode` synced w/ indexer.

Relies on the changes in #1478 to be merged.

## Test Plan

Existing e2e tests. Also, regression testing prior to release.