### PR TITLE
api: Remove go-algorand dep from api pkg

### DIFF
--- a/api/app_boxes_fixtures_test.go
+++ b/api/app_boxes_fixtures_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/avm-abi/apps"
-	"github.com/algorand/go-algorand/data/basics"
+	"github.com/algorand/go-algorand-sdk/v2/crypto"
+	sdk "github.com/algorand/go-algorand-sdk/v2/types"
 	"github.com/algorand/indexer/util/test"
 )
 
@@ -27,8 +28,8 @@ var goalEncodingExamples map[string]string = map[string]string{
 	"string":      "string",
 	"int":         "42",
 	"integer":     "100",
-	"addr":        basics.AppIndex(3).Address().String(),
-	"address":     basics.AppIndex(5).Address().String(),
+	"addr":        crypto.GetApplicationAddress(3).String(),
+	"address":     crypto.GetApplicationAddress(5).String(),
 	"b32":         base32.StdEncoding.EncodeToString([]byte("b32")),
 	"base32":      base32.StdEncoding.EncodeToString([]byte("base32")),
 	"byte base32": base32.StdEncoding.EncodeToString([]byte("byte base32")),
@@ -41,8 +42,8 @@ var goalEncodingExamples map[string]string = map[string]string{
 func setupLiveBoxes(t *testing.T, db *postgres.IndexerDb) {
 	deleted := "DELETED"
 
-	firstAppid := basics.AppIndex(1)
-	thirdAppid := basics.AppIndex(5)
+	firstAppid := sdk.AppIndex(1)
+	thirdAppid := sdk.AppIndex(5)
 
 	// ---- ROUND 1: create and fund the box app and another app which won't have boxes ---- //
 	//currentRound := basics.Round(1)
@@ -80,7 +81,7 @@ func setupLiveBoxes(t *testing.T, db *postgres.IndexerDb) {
 		"box #8",
 	}
 
-	expectedAppBoxes := map[basics.AppIndex]map[string]string{}
+	expectedAppBoxes := map[sdk.AppIndex]map[string]string{}
 	expectedAppBoxes[firstAppid] = map[string]string{}
 	newBoxValue := "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
 	//boxTxns := make([]*transactions.SignedTxnWithAD, 0)
@@ -274,7 +275,7 @@ func setupLiveBoxes(t *testing.T, db *postgres.IndexerDb) {
 
 	// ---- SUMMARY ---- //
 
-	totals := map[basics.AppIndex]map[string]int{}
+	totals := map[sdk.AppIndex]map[string]int{}
 	for appIndex, appBoxes := range expectedAppBoxes {
 		totals[appIndex] = map[string]int{
 			"tBoxes":    0,
@@ -356,14 +357,14 @@ var boxSeedFixture = fixture{
 		{
 			Name: "App 3 (as account) totals no boxes - no params",
 			Request: requestInfo{
-				Path:   "/v2/accounts/" + basics.AppIndex(3).Address().String(),
+				Path:   "/v2/accounts/" + crypto.GetApplicationAddress(3).String(),
 				Params: []param{},
 			},
 		},
 		{
 			Name: "App 1 (as account) totals with boxes - no params",
 			Request: requestInfo{
-				Path:   "/v2/accounts/" + basics.AppIndex(1).Address().String(),
+				Path:   "/v2/accounts/" + crypto.GetApplicationAddress(1).String(),
 				Params: []param{},
 			},
 		},

--- a/api/converter_utils.go
+++ b/api/converter_utils.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/algorand/go-algorand-sdk/v2/crypto"
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
-	"github.com/algorand/go-algorand/data/basics"
 )
 
 //////////////////////////////////////////////////////////////////////
@@ -38,7 +37,7 @@ func decodeDigest(str *string, field string, errorArr []string) (string, []strin
 // decodeAddress returns the byte representation of the input string, or appends an error to errorArr
 func decodeAddress(str *string, field string, errorArr []string) ([]byte, []string) {
 	if str != nil {
-		addr, err := basics.UnmarshalChecksumAddress(*str)
+		addr, err := sdk.DecodeAddress(*str)
 		if err != nil {
 			return nil, append(errorArr, fmt.Sprintf("%s '%s': %v", errUnableToParseAddress, field, err))
 		}

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -25,7 +25,6 @@ import (
 	"github.com/algorand/indexer/version"
 
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
-	"github.com/algorand/go-algorand/data/basics"
 )
 
 // ServerImplementation implements the handler interface used by the generated route definitions.
@@ -94,7 +93,7 @@ func validateTransactionFilter(filter *idb.TransactionFilter) error {
 	}
 
 	{
-		var address basics.Address
+		var address sdk.Address
 		copy(address[:], filter.Address)
 		if address.IsZero() {
 			if filter.AddressRole&idb.AddressRoleCloseRemainderTo != 0 {
@@ -433,7 +432,7 @@ func (si *ServerImplementation) SearchForAccounts(ctx echo.Context, params gener
 	}
 
 	if params.Next != nil {
-		addr, err := basics.UnmarshalChecksumAddress(*params.Next)
+		addr, err := sdk.DecodeAddress(*params.Next)
 		if err != nil {
 			return badRequest(ctx, errUnableToParseNext)
 		}
@@ -828,7 +827,7 @@ func (si *ServerImplementation) LookupAssetBalances(ctx echo.Context, assetID ui
 	}
 
 	if params.Next != nil {
-		addr, err := basics.UnmarshalChecksumAddress(*params.Next)
+		addr, err := sdk.DecodeAddress(*params.Next)
 		if err != nil {
 			return badRequest(ctx, errUnableToParseNext)
 		}
@@ -1149,7 +1148,7 @@ func (si *ServerImplementation) fetchAssets(ctx context.Context, options idb.Ass
 				return row.Error
 			}
 
-			creator := basics.Address{}
+			creator := sdk.Address{}
 			if len(row.Creator) != len(creator) {
 				return fmt.Errorf(errInvalidCreatorAddress)
 			}
@@ -1206,7 +1205,7 @@ func (si *ServerImplementation) fetchAssetBalances(ctx context.Context, options 
 				return row.Error
 			}
 
-			addr := basics.Address{}
+			addr := sdk.Address{}
 			if len(row.Address) != len(addr) {
 				return fmt.Errorf(errInvalidCreatorAddress)
 			}
@@ -1247,7 +1246,7 @@ func (si *ServerImplementation) fetchAssetHoldings(ctx context.Context, options 
 				return row.Error
 			}
 
-			addr := basics.Address{}
+			addr := sdk.Address{}
 			if len(row.Address) != len(addr) {
 				return fmt.Errorf(errInvalidCreatorAddress)
 			}

--- a/api/handlers_e2e_test.go
+++ b/api/handlers_e2e_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/indexer/api/generated/v2"
-	"github.com/algorand/indexer/helpers"
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/idb/postgres"
 	pgtest "github.com/algorand/indexer/idb/postgres/testing"
@@ -412,55 +411,35 @@ func TestAccountMaxResultsLimit(t *testing.T) {
 	var txns []sdk.SignedTxnWithAD
 	// make apps and assets
 	for range deletedAppIDs {
-		txn, err := helpers.ConvertSignedTxnWithAD(test.MakeCreateAppTxn(test.AccountA))
-		require.NoError(t, err)
-		txns = append(txns, txn)
+		txns = append(txns, test.MakeCreateAppTxnV2(sdk.Address(test.AccountA)))
 	}
 	for _, id := range deletedAssetIDs {
-		txn, err := helpers.ConvertSignedTxnWithAD(test.MakeAssetConfigTxn(0, 100, 0, false, "UNIT",
-			fmt.Sprintf("Asset %d", id), "http://asset.com", test.AccountA))
-		require.NoError(t, err)
-		txns = append(txns, txn)
+		txns = append(txns, test.MakeAssetConfigTxnV2(0, 100, 0, false, "UNIT",
+			fmt.Sprintf("Asset %d", id), "http://asset.com", sdk.Address(test.AccountA)))
 	}
 	for range expectedAppIDs {
-		txn, err := helpers.ConvertSignedTxnWithAD(test.MakeCreateAppTxn(test.AccountA))
-		require.NoError(t, err)
-		txns = append(txns, txn)
+		txns = append(txns, test.MakeCreateAppTxnV2(sdk.Address(test.AccountA)))
 	}
 	for _, id := range expectedAssetIDs {
-		txn, err := helpers.ConvertSignedTxnWithAD(test.MakeAssetConfigTxn(0, 100, 0, false, "UNIT",
-			fmt.Sprintf("Asset %d", id), "http://asset.com", test.AccountA))
-		require.NoError(t, err)
-		txns = append(txns, txn)
+		txns = append(txns, test.MakeAssetConfigTxnV2(0, 100, 0, false, "UNIT",
+			fmt.Sprintf("Asset %d", id), "http://asset.com", sdk.Address(test.AccountA)))
 	}
 	// delete some apps and assets
 	for _, id := range deletedAppIDs {
-		txn, err := helpers.ConvertSignedTxnWithAD(test.MakeAppDestroyTxn(id, test.AccountA))
-		require.NoError(t, err)
-		txns = append(txns, txn)
+		txns = append(txns, test.MakeAppDestroyTxnV2(id, sdk.Address(test.AccountA)))
 	}
 	for _, id := range deletedAssetIDs {
-		txn, err := helpers.ConvertSignedTxnWithAD(test.MakeAssetDestroyTxn(id, test.AccountA))
-		require.NoError(t, err)
-		txns = append(txns, txn)
+		txns = append(txns, test.MakeAssetDestroyTxnV2(id, sdk.Address(test.AccountA)))
 	}
 
 	// opt in to the remaining ones
 	for _, id := range expectedAppIDs {
-		txn, err := helpers.ConvertSignedTxnWithAD(test.MakeAppOptInTxn(id, test.AccountA))
-		require.NoError(t, err)
-		txns = append(txns, txn)
-		txn, err = helpers.ConvertSignedTxnWithAD(test.MakeAppOptInTxn(id, test.AccountB))
-		require.NoError(t, err)
-		txns = append(txns, txn)
+		txns = append(txns, test.MakeAppOptInTxnV2(id, sdk.Address(test.AccountA)))
+		txns = append(txns, test.MakeAppOptInTxnV2(id, sdk.Address(test.AccountB)))
 	}
 	for _, id := range expectedAssetIDs {
-		txn, err := helpers.ConvertSignedTxnWithAD(test.MakeAssetOptInTxn(id, test.AccountA))
-		require.NoError(t, err)
-		txns = append(txns, txn)
-		txn, err = helpers.ConvertSignedTxnWithAD(test.MakeAssetOptInTxn(id, test.AccountB))
-		require.NoError(t, err)
-		txns = append(txns, txn)
+		txns = append(txns, test.MakeAssetOptInTxnV2(id, sdk.Address(test.AccountA)))
+		txns = append(txns, test.MakeAssetOptInTxnV2(id, sdk.Address(test.AccountB)))
 	}
 
 	ptxns := make([]*sdk.SignedTxnWithAD, len(txns))

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -21,7 +21,6 @@ import (
 	sdkcrypto "github.com/algorand/go-algorand-sdk/v2/crypto"
 	"github.com/algorand/go-algorand-sdk/v2/encoding/msgpack"
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
-	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/indexer/api/generated/v2"
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/idb/mocks"
@@ -262,7 +261,7 @@ func TestValidateTransactionFilter(t *testing.T) {
 		{
 			name: "Zero address close address role",
 			filter: idb.TransactionFilter{
-				Address:     addrSlice(basics.Address{}),
+				Address:     addrSlice(sdk.Address{}),
 				AddressRole: idb.AddressRoleSender | idb.AddressRoleCloseRemainderTo,
 			},
 			errorContains: []string{errZeroAddressCloseRemainderToRole},
@@ -270,7 +269,7 @@ func TestValidateTransactionFilter(t *testing.T) {
 		{
 			name: "Zero address asset sender and asset close address role",
 			filter: idb.TransactionFilter{
-				Address:     addrSlice(basics.Address{}),
+				Address:     addrSlice(sdk.Address{}),
 				AddressRole: idb.AddressRoleAssetSender | idb.AddressRoleAssetCloseTo,
 			},
 			errorContains: []string{

--- a/api/pointer_utils.go
+++ b/api/pointer_utils.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
-	"github.com/algorand/go-algorand/data/basics"
 )
 
 ////////////////////////////////
@@ -109,8 +108,8 @@ func strArrayPtr(x []string) *[]string {
 	return &x
 }
 
-func addrSlice(x basics.Address) []byte {
-	xx := new(basics.Address)
+func addrSlice(x sdk.Address) []byte {
+	xx := new(sdk.Address)
 	*xx = x
 	return xx[:]
 }

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -138,6 +138,16 @@ func ConvertPayset(payset transactions.Payset) ([]sdk.SignedTxnInBlock, error) {
 	return ret, nil
 }
 
+func ConvertSignedTxnWithAD(txn transactions.SignedTxnWithAD) (sdk.SignedTxnWithAD, error) {
+	var ret sdk.SignedTxnWithAD
+	b := msgpack.Encode(txn)
+	err := msgpack.Decode(b, &ret)
+	if err != nil {
+		return ret, fmt.Errorf("ConvertSignedTxnWithAD err: %v", err)
+	}
+	return ret, nil
+}
+
 // ConvertLedgerStateDelta returns sdk.LedgerStateDelta
 func ConvertLedgerStateDelta(payset ledgercore.StateDelta) (sdk.LedgerStateDelta, error) {
 	var ret sdk.LedgerStateDelta

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -138,6 +138,7 @@ func ConvertPayset(payset transactions.Payset) ([]sdk.SignedTxnInBlock, error) {
 	return ret, nil
 }
 
+// ConvertSignedTxnWithAD returns sdk.SignedTxnWithAD
 func ConvertSignedTxnWithAD(txn transactions.SignedTxnWithAD) (sdk.SignedTxnWithAD, error) {
 	var ret sdk.SignedTxnWithAD
 	b := msgpack.Encode(txn)

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -138,17 +138,6 @@ func ConvertPayset(payset transactions.Payset) ([]sdk.SignedTxnInBlock, error) {
 	return ret, nil
 }
 
-// ConvertSignedTxnWithAD returns sdk.SignedTxnWithAD
-func ConvertSignedTxnWithAD(txn transactions.SignedTxnWithAD) (sdk.SignedTxnWithAD, error) {
-	var ret sdk.SignedTxnWithAD
-	b := msgpack.Encode(txn)
-	err := msgpack.Decode(b, &ret)
-	if err != nil {
-		return ret, fmt.Errorf("ConvertSignedTxnWithAD err: %v", err)
-	}
-	return ret, nil
-}
-
 // ConvertLedgerStateDelta returns sdk.LedgerStateDelta
 func ConvertLedgerStateDelta(payset ledgercore.StateDelta) (sdk.LedgerStateDelta, error) {
 	var ret sdk.LedgerStateDelta

--- a/util/test/account_testutil.go
+++ b/util/test/account_testutil.go
@@ -797,6 +797,79 @@ func MakePaymentTxnV2(fee, amt, closeAmt, sendRewards, receiveRewards,
 	}
 }
 
+// MakeAppDestroyTxnV2 makes a transaction that destroys an app.
+func MakeAppDestroyTxnV2(appid uint64, sender sdk.Address) sdk.SignedTxnWithAD {
+	return sdk.SignedTxnWithAD{
+		SignedTxn: sdk.SignedTxn{
+			Txn: sdk.Transaction{
+				Type: "appl",
+				Header: sdk.Header{
+					Sender:      sender,
+					GenesisHash: sdk.Digest(GenesisHash),
+					Note:        ArbitraryString(),
+				},
+				ApplicationFields: sdk.ApplicationFields{
+					ApplicationCallTxnFields: sdk.ApplicationCallTxnFields{
+						ApplicationID:     sdk.AppIndex(appid),
+						OnCompletion:      sdk.DeleteApplicationOC,
+						ApprovalProgram:   []byte{0x02, 0x20, 0x01, 0x01, 0x22},
+						ClearStateProgram: []byte{0x02, 0x20, 0x01, 0x01, 0x22},
+					},
+				},
+			},
+			Sig: sdk.Signature(Signature),
+		},
+	}
+}
+
+// MakeAssetDestroyTxnV2 makes a transaction that destroys an asset.
+func MakeAssetDestroyTxnV2(assetID uint64, sender sdk.Address) sdk.SignedTxnWithAD {
+	return sdk.SignedTxnWithAD{
+		SignedTxn: sdk.SignedTxn{
+			Txn: sdk.Transaction{
+				Type: "acfg",
+				Header: sdk.Header{
+					Sender:      sender,
+					GenesisHash: sdk.Digest(GenesisHash),
+					Note:        ArbitraryString(),
+				},
+				AssetConfigTxnFields: sdk.AssetConfigTxnFields{
+					ConfigAsset: sdk.AssetIndex(assetID),
+				},
+			},
+			Sig: sdk.Signature(Signature),
+		},
+	}
+}
+
+// MakeAppOptInTxnV2 makes a transaction that opts in an app.
+func MakeAppOptInTxnV2(appid uint64, sender sdk.Address) sdk.SignedTxnWithAD {
+	return sdk.SignedTxnWithAD{
+		SignedTxn: sdk.SignedTxn{
+			Txn: sdk.Transaction{
+				Type: "appl",
+				Header: sdk.Header{
+					Sender:      sender,
+					GenesisHash: sdk.Digest(GenesisHash),
+					Note:        ArbitraryString(),
+				},
+				ApplicationFields: sdk.ApplicationFields{
+					ApplicationCallTxnFields: sdk.ApplicationCallTxnFields{
+						ApplicationID: sdk.AppIndex(appid),
+						OnCompletion:  sdk.OptInOC,
+					},
+				},
+			},
+			Sig: sdk.Signature(Signature),
+		},
+	}
+}
+
+// MakeAssetOptInTxnV2 makes a transaction that opts in an asset.
+func MakeAssetOptInTxnV2(assetid uint64, address sdk.Address) sdk.SignedTxnWithAD {
+	return MakeAssetTransferTxnV2(assetid, 0, address, address, sdk.Address{})
+}
+
 // MakeCreateAppTxnV2 makes a transaction that creates a simple application.
 func MakeCreateAppTxnV2(sender sdk.Address) sdk.SignedTxnWithAD {
 	// Create a transaction with ExtraProgramPages field set to 1


### PR DESCRIPTION


## Summary

Refactor the `api` package to remove the go-algorand dependency.

## Test Plan

Existing unit/e2e tests.
