### PR TITLE
new-feature: filter transactions at the group level  

### DIFF
--- a/conduit-docs/conduit_processors_filter.md
+++ b/conduit-docs/conduit_processors_filter.md
@@ -1,0 +1,50 @@
+
+### SubConfig
+<table>
+<tr>
+<th>key</th><th>type</th><th>description</th>
+
+<tr><td>tag</td><td>string</td><td> <code>tag</code> is the tag of the struct to analyze.<br/>
+	It can be of the form `txn.*` where the specific ending is determined by the field you wish to filter on.<br/>
+	It can also be a field in the ApplyData.
+</td></tr>
+
+<tr><td>expression-type</td><td>expression.Type</td><td> <code>expression-type</code> is the type of comparison applied between the field, identified by the tag, and the expression.<br/>
+	<ul>
+		<li>exact</li>
+		<li>regex</li>
+		<li>less-than</li>
+		<li>less-than-equal</li>
+		<li>greater-than</li>
+		<li>great-than-equal</li>
+		<li>equal</li>
+		<li>not-equal</li>
+	</ul>
+</td></tr>
+
+<tr><td>expression</td><td>string</td><td><code>expression</code> is the user-supplied part of the search or comparison.
+</td></tr>
+</table>
+
+
+### Config
+<table>
+<tr>
+<th>key</th><th>type</th><th>description</th>
+
+<tr><td>search-inner</td><td>bool</td><td><code>search-inner</code> configures the filter processor to recursively search inner transactions for expressions.
+</td></tr>
+
+<tr><td>omit-group-transactions</td><td>bool</td><td><code>omit-group-transactions</code> configures the filter processor to return the matched transaction without its grouped transactions.
+</td></tr>
+
+<tr><td>filters</td><td>[]map[string][]SubConfig</td><td> <code>filters</code> are a list of SubConfig objects with an operation acting as the string key in the map
+
+	filters:
+		- [any,all,none]:
+			expression: ""
+			expression-type: ""
+			tag: ""
+</td></tr>
+</table>
+

--- a/conduit/plugins/processors/filterprocessor/config.go
+++ b/conduit/plugins/processors/filterprocessor/config.go
@@ -37,6 +37,9 @@ type SubConfig struct {
 type Config struct {
 	// <code>search-inner</code> configures the filter processor to recursively search inner transactions for expressions.
 	SearchInner bool `yaml:"search-inner"`
+	// <code>omit-group-transactions</code> configures the filter processor to return the matched transaction without its grouped transactions.
+	OmitGroupTransactions bool `yaml:"omit-group-transactions"`
+
 	/* <code>filters</code> are a list of SubConfig objects with an operation acting as the string key in the map
 
 	filters:

--- a/conduit/plugins/processors/filterprocessor/fields/searcher.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher.go
@@ -12,9 +12,10 @@ import (
 
 // Searcher searches the struct with an expression
 type Searcher struct {
-	Exp         expression.Expression
-	Tag         string
-	SearchInner bool
+	Exp             expression.Expression
+	Tag             string
+	SearchInner     bool
+	OmitGroupedTxns bool
 }
 
 // This function is ONLY to be used by the filter.field function.
@@ -68,11 +69,11 @@ func checkTagAndExpressionExist(expressionType expression.Type, tag string) (out
 
 // MakeFieldSearcher will check that the field exists and that it contains the necessary "conversion" function
 // TODO: Remove expressionType. It is validated when the expression is created.
-func MakeFieldSearcher(e expression.Expression, expressionType expression.Type, tag string, searchInner bool) (*Searcher, error) {
+func MakeFieldSearcher(e expression.Expression, expressionType expression.Type, tag string, searchInner bool, omnitGroupedTxns bool) (*Searcher, error) {
 
 	if err := checkTagAndExpressionExist(expressionType, tag); err != nil {
 		return nil, err
 	}
 
-	return &Searcher{Exp: e, Tag: tag, SearchInner: searchInner}, nil
+	return &Searcher{Exp: e, Tag: tag, SearchInner: searchInner, OmitGroupedTxns: omnitGroupedTxns}, nil
 }

--- a/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher_test.go
@@ -19,7 +19,7 @@ func TestInternalSearch(t *testing.T) {
 	tag := "sgnr"
 	exp, err := expression.MakeExpression(expressionType, address1.String(), "")
 	require.NoError(t, err)
-	searcher, err := MakeFieldSearcher(exp, expressionType, tag, false)
+	searcher, err := MakeFieldSearcher(exp, expressionType, tag, false, false)
 	require.NoError(t, err)
 
 	result, err := searcher.search(
@@ -52,12 +52,12 @@ func TestMakeFieldSearcher(t *testing.T) {
 	sampleExpressionStr := "sample"
 	exp, err := expression.MakeExpression(expressionType, sampleExpressionStr, "")
 	require.NoError(t, err)
-	searcher, err := MakeFieldSearcher(exp, expressionType, tag, false)
+	searcher, err := MakeFieldSearcher(exp, expressionType, tag, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, searcher)
 	assert.Equal(t, searcher.Tag, tag)
 
-	searcher, err = MakeFieldSearcher(exp, "made-up-expression-type", sampleExpressionStr, false)
+	searcher, err = MakeFieldSearcher(exp, "made-up-expression-type", sampleExpressionStr, false, false)
 	require.Error(t, err)
 }
 
@@ -104,7 +104,7 @@ func TestInnerTxnSearch(t *testing.T) {
 
 	{
 		// searchInner: false
-		searcher, err := MakeFieldSearcher(exp, expression.EqualTo, "txn.snd", false)
+		searcher, err := MakeFieldSearcher(exp, expression.EqualTo, "txn.snd", false, false)
 		require.NoError(t, err)
 
 		// Provide the matching inner transaction.
@@ -125,7 +125,7 @@ func TestInnerTxnSearch(t *testing.T) {
 
 	{
 		// searchInner: true
-		searcher, err := MakeFieldSearcher(exp, expression.EqualTo, "txn.snd", true)
+		searcher, err := MakeFieldSearcher(exp, expression.EqualTo, "txn.snd", true, false)
 		require.NoError(t, err)
 
 		// Provide the matching inner transaction.

--- a/conduit/plugins/processors/filterprocessor/filter_processor_bench_test.go
+++ b/conduit/plugins/processors/filterprocessor/filter_processor_bench_test.go
@@ -61,10 +61,10 @@ func BenchmarkProcess(b *testing.B) {
 	for _, v := range table {
 		b.Run(fmt.Sprintf("inner_txn_count_%d", v.input), func(b *testing.B) {
 			bd, tag := blockData(addr, v.input)
-			cfgStr := fmt.Sprintf(`filters:
+			cfgStr := fmt.Sprintf(`search-inner: true
+filters:
   - all:
     - tag: %s
-      search-inner: true
       expression-type: equal
       expression: "%s"`, tag, addr.String())
 


### PR DESCRIPTION
#1482 
this PR adds a new filter flag `omit-group-transactions`. filter processor would return the matched txn and its grouped txns by default. when `omit-group-transactions` is set to false, only matched txns are returned. 

## Test
new unit tests