### PR TITLE
chore: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-.github/ @algorand/dev
-.circleci/ @algorand/dev
+.github/ @algorand/lamprey
+.circleci/ @algorand/lamprey


### PR DESCRIPTION
removing algorand/dev from codeowners to prevent `algorand/dev` from getting tagged automatically as a PR reviewer. 