### PR TITLE
nightly-build: add missing python dep

### DIFF
--- a/misc/requirements.txt
+++ b/misc/requirements.txt
@@ -5,3 +5,4 @@ py-algorand-sdk >=1.3.0,<2
 pytest==6.2.5
 GitPython==3.1.26
 PyYAML==6.0
+requests==2.28.2


### PR DESCRIPTION
indexer-v-algod fails because requests module is not found. this PR fixes this issue. 