### PR TITLE
alerting: Slack `#lamprey-builds` Channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
       - run_e2e_tests_nightly
       - codecov/upload
       - slack/notify: &slack-fail-event
+          channel: C056CK9PYRY # #lamprey-builds
           event: fail
           custom: |
             {
@@ -93,6 +94,7 @@ jobs:
       - install_dependencies
       - run_indexer_vs_algod
       - slack/notify: &slack-fail-event
+          channel: C056CK9PYRY # #lamprey-builds
           event: fail
           custom: |
             {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,6 @@ jobs:
       # Change this to run_e2e_tests once we have stable algod binaries containing delta APIs
       - run_e2e_tests_nightly
       - codecov/upload
-
   test_nightly:
     machine:
       image: << pipeline.parameters.ubuntu_image >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
     environment:
       CI_E2E_FILENAME: "fa6ad40d/rel-nightly"
     steps:
+      - fail_intentionally
       - go/install:
           version: << parameters.go_version >>
       - install_dependencies
@@ -56,6 +57,11 @@ jobs:
       # Change this to run_e2e_tests once we have stable algod binaries containing delta APIs
       - run_e2e_tests_nightly
       - codecov/upload
+      - slack/notify:
+          channel: "#lamprey-builds"
+          event: fail
+          template: basic_fail_1
+
   test_nightly:
     machine:
       image: << pipeline.parameters.ubuntu_image >>
@@ -108,6 +114,13 @@ jobs:
             }
 
 commands:
+  fail_intentionally:
+    description: Fail intentionally
+    steps:
+      - run:
+          name: Fail intentionally
+          command: exit 1
+
   install_dependencies:
     description: prepare machine for next steps
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,13 +30,13 @@ workflows:
     jobs:
       - test_nightly:
           name: nightly_test_with_go_<< matrix.go_version >>
-          context: slack-secrets
+          context: lamprey-secrets
           matrix: &go-version-matrix
             parameters:
               go_version: ["1.17.9"]
       - indexer_vs_algod_nightly:
           name: nightly_test_indexer_vs_algod
-          context: slack-secrets
+          context: lamprey-secrets
 
 jobs:
   test:
@@ -73,7 +73,6 @@ jobs:
       - run_e2e_tests_nightly
       - codecov/upload
       - slack/notify: &slack-fail-event
-          channel: "#lamprey-builds"
           event: fail
           custom: |
             {
@@ -94,7 +93,6 @@ jobs:
       - install_dependencies
       - run_indexer_vs_algod
       - slack/notify: &slack-fail-event
-          channel: "#lamprey-builds"
           event: fail
           custom: |
             {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ workflows:
     jobs:
       - test:
           name: test_with_go_<< matrix.go_version >>
-          context: slack-secrets
           matrix: &go-version-matrix
             parameters:
               go_version: ["1.17.9"]
@@ -49,7 +48,6 @@ jobs:
     environment:
       CI_E2E_FILENAME: "fa6ad40d/rel-nightly"
     steps:
-      - fail_intentionally
       - go/install:
           version: << parameters.go_version >>
       - install_dependencies
@@ -58,21 +56,6 @@ jobs:
       # Change this to run_e2e_tests once we have stable algod binaries containing delta APIs
       - run_e2e_tests_nightly
       - codecov/upload
-      - slack/notify:
-          channel: "#lamprey-builds"
-          event: fail
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Intentional FAIL for experimental purposes: <$CIRCLE_BUILD_URL|$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME>\n(<https://app.circleci.com/pipelines/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?branch=$CIRCLE_BRANCH|$CIRCLE_BRANCH>) \n- <$CIRCLE_BUILD_URL|$CIRCLE_JOB> failed\n\n"
-                  }
-                }
-              ]
-            }
 
   test_nightly:
     machine:
@@ -128,13 +111,6 @@ jobs:
             }
 
 commands:
-  fail_intentionally:
-    description: Fail intentionally
-    steps:
-      - run:
-          name: Fail intentionally
-          command: exit 1
-
   install_dependencies:
     description: prepare machine for next steps
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       # Change this to run_e2e_tests once we have stable algod binaries containing delta APIs
       - run_e2e_tests_nightly
       - codecov/upload
-      - slack/notify:
+      - slack/notify: &slack-fail-event
           channel: "#lamprey-builds"
           event: fail
           template: basic_fail_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ workflows:
     jobs:
       - test:
           name: test_with_go_<< matrix.go_version >>
+          context: slack-secrets
           matrix: &go-version-matrix
             parameters:
               go_version: ["1.17.9"]
@@ -58,7 +59,7 @@ jobs:
       - run_e2e_tests_nightly
       - codecov/upload
       - slack/notify: &slack-fail-event
-          # channel: "#lamprey-builds"
+          channel: "#lamprey-builds"
           event: fail
           custom: |
             {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,18 @@ jobs:
       - slack/notify: &slack-fail-event
           channel: "#lamprey-builds"
           event: fail
-          template: basic_fail_1
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Failed: <$CIRCLE_BUILD_URL|$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME>\n(<https://app.circleci.com/pipelines/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?branch=$CIRCLE_BRANCH|$CIRCLE_BRANCH>) \n- <$CIRCLE_BUILD_URL|$CIRCLE_JOB> failed\n\n"
+                  }
+                }
+              ]
+            }
 
   test_nightly:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       # Change this to run_e2e_tests once we have stable algod binaries containing delta APIs
       - run_e2e_tests_nightly
       - codecov/upload
-      - slack/notify: &slack-fail-event
+      - slack/notify:
           channel: "#lamprey-builds"
           event: fail
           custom: |
@@ -68,7 +68,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Failed: <$CIRCLE_BUILD_URL|$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME>\n(<https://app.circleci.com/pipelines/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?branch=$CIRCLE_BRANCH|$CIRCLE_BRANCH>) \n- <$CIRCLE_BUILD_URL|$CIRCLE_JOB> failed\n\n"
+                    "text": "Intentional FAIL for experimental purposes: <$CIRCLE_BUILD_URL|$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME>\n(<https://app.circleci.com/pipelines/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?branch=$CIRCLE_BRANCH|$CIRCLE_BRANCH>) \n- <$CIRCLE_BUILD_URL|$CIRCLE_JOB> failed\n\n"
                   }
                 }
               ]
@@ -91,6 +91,7 @@ jobs:
       - run_e2e_tests_nightly
       - codecov/upload
       - slack/notify: &slack-fail-event
+          channel: "#lamprey-builds"
           event: fail
           custom: |
             {
@@ -111,6 +112,7 @@ jobs:
       - install_dependencies
       - run_indexer_vs_algod
       - slack/notify: &slack-fail-event
+          channel: "#lamprey-builds"
           event: fail
           custom: |
             {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   go: circleci/go@1.7.0
   slack: circleci/slack@4.7.1
-  codecov: codecov/codecov@3.1.1
+  codecov: codecov/codecov@3.2.4
 
 parameters:
   ubuntu_image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - install_linter
       - run_tests
       # Change this to run_e2e_tests once we have stable algod binaries containing delta APIs
-      - run_e2e_tests_nightly
+      # - run_e2e_tests_nightly
       - codecov/upload
   test_nightly:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - run_e2e_tests_nightly
       - codecov/upload
       - slack/notify: &slack-fail-event
-          channel: "#lamprey-builds"
+          # channel: "#lamprey-builds"
           event: fail
           custom: |
             {


### PR DESCRIPTION
## Summary

Indexer is owned by Team Lamprey. Therefore, alerts of indexer build failures ought to be routed to a Lamprey-specific slack channel instead of `#dev-alerts`.

## Issues

#1521 

## Test Plan

CI

You can see that the configuration works by looking at recent notifications inside of `#lamprey-builds`.
