### PR TITLE
filter-plugin: Inner Txn support.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,6 +6,7 @@ ignore:
   - "idb/mocks"
   - "idb/dummy"
   - "util/test"
+  - "conduit/plugins/processors/filterprocessor/fields/generated_signed_txn_map.go"
 
 coverage:
   precision: 2

--- a/conduit/plugins/processors/filterprocessor/config.go
+++ b/conduit/plugins/processors/filterprocessor/config.go
@@ -28,9 +28,11 @@ type SubConfig struct {
 		<li>not-equal</li>
 	</ul>
 	*/
-	ExpressionType expression.FilterType `yaml:"expression-type"`
+	ExpressionType expression.ExpressionType `yaml:"expression-type"`
 	// <code>expression</code> is the user-supplied part of the search or comparison.
 	Expression string `yaml:"expression"`
+	// <code>match-inner</code> tells the filter processor to recursively search inner transactions for the expression.
+	SearchInner bool `yaml:"search-inner"`
 }
 
 // Config configuration for the filter processor

--- a/conduit/plugins/processors/filterprocessor/config.go
+++ b/conduit/plugins/processors/filterprocessor/config.go
@@ -31,12 +31,12 @@ type SubConfig struct {
 	ExpressionType expression.Type `yaml:"expression-type"`
 	// <code>expression</code> is the user-supplied part of the search or comparison.
 	Expression string `yaml:"expression"`
-	// <code>match-inner</code> tells the filter processor to recursively search inner transactions for the expression.
-	SearchInner bool `yaml:"search-inner"`
 }
 
 // Config configuration for the filter processor
 type Config struct {
+	// <code>search-inner</code> configures the filter processor to recursively search inner transactions for expressions.
+	SearchInner bool `yaml:"search-inner"`
 	/* <code>filters</code> are a list of SubConfig objects with an operation acting as the string key in the map
 
 	filters:

--- a/conduit/plugins/processors/filterprocessor/config.go
+++ b/conduit/plugins/processors/filterprocessor/config.go
@@ -28,7 +28,7 @@ type SubConfig struct {
 		<li>not-equal</li>
 	</ul>
 	*/
-	ExpressionType expression.ExpressionType `yaml:"expression-type"`
+	ExpressionType expression.Type `yaml:"expression-type"`
 	// <code>expression</code> is the user-supplied part of the search or comparison.
 	Expression string `yaml:"expression"`
 	// <code>match-inner</code> tells the filter processor to recursively search inner transactions for the expression.

--- a/conduit/plugins/processors/filterprocessor/expression/expression.go
+++ b/conduit/plugins/processors/filterprocessor/expression/expression.go
@@ -101,18 +101,22 @@ func makeUnsignedExpression(searchStr string, expressionType Type) (Expression, 
 }
 
 // MakeExpression creates an expression based on an expression type
-func MakeExpression(filterType Type, expressionSearchStr string, target interface{}) (exp Expression, err error) {
+func MakeExpression(expressionType Type, expressionSearchStr string, target interface{}) (exp Expression, err error) {
+	if _, ok := TypeMap[expressionType]; !ok {
+		return nil, fmt.Errorf("expression type (%s) is not supported", expressionType)
+	}
+
 	switch t := target.(type) {
 	case uint64:
-		return makeUnsignedExpression(expressionSearchStr, filterType)
+		return makeUnsignedExpression(expressionSearchStr, expressionType)
 	case int64:
-		return makeSignedExpression(expressionSearchStr, filterType)
+		return makeSignedExpression(expressionSearchStr, expressionType)
 	case string:
-		if filterType == EqualTo {
+		if expressionType == EqualTo {
 			// Equal to for strings is a special case of the regex pattern.
 			expressionSearchStr = fmt.Sprintf("^%s$", regexp.QuoteMeta(expressionSearchStr))
 		}
-		return makeRegexExpression(expressionSearchStr, filterType)
+		return makeRegexExpression(expressionSearchStr, expressionType)
 
 	default:
 		return nil, fmt.Errorf("unknown expression type: %T", t)

--- a/conduit/plugins/processors/filterprocessor/expression/expression.go
+++ b/conduit/plugins/processors/filterprocessor/expression/expression.go
@@ -56,6 +56,19 @@ func (e *regexExpression) Match(input interface{}) (bool, error) {
 	}
 }
 
+type stringEqualExpression struct {
+	Str string
+}
+
+func (e *stringEqualExpression) Match(input interface{}) (bool, error) {
+	switch v := input.(type) {
+	case string:
+		return e.Str == v, nil
+	default:
+		return false, fmt.Errorf("unexpected regex search input type (%T)", v)
+	}
+}
+
 func makeRegexExpression(searchStr string, expressionType Type) (Expression, error) {
 	if expressionType != EqualTo && expressionType != Regex {
 		return nil, fmt.Errorf("target type (string) does not support %s filters", expressionType)
@@ -113,8 +126,7 @@ func MakeExpression(expressionType Type, expressionSearchStr string, target inte
 		return makeSignedExpression(expressionSearchStr, expressionType)
 	case string:
 		if expressionType == EqualTo {
-			// Equal to for strings is a special case of the regex pattern.
-			expressionSearchStr = fmt.Sprintf("^%s$", regexp.QuoteMeta(expressionSearchStr))
+			return &stringEqualExpression{Str: expressionSearchStr}, nil
 		}
 		return makeRegexExpression(expressionSearchStr, expressionType)
 

--- a/conduit/plugins/processors/filterprocessor/expression/expression.go
+++ b/conduit/plugins/processors/filterprocessor/expression/expression.go
@@ -69,10 +69,7 @@ func (e *stringEqualExpression) Match(input interface{}) (bool, error) {
 	}
 }
 
-func makeRegexExpression(searchStr string, expressionType Type) (Expression, error) {
-	if expressionType != EqualTo && expressionType != Regex {
-		return nil, fmt.Errorf("target type (string) does not support %s filters", expressionType)
-	}
+func makeRegexExpression(searchStr string) (Expression, error) {
 	r, err := regexp.Compile(searchStr)
 	if err != nil {
 		return nil, err
@@ -125,11 +122,14 @@ func MakeExpression(expressionType Type, expressionSearchStr string, target inte
 	case int64:
 		return makeSignedExpression(expressionSearchStr, expressionType)
 	case string:
-		if expressionType == EqualTo {
+		switch expressionType {
+		case EqualTo:
 			return &stringEqualExpression{Str: expressionSearchStr}, nil
+		case Regex:
+			return makeRegexExpression(expressionSearchStr)
+		default:
+			return nil, fmt.Errorf("target type (string) does not support %s filters", expressionType)
 		}
-		return makeRegexExpression(expressionSearchStr, expressionType)
-
 	default:
 		return nil, fmt.Errorf("unknown expression type: %T", t)
 	}

--- a/conduit/plugins/processors/filterprocessor/expression/expression.go
+++ b/conduit/plugins/processors/filterprocessor/expression/expression.go
@@ -40,14 +40,14 @@ var TypeMap = map[FilterType]interface{}{
 
 // Expression the expression interface
 type Expression interface {
-	Search(input interface{}) (bool, error)
+	Match(input interface{}) (bool, error)
 }
 
 type regexExpression struct {
 	Regex *regexp.Regexp
 }
 
-func (e *regexExpression) Search(input interface{}) (bool, error) {
+func (e *regexExpression) Match(input interface{}) (bool, error) {
 	switch v := input.(type) {
 	case string:
 		return e.Regex.MatchString(v), nil

--- a/conduit/plugins/processors/filterprocessor/expression/expression.go
+++ b/conduit/plugins/processors/filterprocessor/expression/expression.go
@@ -6,36 +6,36 @@ import (
 	"strconv"
 )
 
-// FilterType is the type of the filter (i.e. const, regex, etc)
-type FilterType string
+// ExpressionType is the type of the filter (i.e. const, regex, etc)
+type ExpressionType string
 
 const (
-	// EqualToFilter a filter that applies numerical and string equal to operations
-	EqualToFilter FilterType = "equal"
-	// RegexFilter a filter that applies regex rules to the matching
-	RegexFilter FilterType = "regex"
+	// EqualTo a filter that applies numerical and string equal to operations
+	EqualTo ExpressionType = "equal"
+	// Regex a filter that applies regex rules to the matching
+	Regex ExpressionType = "regex"
 
-	// LessThanFilter a filter that applies numerical less than operation
-	LessThanFilter FilterType = "less-than"
-	// LessThanEqualFilter a filter that applies numerical less than or equal operation
-	LessThanEqualFilter FilterType = "less-than-equal"
-	// GreaterThanFilter a filter that applies numerical greater than operation
-	GreaterThanFilter FilterType = "greater-than"
-	// GreaterThanEqualFilter a filter that applies numerical greater than or equal operation
-	GreaterThanEqualFilter FilterType = "greater-than-equal"
-	// NotEqualToFilter a filter that applies numerical NOT equal to operation
-	NotEqualToFilter FilterType = "not-equal"
+	// LessThan a filter that applies numerical less than operation
+	LessThan ExpressionType = "less-than"
+	// LessThanEqual a filter that applies numerical less than or equal operation
+	LessThanEqual ExpressionType = "less-than-equal"
+	// GreaterThan a filter that applies numerical greater than operation
+	GreaterThan ExpressionType = "greater-than"
+	// GreaterThanEqual a filter that applies numerical greater than or equal operation
+	GreaterThanEqual ExpressionType = "greater-than-equal"
+	// NotEqualTo a filter that applies numerical NOT equal to operation
+	NotEqualTo ExpressionType = "not-equal"
 )
 
 // TypeMap contains all the expression types for validation.
-var TypeMap = map[FilterType]interface{}{
-	RegexFilter:            struct{}{},
-	LessThanFilter:         struct{}{},
-	LessThanEqualFilter:    struct{}{},
-	GreaterThanFilter:      struct{}{},
-	GreaterThanEqualFilter: struct{}{},
-	EqualToFilter:          struct{}{},
-	NotEqualToFilter:       struct{}{},
+var TypeMap = map[ExpressionType]interface{}{
+	Regex:            struct{}{},
+	LessThan:         struct{}{},
+	LessThanEqual:    struct{}{},
+	GreaterThan:      struct{}{},
+	GreaterThanEqual: struct{}{},
+	EqualTo:          struct{}{},
+	NotEqualTo:       struct{}{},
 }
 
 // Expression the expression interface
@@ -56,8 +56,8 @@ func (e *regexExpression) Match(input interface{}) (bool, error) {
 	}
 }
 
-func makeRegexExpression(searchStr string, expressionType FilterType) (Expression, error) {
-	if expressionType != EqualToFilter && expressionType != RegexFilter {
+func makeRegexExpression(searchStr string, expressionType ExpressionType) (Expression, error) {
+	if expressionType != EqualTo && expressionType != Regex {
 		return nil, fmt.Errorf("target type (string) does not support %s filters", expressionType)
 	}
 	r, err := regexp.Compile(searchStr)
@@ -68,8 +68,8 @@ func makeRegexExpression(searchStr string, expressionType FilterType) (Expressio
 	return &regexExpression{Regex: r}, nil
 }
 
-func makeSignedExpression(searchStr string, expressionType FilterType) (Expression, error) {
-	if expressionType == RegexFilter {
+func makeSignedExpression(searchStr string, expressionType ExpressionType) (Expression, error) {
+	if expressionType == Regex {
 		return nil, fmt.Errorf("target type (numeric) does not support %s filters", expressionType)
 	}
 
@@ -84,8 +84,8 @@ func makeSignedExpression(searchStr string, expressionType FilterType) (Expressi
 	}, nil
 }
 
-func makeUnsignedExpression(searchStr string, expressionType FilterType) (Expression, error) {
-	if expressionType == RegexFilter {
+func makeUnsignedExpression(searchStr string, expressionType ExpressionType) (Expression, error) {
+	if expressionType == Regex {
 		return nil, fmt.Errorf("target type (numeric) does not support %s filters", expressionType)
 	}
 
@@ -101,14 +101,14 @@ func makeUnsignedExpression(searchStr string, expressionType FilterType) (Expres
 }
 
 // MakeExpression creates an expression based on an expression type
-func MakeExpression(filterType FilterType, expressionSearchStr string, target interface{}) (exp Expression, err error) {
+func MakeExpression(filterType ExpressionType, expressionSearchStr string, target interface{}) (exp Expression, err error) {
 	switch t := target.(type) {
 	case uint64:
 		return makeUnsignedExpression(expressionSearchStr, filterType)
 	case int64:
 		return makeSignedExpression(expressionSearchStr, filterType)
 	case string:
-		if filterType == EqualToFilter {
+		if filterType == EqualTo {
 			// Equal to for strings is a special case of the regex pattern.
 			expressionSearchStr = fmt.Sprintf("^%s$", regexp.QuoteMeta(expressionSearchStr))
 		}

--- a/conduit/plugins/processors/filterprocessor/expression/expression.go
+++ b/conduit/plugins/processors/filterprocessor/expression/expression.go
@@ -6,29 +6,29 @@ import (
 	"strconv"
 )
 
-// ExpressionType is the type of the filter (i.e. const, regex, etc)
-type ExpressionType string
+// Type is the type of the filter (i.e. const, regex, etc)
+type Type string
 
 const (
 	// EqualTo a filter that applies numerical and string equal to operations
-	EqualTo ExpressionType = "equal"
+	EqualTo Type = "equal"
 	// Regex a filter that applies regex rules to the matching
-	Regex ExpressionType = "regex"
+	Regex Type = "regex"
 
 	// LessThan a filter that applies numerical less than operation
-	LessThan ExpressionType = "less-than"
+	LessThan Type = "less-than"
 	// LessThanEqual a filter that applies numerical less than or equal operation
-	LessThanEqual ExpressionType = "less-than-equal"
+	LessThanEqual Type = "less-than-equal"
 	// GreaterThan a filter that applies numerical greater than operation
-	GreaterThan ExpressionType = "greater-than"
+	GreaterThan Type = "greater-than"
 	// GreaterThanEqual a filter that applies numerical greater than or equal operation
-	GreaterThanEqual ExpressionType = "greater-than-equal"
+	GreaterThanEqual Type = "greater-than-equal"
 	// NotEqualTo a filter that applies numerical NOT equal to operation
-	NotEqualTo ExpressionType = "not-equal"
+	NotEqualTo Type = "not-equal"
 )
 
 // TypeMap contains all the expression types for validation.
-var TypeMap = map[ExpressionType]interface{}{
+var TypeMap = map[Type]interface{}{
 	Regex:            struct{}{},
 	LessThan:         struct{}{},
 	LessThanEqual:    struct{}{},
@@ -56,7 +56,7 @@ func (e *regexExpression) Match(input interface{}) (bool, error) {
 	}
 }
 
-func makeRegexExpression(searchStr string, expressionType ExpressionType) (Expression, error) {
+func makeRegexExpression(searchStr string, expressionType Type) (Expression, error) {
 	if expressionType != EqualTo && expressionType != Regex {
 		return nil, fmt.Errorf("target type (string) does not support %s filters", expressionType)
 	}
@@ -68,7 +68,7 @@ func makeRegexExpression(searchStr string, expressionType ExpressionType) (Expre
 	return &regexExpression{Regex: r}, nil
 }
 
-func makeSignedExpression(searchStr string, expressionType ExpressionType) (Expression, error) {
+func makeSignedExpression(searchStr string, expressionType Type) (Expression, error) {
 	if expressionType == Regex {
 		return nil, fmt.Errorf("target type (numeric) does not support %s filters", expressionType)
 	}
@@ -84,7 +84,7 @@ func makeSignedExpression(searchStr string, expressionType ExpressionType) (Expr
 	}, nil
 }
 
-func makeUnsignedExpression(searchStr string, expressionType ExpressionType) (Expression, error) {
+func makeUnsignedExpression(searchStr string, expressionType Type) (Expression, error) {
 	if expressionType == Regex {
 		return nil, fmt.Errorf("target type (numeric) does not support %s filters", expressionType)
 	}
@@ -101,7 +101,7 @@ func makeUnsignedExpression(searchStr string, expressionType ExpressionType) (Ex
 }
 
 // MakeExpression creates an expression based on an expression type
-func MakeExpression(filterType ExpressionType, expressionSearchStr string, target interface{}) (exp Expression, err error) {
+func MakeExpression(filterType Type, expressionSearchStr string, target interface{}) (exp Expression, err error) {
 	switch t := target.(type) {
 	case uint64:
 		return makeUnsignedExpression(expressionSearchStr, filterType)

--- a/conduit/plugins/processors/filterprocessor/expression/expression_test.go
+++ b/conduit/plugins/processors/filterprocessor/expression/expression_test.go
@@ -11,11 +11,11 @@ import (
 
 func TestExpression(t *testing.T) {
 	// used at the end to make sure we covered all filter types
-	allCovered := make(map[ExpressionType]interface{})
+	allCovered := make(map[Type]interface{})
 
 	testcases := []struct {
 		name            string
-		expressionType  ExpressionType
+		expressionType  Type
 		searchString    string
 		targetInterface interface{}
 		input           interface{}

--- a/conduit/plugins/processors/filterprocessor/expression/expression_test.go
+++ b/conduit/plugins/processors/filterprocessor/expression/expression_test.go
@@ -382,7 +382,7 @@ func TestExpression(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			match, err := exp.Search(tc.input)
+			match, err := exp.Match(tc.input)
 			if tc.searchErr != "" {
 				assert.ErrorContains(t, err, tc.searchErr)
 				return
@@ -407,6 +407,6 @@ func BenchmarkSearch(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		exp.Search("11")
+		exp.Match("11")
 	}
 }

--- a/conduit/plugins/processors/filterprocessor/expression/expression_test.go
+++ b/conduit/plugins/processors/filterprocessor/expression/expression_test.go
@@ -11,11 +11,11 @@ import (
 
 func TestExpression(t *testing.T) {
 	// used at the end to make sure we covered all filter types
-	allCovered := make(map[FilterType]interface{})
+	allCovered := make(map[ExpressionType]interface{})
 
 	testcases := []struct {
 		name            string
-		filterType      FilterType
+		expressionType  ExpressionType
 		searchString    string
 		targetInterface interface{}
 		input           interface{}
@@ -26,28 +26,28 @@ func TestExpression(t *testing.T) {
 		// wrong type errors
 		{
 			name:            "error_Invalid-type",
-			filterType:      GreaterThanFilter,
+			expressionType:  GreaterThan,
 			targetInterface: int8(1),
 			makeErr:         "unknown expression type: int",
 		},
 		// wrong type errors
 		{
 			name:            "error_Regex-Wrong-type",
-			filterType:      GreaterThanFilter,
+			expressionType:  GreaterThan,
 			searchString:    "5",
 			targetInterface: "asdf",
 			makeErr:         "target type (string) does not support greater-than filters",
 		},
 		{
 			name:            "error_Uint-bad-filter-type",
-			filterType:      RegexFilter,
+			expressionType:  Regex,
 			searchString:    "not a number",
 			targetInterface: uint64(0),
 			makeErr:         "target type (numeric) does not support regex filters",
 		},
 		{
 			name:            "error_Int-bad-filter-type",
-			filterType:      RegexFilter,
+			expressionType:  Regex,
 			searchString:    "not a number",
 			targetInterface: int64(0),
 			makeErr:         "target type (numeric) does not support regex filters",
@@ -55,35 +55,35 @@ func TestExpression(t *testing.T) {
 		// search string errors
 		{
 			name:            "error_Uint-not-a-number",
-			filterType:      GreaterThanFilter,
+			expressionType:  GreaterThan,
 			searchString:    "not a number",
 			targetInterface: uint64(0),
 			makeErr:         "search string \"not a number\" is not a valid uint64:",
 		},
 		{
 			name:            "error_Int-not-a-number",
-			filterType:      GreaterThanEqualFilter,
+			expressionType:  GreaterThanEqual,
 			searchString:    "not a number",
 			targetInterface: int64(0),
 			makeErr:         "search string \"not a number\" is not a valid int64:",
 		},
 		{
 			name:            "error_Uint-signed-number",
-			filterType:      GreaterThanFilter,
+			expressionType:  GreaterThan,
 			searchString:    "-1",
 			targetInterface: uint64(0),
 			makeErr:         "search string \"-1\" is not a valid uint64:",
 		},
 		{
 			name:            "error_Int-overflow",
-			filterType:      GreaterThanEqualFilter,
+			expressionType:  GreaterThanEqual,
 			searchString:    fmt.Sprintf("%d", uint64(math.MaxInt)+1),
 			targetInterface: int64(0),
 			makeErr:         fmt.Sprintf("search string \"%d\" is not a valid int64:", uint64(math.MaxInt)+1),
 		},
 		{
 			name:            "error_Regex-bad-pattern",
-			filterType:      RegexFilter,
+			expressionType:  Regex,
 			searchString:    "*",
 			targetInterface: "asdf",
 			makeErr:         "error parsing regexp:",
@@ -91,7 +91,7 @@ func TestExpression(t *testing.T) {
 		// input errors
 		{
 			name:            "error_Regex-match",
-			filterType:      RegexFilter,
+			expressionType:  Regex,
 			searchString:    ".*thing",
 			targetInterface: "asdf",
 			input:           5,
@@ -100,7 +100,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "error_Uint-bad-number",
-			filterType:      GreaterThanFilter,
+			expressionType:  GreaterThan,
 			searchString:    "10",
 			targetInterface: uint64(0),
 			input:           "El Toro Loco",
@@ -108,7 +108,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "error_Int-bad-number",
-			filterType:      GreaterThanFilter,
+			expressionType:  GreaterThan,
 			searchString:    "10",
 			targetInterface: int64(0),
 			input:           "Bad Company",
@@ -116,7 +116,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "error_Uint-bad-number-2",
-			filterType:      GreaterThanFilter,
+			expressionType:  GreaterThan,
 			searchString:    "10",
 			targetInterface: uint64(0),
 			input:           int64(10), // wrong sign
@@ -124,16 +124,16 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "error_Int-bad-number-2",
-			filterType:      GreaterThanFilter,
+			expressionType:  GreaterThan,
 			searchString:    "10",
 			targetInterface: int64(0),
 			input:           uint64(10), // wrong sign
 			searchErr:       "unexpected numeric search input \"10\"",
 		},
-		// match / no-match - RegexFilter
+		// match / no-match - Regex
 		{
 			name:            "Regex-match",
-			filterType:      RegexFilter,
+			expressionType:  Regex,
 			searchString:    ".*Dragonoid",
 			targetInterface: "asdf",
 			input:           "Bakugan Dragonoid",
@@ -141,16 +141,16 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "Regex-no-match",
-			filterType:      RegexFilter,
+			expressionType:  Regex,
 			searchString:    "Mohawk Warrior",
 			targetInterface: "asdf",
 			input:           "Grave Digger",
 			match:           false,
 		},
-		// match / no-match - EqualToFilter (numeric and string)
+		// match / no-match - EqualTo (numeric and string)
 		{
 			name:            "EqualTo-string-match",
-			filterType:      EqualToFilter,
+			expressionType:  EqualTo,
 			searchString:    ".*odon",
 			targetInterface: "asdf",
 			input:           "Megalodon",
@@ -158,7 +158,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "EqualTo-string-match-special",
-			filterType:      EqualToFilter,
+			expressionType:  EqualTo,
 			searchString:    ".*odon",
 			targetInterface: "asdf",
 			input:           ".*odon",
@@ -166,7 +166,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "EqualTo-string-no-match",
-			filterType:      EqualToFilter,
+			expressionType:  EqualTo,
 			searchString:    "Monster Mutt",
 			targetInterface: "asdf",
 			input:           "Max-D",
@@ -174,7 +174,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "EqualTo-int-match",
-			filterType:      EqualToFilter,
+			expressionType:  EqualTo,
 			searchString:    "10",
 			targetInterface: int64(0),
 			input:           int64(10),
@@ -182,7 +182,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "EqualTo-int-no-match",
-			filterType:      EqualToFilter,
+			expressionType:  EqualTo,
 			searchString:    "10",
 			targetInterface: int64(0),
 			input:           int64(11),
@@ -190,7 +190,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "EqualTo-uint-match",
-			filterType:      EqualToFilter,
+			expressionType:  EqualTo,
 			searchString:    "10",
 			targetInterface: uint64(0),
 			input:           uint64(10),
@@ -198,16 +198,16 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "EqualTo-uint-no-match",
-			filterType:      EqualToFilter,
+			expressionType:  EqualTo,
 			searchString:    "10",
 			targetInterface: uint64(0),
 			input:           uint64(11),
 			match:           false,
 		},
-		// match / no-match - GreaterThanFilter
+		// match / no-match - GreaterThan
 		{
 			name:            "GreaterThan-int-match",
-			filterType:      GreaterThanFilter,
+			expressionType:  GreaterThan,
 			searchString:    "10",
 			targetInterface: int64(0),
 			input:           int64(11),
@@ -215,7 +215,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "GreaterThan-int-no-match",
-			filterType:      GreaterThanFilter,
+			expressionType:  GreaterThan,
 			searchString:    "10",
 			targetInterface: int64(0),
 			input:           int64(10),
@@ -223,7 +223,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "GreaterThan-uint-match",
-			filterType:      GreaterThanFilter,
+			expressionType:  GreaterThan,
 			searchString:    "10",
 			targetInterface: uint64(0),
 			input:           uint64(11),
@@ -231,16 +231,16 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "GreaterThan-uint-no-match",
-			filterType:      GreaterThanFilter,
+			expressionType:  GreaterThan,
 			searchString:    "10",
 			targetInterface: uint64(0),
 			input:           uint64(10),
 			match:           false,
 		},
-		// match / no-match - GreaterThanEqualFilter
+		// match / no-match - GreaterThanEqual
 		{
 			name:            "GreaterThanEqual-int-match",
-			filterType:      GreaterThanEqualFilter,
+			expressionType:  GreaterThanEqual,
 			searchString:    "10",
 			targetInterface: int64(0),
 			input:           int64(10),
@@ -248,7 +248,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "GreaterThanEqual-int-no-match",
-			filterType:      GreaterThanEqualFilter,
+			expressionType:  GreaterThanEqual,
 			searchString:    "10",
 			targetInterface: int64(0),
 			input:           int64(9),
@@ -256,7 +256,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "GreaterThanEqual-uint-match",
-			filterType:      GreaterThanEqualFilter,
+			expressionType:  GreaterThanEqual,
 			searchString:    "10",
 			targetInterface: uint64(0),
 			input:           uint64(10),
@@ -264,16 +264,16 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "GreaterThanEqual-uint-no-match",
-			filterType:      GreaterThanEqualFilter,
+			expressionType:  GreaterThanEqual,
 			searchString:    "10",
 			targetInterface: uint64(0),
 			input:           uint64(9),
 			match:           false,
 		},
-		// match / no-match - LessThanFilter
+		// match / no-match - LessThan
 		{
 			name:            "LessThan-int-match",
-			filterType:      LessThanFilter,
+			expressionType:  LessThan,
 			searchString:    "10",
 			targetInterface: int64(0),
 			input:           int64(9),
@@ -281,7 +281,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "LessThan-int-no-match",
-			filterType:      LessThanFilter,
+			expressionType:  LessThan,
 			searchString:    "10",
 			targetInterface: int64(0),
 			input:           int64(10),
@@ -289,7 +289,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "LessThan-uint-match",
-			filterType:      LessThanFilter,
+			expressionType:  LessThan,
 			searchString:    "10",
 			targetInterface: uint64(0),
 			input:           uint64(9),
@@ -297,16 +297,16 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "LessThan-uint-no-match",
-			filterType:      LessThanFilter,
+			expressionType:  LessThan,
 			searchString:    "10",
 			targetInterface: uint64(0),
 			input:           uint64(10),
 			match:           false,
 		},
-		// match / no-match - LessThanEqualFilter
+		// match / no-match - LessThanEqual
 		{
 			name:            "LessThanEqual-int-match",
-			filterType:      LessThanEqualFilter,
+			expressionType:  LessThanEqual,
 			searchString:    "10",
 			targetInterface: int64(0),
 			input:           int64(10),
@@ -314,7 +314,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "LessThanEqual-int-no-match",
-			filterType:      LessThanEqualFilter,
+			expressionType:  LessThanEqual,
 			searchString:    "10",
 			targetInterface: int64(0),
 			input:           int64(11),
@@ -322,7 +322,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "LessThanEqual-uint-match",
-			filterType:      LessThanEqualFilter,
+			expressionType:  LessThanEqual,
 			searchString:    "10",
 			targetInterface: uint64(0),
 			input:           uint64(10),
@@ -330,7 +330,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "LessThanEqual-uint-no-match",
-			filterType:      LessThanEqualFilter,
+			expressionType:  LessThanEqual,
 			searchString:    "10",
 			targetInterface: uint64(0),
 			input:           uint64(11),
@@ -339,7 +339,7 @@ func TestExpression(t *testing.T) {
 		// match / no-match - NotEqualFilter
 		{
 			name:            "NotEqualTo-int-match",
-			filterType:      NotEqualToFilter,
+			expressionType:  NotEqualTo,
 			searchString:    "10",
 			targetInterface: int64(0),
 			input:           int64(9),
@@ -347,7 +347,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "NotEqualTo-int-no-match",
-			filterType:      NotEqualToFilter,
+			expressionType:  NotEqualTo,
 			searchString:    "10",
 			targetInterface: int64(0),
 			input:           int64(10),
@@ -355,7 +355,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "NotEqualTo-uint-match",
-			filterType:      NotEqualToFilter,
+			expressionType:  NotEqualTo,
 			searchString:    "10",
 			targetInterface: uint64(0),
 			input:           uint64(9),
@@ -363,7 +363,7 @@ func TestExpression(t *testing.T) {
 		},
 		{
 			name:            "NotEqualTo-uint-no-match",
-			filterType:      NotEqualToFilter,
+			expressionType:  NotEqualTo,
 			searchString:    "10",
 			targetInterface: uint64(0),
 			input:           uint64(10),
@@ -375,7 +375,7 @@ func TestExpression(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			exp, err := MakeExpression(tc.filterType, tc.searchString, tc.targetInterface)
+			exp, err := MakeExpression(tc.expressionType, tc.searchString, tc.targetInterface)
 			if tc.makeErr != "" {
 				assert.ErrorContains(t, err, tc.makeErr)
 				return
@@ -395,14 +395,14 @@ func TestExpression(t *testing.T) {
 	// Quick check that the inputs cover all types of expressions.
 	t.Run("All Expressions Tested", func(t *testing.T) {
 		for _, tc := range testcases {
-			allCovered[tc.filterType] = struct{}{}
+			allCovered[tc.expressionType] = struct{}{}
 		}
 		require.EqualValues(t, TypeMap, allCovered)
 	})
 }
 
 func BenchmarkSearch(b *testing.B) {
-	exp, err := MakeExpression(EqualToFilter, "10", "")
+	exp, err := MakeExpression(EqualTo, "10", "")
 	require.NoError(b, err)
 
 	b.ResetTimer()

--- a/conduit/plugins/processors/filterprocessor/expression/numerical_expressions.go
+++ b/conduit/plugins/processors/filterprocessor/expression/numerical_expressions.go
@@ -12,7 +12,7 @@ type microAlgoExpression struct {
 	Op          FilterType
 }
 
-func (m microAlgoExpression) Search(input interface{}) (bool, error) {
+func (m microAlgoExpression) Match(input interface{}) (bool, error) {
 
 	inputValue, ok := input.(basics.MicroAlgos)
 	if !ok {
@@ -42,7 +42,7 @@ type int64NumericalExpression struct {
 	Op          FilterType
 }
 
-func (s int64NumericalExpression) Search(input interface{}) (bool, error) {
+func (s int64NumericalExpression) Match(input interface{}) (bool, error) {
 	inputValue, ok := input.(int64)
 	if !ok {
 		return false, fmt.Errorf("unexpected numeric search input \"%v\"", input)
@@ -72,7 +72,7 @@ type uint64NumericalExpression struct {
 	Op          FilterType
 }
 
-func (u uint64NumericalExpression) Search(input interface{}) (bool, error) {
+func (u uint64NumericalExpression) Match(input interface{}) (bool, error) {
 	inputValue, ok := input.(uint64)
 	if !ok {
 		return false, fmt.Errorf("unexpected numeric search input \"%v\"", input)

--- a/conduit/plugins/processors/filterprocessor/expression/numerical_expressions.go
+++ b/conduit/plugins/processors/filterprocessor/expression/numerical_expressions.go
@@ -9,7 +9,7 @@ import (
 
 type microAlgoExpression struct {
 	FilterValue basics.MicroAlgos
-	Op          FilterType
+	Op          ExpressionType
 }
 
 func (m microAlgoExpression) Match(input interface{}) (bool, error) {
@@ -20,17 +20,17 @@ func (m microAlgoExpression) Match(input interface{}) (bool, error) {
 	}
 
 	switch m.Op {
-	case LessThanFilter:
+	case LessThan:
 		return inputValue.Raw < m.FilterValue.Raw, nil
-	case LessThanEqualFilter:
+	case LessThanEqual:
 		return inputValue.Raw <= m.FilterValue.Raw, nil
-	case EqualToFilter:
+	case EqualTo:
 		return inputValue.Raw == m.FilterValue.Raw, nil
-	case NotEqualToFilter:
+	case NotEqualTo:
 		return inputValue.Raw != m.FilterValue.Raw, nil
-	case GreaterThanFilter:
+	case GreaterThan:
 		return inputValue.Raw > m.FilterValue.Raw, nil
-	case GreaterThanEqualFilter:
+	case GreaterThanEqual:
 		return inputValue.Raw >= m.FilterValue.Raw, nil
 	default:
 		return false, fmt.Errorf("unknown op: %s", m.Op)
@@ -39,7 +39,7 @@ func (m microAlgoExpression) Match(input interface{}) (bool, error) {
 
 type int64NumericalExpression struct {
 	FilterValue int64
-	Op          FilterType
+	Op          ExpressionType
 }
 
 func (s int64NumericalExpression) Match(input interface{}) (bool, error) {
@@ -49,17 +49,17 @@ func (s int64NumericalExpression) Match(input interface{}) (bool, error) {
 	}
 
 	switch s.Op {
-	case LessThanFilter:
+	case LessThan:
 		return inputValue < s.FilterValue, nil
-	case LessThanEqualFilter:
+	case LessThanEqual:
 		return inputValue <= s.FilterValue, nil
-	case EqualToFilter:
+	case EqualTo:
 		return inputValue == s.FilterValue, nil
-	case NotEqualToFilter:
+	case NotEqualTo:
 		return inputValue != s.FilterValue, nil
-	case GreaterThanFilter:
+	case GreaterThan:
 		return inputValue > s.FilterValue, nil
-	case GreaterThanEqualFilter:
+	case GreaterThanEqual:
 		return inputValue >= s.FilterValue, nil
 	default:
 		return false, fmt.Errorf("unknown op: %s", s.Op)
@@ -69,7 +69,7 @@ func (s int64NumericalExpression) Match(input interface{}) (bool, error) {
 
 type uint64NumericalExpression struct {
 	FilterValue uint64
-	Op          FilterType
+	Op          ExpressionType
 }
 
 func (u uint64NumericalExpression) Match(input interface{}) (bool, error) {
@@ -79,17 +79,17 @@ func (u uint64NumericalExpression) Match(input interface{}) (bool, error) {
 	}
 
 	switch u.Op {
-	case LessThanFilter:
+	case LessThan:
 		return inputValue < u.FilterValue, nil
-	case LessThanEqualFilter:
+	case LessThanEqual:
 		return inputValue <= u.FilterValue, nil
-	case EqualToFilter:
+	case EqualTo:
 		return inputValue == u.FilterValue, nil
-	case NotEqualToFilter:
+	case NotEqualTo:
 		return inputValue != u.FilterValue, nil
-	case GreaterThanFilter:
+	case GreaterThan:
 		return inputValue > u.FilterValue, nil
-	case GreaterThanEqualFilter:
+	case GreaterThanEqual:
 		return inputValue >= u.FilterValue, nil
 
 	default:

--- a/conduit/plugins/processors/filterprocessor/expression/numerical_expressions.go
+++ b/conduit/plugins/processors/filterprocessor/expression/numerical_expressions.go
@@ -9,7 +9,7 @@ import (
 
 type microAlgoExpression struct {
 	FilterValue basics.MicroAlgos
-	Op          ExpressionType
+	Op          Type
 }
 
 func (m microAlgoExpression) Match(input interface{}) (bool, error) {
@@ -39,7 +39,7 @@ func (m microAlgoExpression) Match(input interface{}) (bool, error) {
 
 type int64NumericalExpression struct {
 	FilterValue int64
-	Op          ExpressionType
+	Op          Type
 }
 
 func (s int64NumericalExpression) Match(input interface{}) (bool, error) {
@@ -69,7 +69,7 @@ func (s int64NumericalExpression) Match(input interface{}) (bool, error) {
 
 type uint64NumericalExpression struct {
 	FilterValue uint64
-	Op          ExpressionType
+	Op          Type
 }
 
 func (u uint64NumericalExpression) Match(input interface{}) (bool, error) {

--- a/conduit/plugins/processors/filterprocessor/fields/generated_signed_txn_map.go
+++ b/conduit/plugins/processors/filterprocessor/fields/generated_signed_txn_map.go
@@ -5,208 +5,202 @@ package fields
 import (
 	"encoding/base64"
 	"fmt"
-
+	
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
 )
 
-// LookupFieldByTag takes a tag and associated SignedTxnInBlock and returns the value
+// LookupFieldByTag takes a tag and associated SignedTxnWithAD and returns the value
 // referenced by the tag.  An error is returned if the tag does not exist
-func LookupFieldByTag(tag string, input *sdk.SignedTxnInBlock) (interface{}, error) {
+func LookupFieldByTag(tag string, input *sdk.SignedTxnWithAD) (interface{}, error) {
 	switch tag {
 	case "aca":
-		value := input.SignedTxnWithAD.ApplyData.AssetClosingAmount
+		value := input.ApplyData.AssetClosingAmount
 		return value, nil
 	case "apid":
-		value := input.SignedTxnWithAD.ApplyData.ApplicationID
+		value := input.ApplyData.ApplicationID
 		return value, nil
 	case "ca":
-		value := uint64(input.SignedTxnWithAD.ApplyData.ClosingAmount)
+		value := uint64(input.ApplyData.ClosingAmount)
 		return value, nil
 	case "caid":
-		value := input.SignedTxnWithAD.ApplyData.ConfigAsset
-		return value, nil
-	case "hgh":
-		value := fmt.Sprintf("%t", input.HasGenesisHash)
-		return value, nil
-	case "hgi":
-		value := fmt.Sprintf("%t", input.HasGenesisID)
+		value := input.ApplyData.ConfigAsset
 		return value, nil
 	case "lsig.msig.thr":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Lsig.Msig.Threshold)
+		value := uint64(input.SignedTxn.Lsig.Msig.Threshold)
 		return value, nil
 	case "lsig.msig.v":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Lsig.Msig.Version)
+		value := uint64(input.SignedTxn.Lsig.Msig.Version)
 		return value, nil
 	case "msig.thr":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Msig.Threshold)
+		value := uint64(input.SignedTxn.Msig.Threshold)
 		return value, nil
 	case "msig.v":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Msig.Version)
+		value := uint64(input.SignedTxn.Msig.Version)
 		return value, nil
 	case "rc":
-		value := uint64(input.SignedTxnWithAD.ApplyData.CloseRewards)
+		value := uint64(input.ApplyData.CloseRewards)
 		return value, nil
 	case "rr":
-		value := uint64(input.SignedTxnWithAD.ApplyData.ReceiverRewards)
+		value := uint64(input.ApplyData.ReceiverRewards)
 		return value, nil
 	case "rs":
-		value := uint64(input.SignedTxnWithAD.ApplyData.SenderRewards)
+		value := uint64(input.ApplyData.SenderRewards)
 		return value, nil
 	case "sgnr":
-		value := input.SignedTxnWithAD.SignedTxn.AuthAddr.String()
+		value := input.SignedTxn.AuthAddr.String()
 		return value, nil
 	case "txn.aamt":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.AssetAmount
+		value := input.SignedTxn.Txn.AssetTransferTxnFields.AssetAmount
 		return value, nil
 	case "txn.aclose":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.AssetCloseTo.String()
+		value := input.SignedTxn.Txn.AssetTransferTxnFields.AssetCloseTo.String()
 		return value, nil
 	case "txn.afrz":
-		value := fmt.Sprintf("%t", input.SignedTxnWithAD.SignedTxn.Txn.AssetFreezeTxnFields.AssetFrozen)
+		value := fmt.Sprintf("%t", input.SignedTxn.Txn.AssetFreezeTxnFields.AssetFrozen)
 		return value, nil
 	case "txn.amt":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Amount)
+		value := uint64(input.SignedTxn.Txn.PaymentTxnFields.Amount)
 		return value, nil
 	case "txn.apan":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.ApplicationFields.ApplicationCallTxnFields.OnCompletion)
+		value := uint64(input.SignedTxn.Txn.ApplicationFields.ApplicationCallTxnFields.OnCompletion)
 		return value, nil
 	case "txn.apar.am":
-		value := base64.StdEncoding.EncodeToString(input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.MetadataHash[:])
+		value := base64.StdEncoding.EncodeToString(input.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.MetadataHash[:])
 		return value, nil
 	case "txn.apar.an":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.AssetName
+		value := input.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.AssetName
 		return value, nil
 	case "txn.apar.au":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.URL
+		value := input.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.URL
 		return value, nil
 	case "txn.apar.c":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Clawback.String()
+		value := input.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Clawback.String()
 		return value, nil
 	case "txn.apar.dc":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Decimals)
+		value := uint64(input.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Decimals)
 		return value, nil
 	case "txn.apar.df":
-		value := fmt.Sprintf("%t", input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.DefaultFrozen)
+		value := fmt.Sprintf("%t", input.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.DefaultFrozen)
 		return value, nil
 	case "txn.apar.f":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Freeze.String()
+		value := input.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Freeze.String()
 		return value, nil
 	case "txn.apar.m":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Manager.String()
+		value := input.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Manager.String()
 		return value, nil
 	case "txn.apar.r":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Reserve.String()
+		value := input.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Reserve.String()
 		return value, nil
 	case "txn.apar.t":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Total
+		value := input.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.Total
 		return value, nil
 	case "txn.apar.un":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.UnitName
+		value := input.SignedTxn.Txn.AssetConfigTxnFields.AssetParams.UnitName
 		return value, nil
 	case "txn.apep":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.ApplicationFields.ApplicationCallTxnFields.ExtraProgramPages)
+		value := uint64(input.SignedTxn.Txn.ApplicationFields.ApplicationCallTxnFields.ExtraProgramPages)
 		return value, nil
 	case "txn.apgs.nbs":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.ApplicationFields.ApplicationCallTxnFields.GlobalStateSchema.NumByteSlice
+		value := input.SignedTxn.Txn.ApplicationFields.ApplicationCallTxnFields.GlobalStateSchema.NumByteSlice
 		return value, nil
 	case "txn.apgs.nui":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.ApplicationFields.ApplicationCallTxnFields.GlobalStateSchema.NumUint
+		value := input.SignedTxn.Txn.ApplicationFields.ApplicationCallTxnFields.GlobalStateSchema.NumUint
 		return value, nil
 	case "txn.apid":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.ApplicationFields.ApplicationCallTxnFields.ApplicationID)
+		value := uint64(input.SignedTxn.Txn.ApplicationFields.ApplicationCallTxnFields.ApplicationID)
 		return value, nil
 	case "txn.apls.nbs":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.ApplicationFields.ApplicationCallTxnFields.LocalStateSchema.NumByteSlice
+		value := input.SignedTxn.Txn.ApplicationFields.ApplicationCallTxnFields.LocalStateSchema.NumByteSlice
 		return value, nil
 	case "txn.apls.nui":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.ApplicationFields.ApplicationCallTxnFields.LocalStateSchema.NumUint
+		value := input.SignedTxn.Txn.ApplicationFields.ApplicationCallTxnFields.LocalStateSchema.NumUint
 		return value, nil
 	case "txn.arcv":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.AssetReceiver.String()
+		value := input.SignedTxn.Txn.AssetTransferTxnFields.AssetReceiver.String()
 		return value, nil
 	case "txn.asnd":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.AssetSender.String()
+		value := input.SignedTxn.Txn.AssetTransferTxnFields.AssetSender.String()
 		return value, nil
 	case "txn.caid":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.AssetConfigTxnFields.ConfigAsset)
+		value := uint64(input.SignedTxn.Txn.AssetConfigTxnFields.ConfigAsset)
 		return value, nil
 	case "txn.close":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.CloseRemainderTo.String()
+		value := input.SignedTxn.Txn.PaymentTxnFields.CloseRemainderTo.String()
 		return value, nil
 	case "txn.fadd":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.AssetFreezeTxnFields.FreezeAccount.String()
+		value := input.SignedTxn.Txn.AssetFreezeTxnFields.FreezeAccount.String()
 		return value, nil
 	case "txn.faid":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.AssetFreezeTxnFields.FreezeAsset)
+		value := uint64(input.SignedTxn.Txn.AssetFreezeTxnFields.FreezeAsset)
 		return value, nil
 	case "txn.fee":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.Header.Fee)
+		value := uint64(input.SignedTxn.Txn.Header.Fee)
 		return value, nil
 	case "txn.fv":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.Header.FirstValid)
+		value := uint64(input.SignedTxn.Txn.Header.FirstValid)
 		return value, nil
 	case "txn.gen":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.Header.GenesisID
+		value := input.SignedTxn.Txn.Header.GenesisID
 		return value, nil
 	case "txn.grp":
-		value := base64.StdEncoding.EncodeToString(input.SignedTxnWithAD.SignedTxn.Txn.Header.Group[:])
+		value := base64.StdEncoding.EncodeToString(input.SignedTxn.Txn.Header.Group[:])
 		return value, nil
 	case "txn.lv":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.Header.LastValid)
+		value := uint64(input.SignedTxn.Txn.Header.LastValid)
 		return value, nil
 	case "txn.nonpart":
-		value := fmt.Sprintf("%t", input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.Nonparticipation)
+		value := fmt.Sprintf("%t", input.SignedTxn.Txn.KeyregTxnFields.Nonparticipation)
 		return value, nil
 	case "txn.note":
-		value := base64.StdEncoding.EncodeToString(input.SignedTxnWithAD.SignedTxn.Txn.Header.Note[:])
+		value := base64.StdEncoding.EncodeToString(input.SignedTxn.Txn.Header.Note[:])
 		return value, nil
 	case "txn.rcv":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Receiver.String()
+		value := input.SignedTxn.Txn.PaymentTxnFields.Receiver.String()
 		return value, nil
 	case "txn.rekey":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.Header.RekeyTo.String()
+		value := input.SignedTxn.Txn.Header.RekeyTo.String()
 		return value, nil
 	case "txn.snd":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.Header.Sender.String()
+		value := input.SignedTxn.Txn.Header.Sender.String()
 		return value, nil
 	case "txn.sp.P.td":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.PartProofs.TreeDepth)
+		value := uint64(input.SignedTxn.Txn.StateProofTxnFields.StateProof.PartProofs.TreeDepth)
 		return value, nil
 	case "txn.sp.S.td":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.SigProofs.TreeDepth)
+		value := uint64(input.SignedTxn.Txn.StateProofTxnFields.StateProof.SigProofs.TreeDepth)
 		return value, nil
 	case "txn.sp.v":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.MerkleSignatureSaltVersion)
+		value := uint64(input.SignedTxn.Txn.StateProofTxnFields.StateProof.MerkleSignatureSaltVersion)
 		return value, nil
 	case "txn.sp.w":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProof.SignedWeight
+		value := input.SignedTxn.Txn.StateProofTxnFields.StateProof.SignedWeight
 		return value, nil
 	case "txn.spmsg.P":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.Message.LnProvenWeight
+		value := input.SignedTxn.Txn.StateProofTxnFields.Message.LnProvenWeight
 		return value, nil
 	case "txn.spmsg.f":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.Message.FirstAttestedRound
+		value := input.SignedTxn.Txn.StateProofTxnFields.Message.FirstAttestedRound
 		return value, nil
 	case "txn.spmsg.l":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.Message.LastAttestedRound
+		value := input.SignedTxn.Txn.StateProofTxnFields.Message.LastAttestedRound
 		return value, nil
 	case "txn.sptype":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.StateProofTxnFields.StateProofType)
+		value := uint64(input.SignedTxn.Txn.StateProofTxnFields.StateProofType)
 		return value, nil
 	case "txn.type":
-		value := string(input.SignedTxnWithAD.SignedTxn.Txn.Type)
+		value := string(input.SignedTxn.Txn.Type)
 		return value, nil
 	case "txn.votefst":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.VoteFirst)
+		value := uint64(input.SignedTxn.Txn.KeyregTxnFields.VoteFirst)
 		return value, nil
 	case "txn.votekd":
-		value := input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.VoteKeyDilution
+		value := input.SignedTxn.Txn.KeyregTxnFields.VoteKeyDilution
 		return value, nil
 	case "txn.votelst":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.KeyregTxnFields.VoteLast)
+		value := uint64(input.SignedTxn.Txn.KeyregTxnFields.VoteLast)
 		return value, nil
 	case "txn.xaid":
-		value := uint64(input.SignedTxnWithAD.SignedTxn.Txn.AssetTransferTxnFields.XferAsset)
+		value := uint64(input.SignedTxn.Txn.AssetTransferTxnFields.XferAsset)
 		return value, nil
 	default:
 		return nil, fmt.Errorf("unknown tag: %s", tag)

--- a/conduit/plugins/processors/filterprocessor/fields/generated_signed_txn_map.go
+++ b/conduit/plugins/processors/filterprocessor/fields/generated_signed_txn_map.go
@@ -5,7 +5,7 @@ package fields
 import (
 	"encoding/base64"
 	"fmt"
-	
+
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
 )
 

--- a/conduit/plugins/processors/filterprocessor/fields/searcher.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher.go
@@ -21,7 +21,7 @@ type Searcher struct {
 // MakeFieldSearcher) then this can panic
 func (f Searcher) search(input sdk.SignedTxnInBlock) (bool, error) {
 
-	val, err := LookupFieldByTag(f.Tag, &input)
+	val, err := LookupFieldByTag(f.Tag, &input.SignedTxnWithAD)
 	if err != nil {
 		return false, err
 	}
@@ -36,7 +36,7 @@ func (f Searcher) search(input sdk.SignedTxnInBlock) (bool, error) {
 
 // checks that the supplied tag exists in the struct and recovers from any panics
 func checkTagAndExpressionExist(expressionType expression.FilterType, tag string) (outError error) {
-	_, err := LookupFieldByTag(tag, &sdk.SignedTxnInBlock{})
+	_, err := LookupFieldByTag(tag, &sdk.SignedTxnWithAD{})
 
 	if err != nil {
 		return fmt.Errorf("%s does not exist in transactions.SignedTxnInBlock struct", tag)

--- a/conduit/plugins/processors/filterprocessor/fields/searcher.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher.go
@@ -26,7 +26,7 @@ func (f Searcher) search(input *sdk.SignedTxnWithAD) (bool, error) {
 		return false, err
 	}
 
-	b, err := f.Exp.Search(val)
+	b, err := f.Exp.Match(val)
 	if err != nil {
 		return false, err
 	}

--- a/conduit/plugins/processors/filterprocessor/fields/searcher.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher.go
@@ -52,7 +52,7 @@ func (f Searcher) search(input *sdk.SignedTxnWithAD) (bool, error) {
 }
 
 // checks that the supplied tag exists in the struct and recovers from any panics
-func checkTagAndExpressionExist(expressionType expression.ExpressionType, tag string) (outError error) {
+func checkTagAndExpressionExist(expressionType expression.Type, tag string) (outError error) {
 	_, err := LookupFieldByTag(tag, &sdk.SignedTxnWithAD{})
 
 	if err != nil {
@@ -67,7 +67,7 @@ func checkTagAndExpressionExist(expressionType expression.ExpressionType, tag st
 }
 
 // MakeFieldSearcher will check that the field exists and that it contains the necessary "conversion" function
-func MakeFieldSearcher(e expression.Expression, expressionType expression.ExpressionType, tag string, searchInner bool) (*Searcher, error) {
+func MakeFieldSearcher(e expression.Expression, expressionType expression.Type, tag string, searchInner bool) (*Searcher, error) {
 
 	if err := checkTagAndExpressionExist(expressionType, tag); err != nil {
 		return nil, err

--- a/conduit/plugins/processors/filterprocessor/fields/searcher.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher.go
@@ -19,9 +19,9 @@ type Searcher struct {
 // This function is ONLY to be used by the filter.field function.
 // The reason being is that without validation of the tag (which is provided by
 // MakeFieldSearcher) then this can panic
-func (f Searcher) search(input sdk.SignedTxnInBlock) (bool, error) {
+func (f Searcher) search(input *sdk.SignedTxnWithAD) (bool, error) {
 
-	val, err := LookupFieldByTag(f.Tag, &input.SignedTxnWithAD)
+	val, err := LookupFieldByTag(f.Tag, input)
 	if err != nil {
 		return false, err
 	}

--- a/conduit/plugins/processors/filterprocessor/fields/searcher.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher.go
@@ -35,7 +35,7 @@ func (f Searcher) search(input *sdk.SignedTxnWithAD) (bool, error) {
 }
 
 // checks that the supplied tag exists in the struct and recovers from any panics
-func checkTagAndExpressionExist(expressionType expression.FilterType, tag string) (outError error) {
+func checkTagAndExpressionExist(expressionType expression.ExpressionType, tag string) (outError error) {
 	_, err := LookupFieldByTag(tag, &sdk.SignedTxnWithAD{})
 
 	if err != nil {
@@ -50,7 +50,7 @@ func checkTagAndExpressionExist(expressionType expression.FilterType, tag string
 }
 
 // MakeFieldSearcher will check that the field exists and that it contains the necessary "conversion" function
-func MakeFieldSearcher(e expression.Expression, expressionType expression.FilterType, tag string) (*Searcher, error) {
+func MakeFieldSearcher(e expression.Expression, expressionType expression.ExpressionType, tag string, searchInner bool) (*Searcher, error) {
 
 	if err := checkTagAndExpressionExist(expressionType, tag); err != nil {
 		return nil, err

--- a/conduit/plugins/processors/filterprocessor/fields/searcher.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher.go
@@ -67,6 +67,7 @@ func checkTagAndExpressionExist(expressionType expression.Type, tag string) (out
 }
 
 // MakeFieldSearcher will check that the field exists and that it contains the necessary "conversion" function
+// TODO: Remove expressionType. It is validated when the expression is created.
 func MakeFieldSearcher(e expression.Expression, expressionType expression.Type, tag string, searchInner bool) (*Searcher, error) {
 
 	if err := checkTagAndExpressionExist(expressionType, tag); err != nil {

--- a/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
@@ -23,7 +23,7 @@ func TestInternalSearch(t *testing.T) {
 	address1 := sdk.Address{1}
 	address2 := sdk.Address{2}
 
-	var expressionType expression.ExpressionType = expression.EqualTo
+	var expressionType expression.Type = expression.EqualTo
 	tag := "sgnr"
 	exp, err := expression.MakeExpression(expressionType, address1.String(), "")
 	assert.NoError(t, err)
@@ -55,7 +55,7 @@ func TestInternalSearch(t *testing.T) {
 
 // TestMakeFieldSearcher tests making a field searcher is valid
 func TestMakeFieldSearcher(t *testing.T) {
-	var expressionType expression.ExpressionType = expression.EqualTo
+	var expressionType expression.Type = expression.EqualTo
 	tag := "sgnr"
 	sampleExpressionStr := "sample"
 	exp, err := expression.MakeExpression(expressionType, sampleExpressionStr, "")

--- a/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
@@ -31,11 +31,9 @@ func TestInternalSearch(t *testing.T) {
 	assert.NoError(t, err)
 
 	result, err := searcher.search(
-		sdk.SignedTxnInBlock{
-			SignedTxnWithAD: sdk.SignedTxnWithAD{
-				SignedTxn: sdk.SignedTxn{
-					AuthAddr: address1,
-				},
+		&sdk.SignedTxnWithAD{
+			SignedTxn: sdk.SignedTxn{
+				AuthAddr: address1,
 			},
 		},
 	)
@@ -44,11 +42,9 @@ func TestInternalSearch(t *testing.T) {
 	assert.True(t, result)
 
 	result, err = searcher.search(
-		sdk.SignedTxnInBlock{
-			SignedTxnWithAD: sdk.SignedTxnWithAD{
-				SignedTxn: sdk.SignedTxn{
-					AuthAddr: address2,
-				},
+		&sdk.SignedTxnWithAD{
+			SignedTxn: sdk.SignedTxn{
+				AuthAddr: address2,
 			},
 		},
 	)

--- a/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
@@ -139,7 +139,7 @@ func TestInnerTxnSearch(t *testing.T) {
 		// It should have no match with searchInner: false.
 		matches, err = searcher.search(&txnWithInnerMatch)
 
-		// No match on inner txn
+		// Match on inner txn
 		require.NoError(t, err)
 		assert.Equal(t, matches, true)
 	}

--- a/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
@@ -23,7 +23,7 @@ func TestInternalSearch(t *testing.T) {
 	address1 := sdk.Address{1}
 	address2 := sdk.Address{2}
 
-	var expressionType expression.FilterType = expression.EqualToFilter
+	var expressionType expression.ExpressionType = expression.EqualTo
 	tag := "sgnr"
 	exp, err := expression.MakeExpression(expressionType, address1.String(), "")
 	assert.NoError(t, err)
@@ -55,7 +55,7 @@ func TestInternalSearch(t *testing.T) {
 
 // TestMakeFieldSearcher tests making a field searcher is valid
 func TestMakeFieldSearcher(t *testing.T) {
-	var expressionType expression.FilterType = expression.EqualToFilter
+	var expressionType expression.ExpressionType = expression.EqualTo
 	tag := "sgnr"
 	sampleExpressionStr := "sample"
 	exp, err := expression.MakeExpression(expressionType, sampleExpressionStr, "")
@@ -74,16 +74,16 @@ func TestMakeFieldSearcher(t *testing.T) {
 // TestCheckTagExistsAndHasCorrectFunction tests that the check tag exists and function relation works
 func TestCheckTagExistsAndHasCorrectFunction(t *testing.T) {
 	// check that something that doesn't exist throws an error
-	err := checkTagAndExpressionExist(expression.EqualToFilter, "SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.LoreumIpsum.SDF")
+	err := checkTagAndExpressionExist(expression.EqualTo, "SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.LoreumIpsum.SDF")
 	assert.ErrorContains(t, err, "does not exist in transactions")
 
-	err = checkTagAndExpressionExist(expression.EqualToFilter, "LoreumIpsum")
+	err = checkTagAndExpressionExist(expression.EqualTo, "LoreumIpsum")
 	assert.ErrorContains(t, err, "does not exist in transactions")
 
 	// a made up expression type should throw an error
 	err = checkTagAndExpressionExist("made-up-expression-type", "sgnr")
 	assert.ErrorContains(t, err, "is not supported")
 
-	err = checkTagAndExpressionExist(expression.EqualToFilter, "sgnr")
+	err = checkTagAndExpressionExist(expression.EqualTo, "sgnr")
 	assert.NoError(t, err)
 }

--- a/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
@@ -5,30 +5,22 @@ import (
 
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/indexer/conduit/plugins/processors/filterprocessor/expression"
 )
 
 // TestInternalSearch tests the internal search functionality
 func TestInternalSearch(t *testing.T) {
-
-	defer func() {
-		// Since this function should only be called after validation is performed,
-		// this recovery function lets us recover is the schema changes in anyway in the future
-		if r := recover(); r != nil {
-			assert.True(t, false)
-		}
-	}()
-
 	address1 := sdk.Address{1}
 	address2 := sdk.Address{2}
 
 	var expressionType expression.Type = expression.EqualTo
 	tag := "sgnr"
 	exp, err := expression.MakeExpression(expressionType, address1.String(), "")
-	assert.NoError(t, err)
-	searcher, err := MakeFieldSearcher(exp, expressionType, tag)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	searcher, err := MakeFieldSearcher(exp, expressionType, tag, false)
+	require.NoError(t, err)
 
 	result, err := searcher.search(
 		&sdk.SignedTxnWithAD{
@@ -38,7 +30,7 @@ func TestInternalSearch(t *testing.T) {
 		},
 	)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, result)
 
 	result, err = searcher.search(
@@ -49,26 +41,24 @@ func TestInternalSearch(t *testing.T) {
 		},
 	)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, result)
 }
 
 // TestMakeFieldSearcher tests making a field searcher is valid
 func TestMakeFieldSearcher(t *testing.T) {
-	var expressionType expression.Type = expression.EqualTo
+	expressionType := expression.EqualTo
 	tag := "sgnr"
 	sampleExpressionStr := "sample"
 	exp, err := expression.MakeExpression(expressionType, sampleExpressionStr, "")
-	assert.NoError(t, err)
-	searcher, err := MakeFieldSearcher(exp, expressionType, tag)
-	assert.NoError(t, err)
-	assert.NotNil(t, searcher)
+	require.NoError(t, err)
+	searcher, err := MakeFieldSearcher(exp, expressionType, tag, false)
+	require.NoError(t, err)
+	require.NotNil(t, searcher)
 	assert.Equal(t, searcher.Tag, tag)
 
-	searcher, err = MakeFieldSearcher(exp, "made-up-expression-type", sampleExpressionStr)
-	assert.Error(t, err)
-	assert.Nil(t, searcher)
-
+	searcher, err = MakeFieldSearcher(exp, "made-up-expression-type", sampleExpressionStr, false)
+	require.Error(t, err)
 }
 
 // TestCheckTagExistsAndHasCorrectFunction tests that the check tag exists and function relation works
@@ -86,4 +76,71 @@ func TestCheckTagExistsAndHasCorrectFunction(t *testing.T) {
 
 	err = checkTagAndExpressionExist(expression.EqualTo, "sgnr")
 	assert.NoError(t, err)
+}
+
+func TestInnerTxnSearch(t *testing.T) {
+	var addr sdk.Address
+	addr[0] = 0x1
+	exp, err := expression.MakeExpression(expression.EqualTo, addr.String(), "")
+	require.NoError(t, err)
+
+	txnWithInnerMatch := sdk.SignedTxnWithAD{
+		ApplyData: sdk.ApplyData{
+			EvalDelta: sdk.EvalDelta{
+				InnerTxns: []sdk.SignedTxnWithAD{
+					{
+						SignedTxn: sdk.SignedTxn{
+							Txn: sdk.Transaction{
+								Header: sdk.Header{
+									Sender: addr,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	{
+		// searchInner: false
+		searcher, err := MakeFieldSearcher(exp, expression.EqualTo, "txn.snd", false)
+		require.NoError(t, err)
+
+		// Provide the matching inner transaction.
+		// It matches with searchInner: false.
+		matches, err := searcher.search(&txnWithInnerMatch.EvalDelta.InnerTxns[0])
+
+		require.NoError(t, err)
+		assert.Equal(t, matches, true)
+
+		// Provide the root txn, no match at the root.
+		// It should have no match with searchInner: false.
+		matches, err = searcher.search(&txnWithInnerMatch)
+
+		// No match on inner txn
+		require.NoError(t, err)
+		assert.Equal(t, matches, false)
+	}
+
+	{
+		// searchInner: true
+		searcher, err := MakeFieldSearcher(exp, expression.EqualTo, "txn.snd", true)
+		require.NoError(t, err)
+
+		// Provide the matching inner transaction.
+		// It matches with searchInner: false.
+		matches, err := searcher.search(&txnWithInnerMatch.EvalDelta.InnerTxns[0])
+
+		require.NoError(t, err)
+		assert.Equal(t, matches, true)
+
+		// Provide the root txn, no match at the root.
+		// It should have no match with searchInner: false.
+		matches, err = searcher.search(&txnWithInnerMatch)
+
+		// No match on inner txn
+		require.NoError(t, err)
+		assert.Equal(t, matches, true)
+	}
 }

--- a/conduit/plugins/processors/filterprocessor/filter_processor.go
+++ b/conduit/plugins/processors/filterprocessor/filter_processor.go
@@ -94,7 +94,7 @@ func (a *FilterProcessor) Init(ctx context.Context, _ data.InitProvider, cfg plu
 					return fmt.Errorf("filter processor Init(): could not make expression: %w", err)
 				}
 
-				searcher, err := fields.MakeFieldSearcher(exp, subConfig.ExpressionType, subConfig.FilterTag, subConfig.SearchInner)
+				searcher, err := fields.MakeFieldSearcher(exp, subConfig.ExpressionType, subConfig.FilterTag, a.cfg.SearchInner)
 				if err != nil {
 					return fmt.Errorf("filter processor Init(): error making field searcher - %w", err)
 				}

--- a/conduit/plugins/processors/filterprocessor/filter_processor.go
+++ b/conduit/plugins/processors/filterprocessor/filter_processor.go
@@ -84,7 +84,7 @@ func (a *FilterProcessor) Init(ctx context.Context, _ data.InitProvider, cfg plu
 
 			for _, subConfig := range subConfigs {
 
-				t, err := fields.LookupFieldByTag(subConfig.FilterTag, &sdk.SignedTxnInBlock{})
+				t, err := fields.LookupFieldByTag(subConfig.FilterTag, &sdk.SignedTxnWithAD{})
 				if err != nil {
 					return err
 				}

--- a/conduit/plugins/processors/filterprocessor/filter_processor.go
+++ b/conduit/plugins/processors/filterprocessor/filter_processor.go
@@ -94,7 +94,7 @@ func (a *FilterProcessor) Init(ctx context.Context, _ data.InitProvider, cfg plu
 					return fmt.Errorf("filter processor Init(): could not make expression: %w", err)
 				}
 
-				searcher, err := fields.MakeFieldSearcher(exp, subConfig.ExpressionType, subConfig.FilterTag)
+				searcher, err := fields.MakeFieldSearcher(exp, subConfig.ExpressionType, subConfig.FilterTag, subConfig.SearchInner)
 				if err != nil {
 					return fmt.Errorf("filter processor Init(): error making field searcher - %w", err)
 				}

--- a/conduit/plugins/processors/filterprocessor/filter_processor.go
+++ b/conduit/plugins/processors/filterprocessor/filter_processor.go
@@ -43,7 +43,7 @@ var sampleConfig string
 func (a *FilterProcessor) Metadata() conduit.Metadata {
 	return conduit.Metadata{
 		Name:         implementationName,
-		Description:  "FilterProcessor Filter Processor",
+		Description:  "Filter transactions out of the results according to a configurable pattern.",
 		Deprecated:   false,
 		SampleConfig: sampleConfig,
 	}
@@ -123,15 +123,14 @@ func (a *FilterProcessor) Close() error {
 
 // Process processes the input data
 func (a *FilterProcessor) Process(input data.BlockData) (data.BlockData, error) {
-
 	var err error
-
+	payset := input.Payset
 	for _, searcher := range a.FieldFilters {
-		input, err = searcher.SearchAndFilter(input)
+		payset, err = searcher.SearchAndFilter(payset)
 		if err != nil {
 			return data.BlockData{}, err
 		}
 	}
-
+	input.Payset = payset
 	return input, err
 }

--- a/conduit/plugins/processors/filterprocessor/filter_processor_bench_test.go
+++ b/conduit/plugins/processors/filterprocessor/filter_processor_bench_test.go
@@ -2,7 +2,10 @@ package filterprocessor
 
 import (
 	"context"
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
 	"github.com/algorand/indexer/conduit"
@@ -12,22 +15,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func BenchmarkProcess(b *testing.B) {
-	var addr sdk.Address
-	addr[0] = 0x01
-	cfgStr := `---
-filters:
-  - none: 
-    - tag: sgnr
-      expression-type: equal
-      expression: "` + addr.String() + `"
-`
-
-	fp := &FilterProcessor{}
-	err := fp.Init(context.Background(), &conduit.PipelineInitProvider{}, plugins.MakePluginConfig(cfgStr), logrus.New())
-	assert.NoError(b, err)
-
-	bd := data.BlockData{
+func blockData(addr sdk.Address, numInner int) (block data.BlockData, searchTag string) {
+	searchTag = "sgnr"
+	block = data.BlockData{
 		BlockHeader: sdk.BlockHeader{},
 		Payset: []sdk.SignedTxnInBlock{
 			{
@@ -42,9 +32,58 @@ filters:
 		Certificate: nil,
 	}
 
-	// Ignore the setup cost above.
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		fp.Process(bd)
+	for i := 0; i < numInner; i++ {
+		block.Payset[0].AuthAddr = sdk.ZeroAddress
+
+		innerTxn := sdk.SignedTxnWithAD{
+			SignedTxn: sdk.SignedTxn{},
+		}
+		// match the final inner txn
+		if i == numInner-1 {
+			innerTxn.SignedTxn.AuthAddr = addr
+		}
+		block.Payset[0].EvalDelta.InnerTxns = append(block.Payset[0].EvalDelta.InnerTxns, innerTxn)
+	}
+	return
+}
+
+func BenchmarkProcess(b *testing.B) {
+	var addr sdk.Address
+	addr[0] = 0x01
+
+	var table = []struct {
+		input int
+	}{
+		{input: 0},
+		{input: 10},
+		{input: 100},
+	}
+	for _, v := range table {
+		b.Run(fmt.Sprintf("inner_txn_count_%d", v.input), func(b *testing.B) {
+			bd, tag := blockData(addr, v.input)
+			cfgStr := fmt.Sprintf(`filters:
+  - all:
+    - tag: %s
+      search-inner: true
+      expression-type: equal
+      expression: "%s"`, tag, addr.String())
+
+			fp := &FilterProcessor{}
+			err := fp.Init(context.Background(), &conduit.PipelineInitProvider{}, plugins.MakePluginConfig(cfgStr), logrus.New())
+			assert.NoError(b, err)
+
+			// sanity test Process
+			{
+				out, err := fp.Process(bd)
+				require.NoError(b, err)
+				require.Len(b, out.Payset, 1)
+			}
+
+			// Ignore the setup cost above.
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				fp.Process(bd)
+			}
+		})
 	}
 }

--- a/conduit/plugins/processors/filterprocessor/filter_processor_test.go
+++ b/conduit/plugins/processors/filterprocessor/filter_processor_test.go
@@ -7,12 +7,20 @@ import (
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/indexer/conduit"
 	"github.com/algorand/indexer/conduit/plugins"
 	"github.com/algorand/indexer/conduit/plugins/processors"
 	"github.com/algorand/indexer/data"
 )
+
+// create an empty block data so that txn fields can be set with less vertical space
+func testBlock(numTxn int) data.BlockData {
+	return data.BlockData{
+		Payset: make([]sdk.SignedTxnInBlock, numTxn),
+	}
+}
 
 // TestFilterProcessor_Init_None
 func TestFilterProcessor_Init_None(t *testing.T) {
@@ -1014,8 +1022,39 @@ filters:
 	)
 
 	output, err := fp.Process(bd)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(output.Payset))
-	assert.Equal(t, sampleAddr1, output.Payset[0].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Receiver)
-	assert.Equal(t, sampleAddr2, output.Payset[1].SignedTxnWithAD.SignedTxn.Txn.PaymentTxnFields.Receiver)
+	require.NoError(t, err)
+	assert.Subset(t, output.Payset, []sdk.SignedTxnInBlock{bd.Payset[0], bd.Payset[1]})
+}
+
+func TestFilterProcessor_SearchInner(t *testing.T) {
+	sampleAddr1 := sdk.Address{1}
+	cfg := `---
+search-inner: true
+filters:
+  - any:
+    - tag: txn.snd
+      expression-type: equal
+      expression: "` + sampleAddr1.String() + `"
+`
+
+	fp := FilterProcessor{}
+	err := fp.Init(context.Background(), &conduit.PipelineInitProvider{}, plugins.MakePluginConfig(cfg), logrus.New())
+	require.NoError(t, err)
+
+	bd := testBlock(5)
+	bd.Payset[1].EvalDelta.InnerTxns = []sdk.SignedTxnWithAD{
+		{
+			SignedTxn: sdk.SignedTxn{
+				Txn: sdk.Transaction{
+					Header: sdk.Header{
+						Sender: sampleAddr1,
+					},
+				},
+			},
+		},
+	}
+
+	output, err := fp.Process(bd)
+	require.NoError(t, err)
+	assert.Subset(t, output.Payset, []sdk.SignedTxnInBlock{bd.Payset[1]})
 }

--- a/conduit/plugins/processors/filterprocessor/filter_processor_test.go
+++ b/conduit/plugins/processors/filterprocessor/filter_processor_test.go
@@ -1023,7 +1023,7 @@ filters:
 
 	output, err := fp.Process(bd)
 	require.NoError(t, err)
-	assert.Subset(t, output.Payset, []sdk.SignedTxnInBlock{bd.Payset[0], bd.Payset[1]})
+	assert.Equal(t, output.Payset, []sdk.SignedTxnInBlock{bd.Payset[0], bd.Payset[1]})
 }
 
 func TestFilterProcessor_SearchInner(t *testing.T) {
@@ -1056,5 +1056,5 @@ filters:
 
 	output, err := fp.Process(bd)
 	require.NoError(t, err)
-	assert.Subset(t, output.Payset, []sdk.SignedTxnInBlock{bd.Payset[1]})
+	assert.Equal(t, output.Payset, []sdk.SignedTxnInBlock{bd.Payset[1]})
 }

--- a/conduit/plugins/processors/filterprocessor/gen/generate.go
+++ b/conduit/plugins/processors/filterprocessor/gen/generate.go
@@ -251,7 +251,7 @@ package {{ .PackageName }}
 import (
 	"encoding/base64"
 	"fmt"
-	
+
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
 )
 

--- a/conduit/plugins/processors/filterprocessor/gen/generate.go
+++ b/conduit/plugins/processors/filterprocessor/gen/generate.go
@@ -255,9 +255,9 @@ import (
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
 )
 
-// LookupFieldByTag takes a tag and associated SignedTxnInBlock and returns the value
+// LookupFieldByTag takes a tag and associated SignedTxnWithAD and returns the value
 // referenced by the tag.  An error is returned if the tag does not exist
-func LookupFieldByTag(tag string, input *sdk.SignedTxnInBlock) (interface{}, error) {
+func LookupFieldByTag(tag string, input *sdk.SignedTxnWithAD) (interface{}, error) {
 	switch tag {
 {{ range .StructFields }}	case "{{ .TagPath }}":
 		value := {{ ReturnValue . "input" }}
@@ -296,7 +296,7 @@ func main() {
 	}
 
 	// Process fields.
-	fields, errors := getFields(sdk.SignedTxnInBlock{}, ignoreTags)
+	fields, errors := getFields(sdk.SignedTxnWithAD{}, ignoreTags)
 	if len(errors) != 0 {
 		fmt.Fprintln(os.Stderr, "Errors returned while getting struct fields:")
 		for _, err := range errors {

--- a/docs/conduit/plugins/filter_processor.md
+++ b/docs/conduit/plugins/filter_processor.md
@@ -4,7 +4,7 @@ This is used to filter transactions to include only the ones that you want. This
 which only require specific applications or accounts.
 
 ## any / all
-One or more top-level operations should be provided. 
+One or more top-level operations should be provided.
 * any: transactions are included if they match `any` of the nested sub expressions.
 * all: transactions are included if they match `all` of the nested sub expressions.
 
@@ -20,7 +20,7 @@ Parts of an expression:
 ### tag
 The full path to a given field. Uses the messagepack encoded names of a canonical transaction. For example:
 * `txn.snd` is the sender.
-* `tsn.amt` is the amount.
+* `txn.amt` is the amount.
 
 For information about the structure of transactions, refer to the [Transaction Structure](https://developer.algorand.org/docs/get-details/transactions/) documentation. For detail about individual fields, refer to the [Transaction Reference](https://developer.algorand.org/docs/get-details/transactions/transactions/) documentation.
 


### PR DESCRIPTION
## Summary

1. Generator switched to use `SignedTxnWithAD` instead of `SignedTxnInBlock`.
2. Split out a `matches` function from SearchAndFilter to avoid duplicate code for operation types (any/all/none).
3. Rename `Search` to `Match` for lowest level expressions.
4. Rename `FilterType` to `Type`.
5. Remove `Filter` from the `Filter` constants, it is in their type.
6. There is one remaining `search` function in the `Searcher` type. It now has an option to recursively search inner transactions for a match.

## Test Plan

New unit test.

Updated benchmarks.