### PR TITLE
encoding: Fix partupdrmv encoding.

### DIFF
--- a/idb/postgres/internal/encoding/encoding.go
+++ b/idb/postgres/internal/encoding/encoding.go
@@ -70,6 +70,9 @@ func (addr *AlgodEncodedAddress) UnmarshalText(text []byte) error {
 }
 
 func convertExpiredAccounts(accounts []sdk.Address) []AlgodEncodedAddress {
+	if len(accounts) == 0 {
+		return nil
+	}
 	res := make([]AlgodEncodedAddress, len(accounts))
 	for i, addr := range accounts {
 		res[i] = AlgodEncodedAddress(addr)
@@ -78,6 +81,9 @@ func convertExpiredAccounts(accounts []sdk.Address) []AlgodEncodedAddress {
 }
 
 func unconvertExpiredAccounts(accounts []AlgodEncodedAddress) []sdk.Address {
+	if len(accounts) == 0 {
+		return nil
+	}
 	res := make([]sdk.Address, len(accounts))
 	for i, addr := range accounts {
 		res[i] = sdk.Address(addr)

--- a/idb/postgres/internal/encoding/encoding.go
+++ b/idb/postgres/internal/encoding/encoding.go
@@ -52,18 +52,12 @@ func decodeBase64(data string) ([]byte, error) {
 
 func convertBlockHeader(header sdk.BlockHeader) blockHeader {
 	return blockHeader{
-		BlockHeader:         header,
-		BranchOverride:      sdk.Digest(header.Branch),
-		FeeSinkOverride:     sdk.Digest(header.FeeSink),
-		RewardsPoolOverride: sdk.Digest(header.RewardsPool),
+		BlockHeader: header,
 	}
 }
 
 func unconvertBlockHeader(header blockHeader) sdk.BlockHeader {
 	res := header.BlockHeader
-	res.Branch = sdk.BlockHash(header.BranchOverride)
-	res.FeeSink = sdk.Address(header.FeeSinkOverride)
-	res.RewardsPool = sdk.Address(header.RewardsPoolOverride)
 	return res
 }
 
@@ -85,14 +79,10 @@ func DecodeBlockHeader(data []byte) (sdk.BlockHeader, error) {
 
 func convertAssetParams(params sdk.AssetParams) assetParams {
 	ret := assetParams{
-		AssetParams:      params,
-		ManagerOverride:  sdk.Digest(params.Manager),
-		ReserveOverride:  sdk.Digest(params.Reserve),
-		FreezeOverride:   sdk.Digest(params.Freeze),
-		ClawbackOverride: sdk.Digest(params.Clawback),
-		AssetNameBytes:   []byte(params.AssetName),
-		UnitNameBytes:    []byte(params.UnitName),
-		URLBytes:         []byte(params.URL),
+		AssetParams:    params,
+		AssetNameBytes: []byte(params.AssetName),
+		UnitNameBytes:  []byte(params.UnitName),
+		URLBytes:       []byte(params.URL),
 	}
 
 	ret.AssetName = util.PrintableUTF8OrEmpty(params.AssetName)
@@ -125,10 +115,6 @@ func unconvertAssetParams(params assetParams) sdk.AssetParams {
 	if len(res.URL) == 0 {
 		res.URL = string(params.URLBytes)
 	}
-	res.Manager = sdk.Address(params.ManagerOverride)
-	res.Reserve = sdk.Address(params.ReserveOverride)
-	res.Freeze = sdk.Address(params.FreezeOverride)
-	res.Clawback = sdk.Address(params.ClawbackOverride)
 	return res
 }
 
@@ -148,58 +134,16 @@ func DecodeAssetParams(data []byte) (sdk.AssetParams, error) {
 	return unconvertAssetParams(params), nil
 }
 
-func convertAccounts(accounts []sdk.Address) []sdk.Digest {
-	if accounts == nil {
-		return nil
-	}
-
-	res := make([]sdk.Digest, 0, len(accounts))
-	for _, address := range accounts {
-		res = append(res, sdk.Digest(address))
-	}
-	return res
-}
-
-func unconvertAccounts(accounts []sdk.Digest) []sdk.Address {
-	if accounts == nil {
-		return nil
-	}
-
-	res := make([]sdk.Address, 0, len(accounts))
-	for _, address := range accounts {
-		res = append(res, sdk.Address(address))
-	}
-	return res
-}
-
 func convertTransaction(txn sdk.Transaction) transaction {
 	return transaction{
-		Transaction:              txn,
-		SenderOverride:           sdk.Digest(txn.Sender),
-		RekeyToOverride:          sdk.Digest(txn.RekeyTo),
-		ReceiverOverride:         sdk.Digest(txn.Receiver),
-		AssetParamsOverride:      convertAssetParams(txn.AssetParams),
-		CloseRemainderToOverride: sdk.Digest(txn.CloseRemainderTo),
-		AssetSenderOverride:      sdk.Digest(txn.AssetSender),
-		AssetReceiverOverride:    sdk.Digest(txn.AssetReceiver),
-		AssetCloseToOverride:     sdk.Digest(txn.AssetCloseTo),
-		FreezeAccountOverride:    sdk.Digest(txn.FreezeAccount),
-		AccountsOverride:         convertAccounts(txn.Accounts),
+		Transaction:         txn,
+		AssetParamsOverride: convertAssetParams(txn.AssetParams),
 	}
 }
 
 func unconvertTransaction(txn transaction) sdk.Transaction {
 	res := txn.Transaction
-	res.Sender = sdk.Address(txn.SenderOverride)
-	res.RekeyTo = sdk.Address(txn.RekeyToOverride)
-	res.Receiver = sdk.Address(txn.ReceiverOverride)
-	res.CloseRemainderTo = sdk.Address(txn.CloseRemainderToOverride)
 	res.AssetParams = unconvertAssetParams(txn.AssetParamsOverride)
-	res.AssetSender = sdk.Address(txn.AssetSenderOverride)
-	res.AssetReceiver = sdk.Address(txn.AssetReceiverOverride)
-	res.AssetCloseTo = sdk.Address(txn.AssetCloseToOverride)
-	res.FreezeAccount = sdk.Address(txn.FreezeAccountOverride)
-	res.Accounts = unconvertAccounts(txn.AccountsOverride)
 	return res
 }
 
@@ -333,9 +277,9 @@ func unconvertEvalDelta(delta evalDelta) sdk.EvalDelta {
 
 func convertSignedTxnWithAD(stxn sdk.SignedTxnWithAD) signedTxnWithAD {
 	return signedTxnWithAD{
-		SignedTxnWithAD:   stxn,
-		TxnOverride:       convertTransaction(stxn.Txn),
-		AuthAddrOverride:  sdk.Digest(stxn.AuthAddr),
+		SignedTxnWithAD: stxn,
+		TxnOverride:     convertTransaction(stxn.Txn),
+		//AuthAddrOverride:  sdk.Digest(stxn.AuthAddr),
 		EvalDeltaOverride: convertEvalDelta(stxn.EvalDelta),
 	}
 }
@@ -343,7 +287,7 @@ func convertSignedTxnWithAD(stxn sdk.SignedTxnWithAD) signedTxnWithAD {
 func unconvertSignedTxnWithAD(stxn signedTxnWithAD) sdk.SignedTxnWithAD {
 	res := stxn.SignedTxnWithAD
 	res.Txn = unconvertTransaction(stxn.TxnOverride)
-	res.AuthAddr = sdk.Address(stxn.AuthAddrOverride)
+	res.AuthAddr = stxn.AuthAddr
 	res.EvalDelta = unconvertEvalDelta(stxn.EvalDeltaOverride)
 	return res
 }
@@ -371,7 +315,7 @@ func unconvertTrimmedAccountData(ad trimmedAccountData) sdk.AccountData {
 			MicroAlgos:          sdk.MicroAlgos(ad.MicroAlgos),
 			RewardsBase:         ad.RewardsBase,
 			RewardedMicroAlgos:  sdk.MicroAlgos(ad.RewardedMicroAlgos),
-			AuthAddr:            sdk.Address(ad.AuthAddr),
+			AuthAddr:            ad.AuthAddr,
 			TotalAppSchema:      ad.TotalAppSchema,
 			TotalExtraAppPages:  ad.TotalExtraAppPages,
 			TotalAppParams:      ad.TotalAppParams,
@@ -568,35 +512,20 @@ func DecodeAppLocalStateArray(data []byte) ([]sdk.AppLocalState, error) {
 
 	return unconvertAppLocalStateArray(array), nil
 }
-func convertSpecialAddresses(special itypes.SpecialAddresses) specialAddresses {
-	return specialAddresses{
-		SpecialAddresses:    special,
-		FeeSinkOverride:     sdk.Digest(special.FeeSink),
-		RewardsPoolOverride: sdk.Digest(special.RewardsPool),
-	}
-}
-
-func unconvertSpecialAddresses(special specialAddresses) itypes.SpecialAddresses {
-	res := special.SpecialAddresses
-	res.FeeSink = sdk.Address(special.FeeSinkOverride)
-	res.RewardsPool = sdk.Address(special.RewardsPoolOverride)
-	return res
-}
 
 // EncodeSpecialAddresses encodes special addresses (sink and rewards pool) into json.
 func EncodeSpecialAddresses(special itypes.SpecialAddresses) []byte {
-	return encodeJSON(convertSpecialAddresses(special))
+	return encodeJSON(special)
 }
 
 // DecodeSpecialAddresses decodes special addresses (sink and rewards pool) from json.
 func DecodeSpecialAddresses(data []byte) (itypes.SpecialAddresses, error) {
-	var special specialAddresses
+	var special itypes.SpecialAddresses
 	err := DecodeJSON(data, &special)
 	if err != nil {
 		return itypes.SpecialAddresses{}, err
 	}
-
-	return unconvertSpecialAddresses(special), nil
+	return special, nil
 }
 
 // EncodeTxnExtra encodes transaction extra info into json.
@@ -675,7 +604,7 @@ func TrimLcAccountData(ad sdk.AccountData) sdk.AccountData {
 func convertTrimmedLcAccountData(ad sdk.AccountData) baseAccountData {
 	return baseAccountData{
 		Status:              ad.Status,
-		AuthAddr:            sdk.Digest(ad.AuthAddr),
+		AuthAddr:            ad.AuthAddr,
 		TotalAppSchema:      ad.TotalAppSchema,
 		TotalExtraAppPages:  ad.TotalExtraAppPages,
 		TotalAssetParams:    ad.TotalAssetParams,
@@ -699,7 +628,7 @@ func unconvertTrimmedLcAccountData(ba baseAccountData) sdk.AccountData {
 	return sdk.AccountData{
 		AccountBaseData: sdk.AccountBaseData{
 			Status:              ba.Status,
-			AuthAddr:            sdk.Address(ba.AuthAddr),
+			AuthAddr:            ba.AuthAddr,
 			TotalAppSchema:      ba.TotalAppSchema,
 			TotalExtraAppPages:  ba.TotalExtraAppPages,
 			TotalAppParams:      ba.TotalAppParams,

--- a/idb/postgres/internal/encoding/encoding.go
+++ b/idb/postgres/internal/encoding/encoding.go
@@ -50,6 +50,25 @@ func decodeBase64(data string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(data)
 }
 
+// MarshalText returns the address string as an array of bytes
+func (addr *AlgodEncodedAddress) MarshalText() ([]byte, error) {
+	var a sdk.Address
+	copy(a[:], addr[:])
+	return []byte(a.String()), nil
+}
+
+// UnmarshalText initializes the Address from an array of bytes.
+// The bytes may be in the base32 checksum format, or the raw bytes base64 encoded.
+func (addr *AlgodEncodedAddress) UnmarshalText(text []byte) error {
+	var a sdk.Address
+	err := a.UnmarshalText(text)
+	if err != nil {
+		return err
+	}
+	copy(addr[:], a[:])
+	return nil
+}
+
 func convertExpiredAccounts(accounts []sdk.Address) []AlgodEncodedAddress {
 	res := make([]AlgodEncodedAddress, len(accounts))
 	for i, addr := range accounts {

--- a/idb/postgres/internal/encoding/encoding.go
+++ b/idb/postgres/internal/encoding/encoding.go
@@ -50,14 +50,32 @@ func decodeBase64(data string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(data)
 }
 
+func convertExpiredAccounts(accounts []sdk.Address) []AlgodEncodedAddress {
+	res := make([]AlgodEncodedAddress, len(accounts))
+	for i, addr := range accounts {
+		res[i] = AlgodEncodedAddress(addr)
+	}
+	return res
+}
+
+func unconvertExpiredAccounts(accounts []AlgodEncodedAddress) []sdk.Address {
+	res := make([]sdk.Address, len(accounts))
+	for i, addr := range accounts {
+		res[i] = sdk.Address(addr)
+	}
+	return res
+}
+
 func convertBlockHeader(header sdk.BlockHeader) blockHeader {
 	return blockHeader{
-		BlockHeader: header,
+		BlockHeader:                          header,
+		ExpiredParticipationAccountsOverride: convertExpiredAccounts(header.ExpiredParticipationAccounts),
 	}
 }
 
 func unconvertBlockHeader(header blockHeader) sdk.BlockHeader {
 	res := header.BlockHeader
+	res.ExpiredParticipationAccounts = unconvertExpiredAccounts(header.ExpiredParticipationAccountsOverride)
 	return res
 }
 

--- a/idb/postgres/internal/encoding/encoding_test.go
+++ b/idb/postgres/internal/encoding/encoding_test.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/algorand/go-algorand-sdk/v2/encoding/msgpack"
@@ -227,16 +228,26 @@ func TestBlockHeaderEncoding(t *testing.T) {
 			FeeSink:     newaddr(),
 			RewardsPool: newaddr(),
 		},
+		ParticipationUpdates: sdk.ParticipationUpdates{
+			ExpiredParticipationAccounts: []sdk.Address{newaddr()},
+		},
 	}
 
 	buf := EncodeBlockHeader(header)
 
-	expectedString := `{"fees":"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=","prev":"BQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=","rnd":3,"rwd":"AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`
+	template := `{"fees":"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=","partupdrmv":["%s"],"prev":"BQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=","rnd":3,"rwd":"AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`
+	expectedString := fmt.Sprintf(template, "AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANVWEXNA")
 	assert.Equal(t, expectedString, string(buf))
 
 	headerNew, err := DecodeBlockHeader(buf)
 	require.NoError(t, err)
 	assert.Equal(t, header, headerNew)
+
+	// Lenient decode from the corrupted data
+	badString := fmt.Sprintf(template, "AwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+	headerNewFromBad, err := DecodeBlockHeader([]byte(badString))
+	require.NoError(t, err)
+	assert.Equal(t, header, headerNewFromBad)
 }
 
 // Test that the encoding of byteArray in JSON is as expected and that decoding results in

--- a/idb/postgres/internal/encoding/types.go
+++ b/idb/postgres/internal/encoding/types.go
@@ -1,41 +1,23 @@
 package encoding
 
 import (
-	"github.com/algorand/indexer/types"
-
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
 )
 
 type blockHeader struct {
 	sdk.BlockHeader
-	BranchOverride      sdk.Digest `codec:"prev"`
-	FeeSinkOverride     sdk.Digest `codec:"fees"`
-	RewardsPoolOverride sdk.Digest `codec:"rwd"`
 }
 
 type assetParams struct {
 	sdk.AssetParams
-	UnitNameBytes    []byte     `codec:"un64"`
-	AssetNameBytes   []byte     `codec:"an64"`
-	URLBytes         []byte     `codec:"au64"`
-	ManagerOverride  sdk.Digest `codec:"m"`
-	ReserveOverride  sdk.Digest `codec:"r"`
-	FreezeOverride   sdk.Digest `codec:"f"`
-	ClawbackOverride sdk.Digest `codec:"c"`
+	UnitNameBytes  []byte `codec:"un64"`
+	AssetNameBytes []byte `codec:"an64"`
+	URLBytes       []byte `codec:"au64"`
 }
 
 type transaction struct {
 	sdk.Transaction
-	SenderOverride           sdk.Digest   `codec:"snd"`
-	RekeyToOverride          sdk.Digest   `codec:"rekey"`
-	ReceiverOverride         sdk.Digest   `codec:"rcv"`
-	CloseRemainderToOverride sdk.Digest   `codec:"close"`
-	AssetParamsOverride      assetParams  `codec:"apar"`
-	AssetSenderOverride      sdk.Digest   `codec:"asnd"`
-	AssetReceiverOverride    sdk.Digest   `codec:"arcv"`
-	AssetCloseToOverride     sdk.Digest   `codec:"aclose"`
-	FreezeAccountOverride    sdk.Digest   `codec:"fadd"`
-	AccountsOverride         []sdk.Digest `codec:"apat"`
+	AssetParamsOverride assetParams `codec:"apar"`
 }
 
 type valueDelta struct {
@@ -74,16 +56,14 @@ type evalDelta struct {
 type signedTxnWithAD struct {
 	sdk.SignedTxnWithAD
 	TxnOverride       transaction `codec:"txn"`
-	AuthAddrOverride  sdk.Digest  `codec:"sgnr"`
 	EvalDeltaOverride evalDelta   `codec:"dt"`
 }
 
 type trimmedAccountData struct {
 	baseAccountData
-	AuthAddrOverride   sdk.Digest `codec:"spend"`
-	MicroAlgos         uint64     `codec:"algo"`
-	RewardsBase        uint64     `codec:"ebase"`
-	RewardedMicroAlgos uint64     `codec:"ern"`
+	MicroAlgos         uint64 `codec:"algo"`
+	RewardsBase        uint64 `codec:"ebase"`
+	RewardedMicroAlgos uint64 `codec:"ern"`
 }
 
 type tealValue struct {
@@ -103,12 +83,6 @@ type appParams struct {
 	GlobalStateOverride tealKeyValue `codec:"gs"`
 }
 
-type specialAddresses struct {
-	types.SpecialAddresses
-	FeeSinkOverride     sdk.Digest `codec:"FeeSink"`
-	RewardsPoolOverride sdk.Digest `codec:"RewardsPool"`
-}
-
 type baseOnlineAccountData struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
@@ -124,7 +98,7 @@ type baseAccountData struct {
 	_struct struct{} `codec:",omitempty,omitemptyarray"`
 
 	Status              sdk.Status      `codec:"onl"`
-	AuthAddr            sdk.Digest      `codec:"spend"`
+	AuthAddr            sdk.Address     `codec:"spend"`
 	TotalAppSchema      sdk.StateSchema `codec:"tsch"`
 	TotalExtraAppPages  uint32          `codec:"teap"`
 	TotalAssetParams    uint64          `codec:"tasp"`

--- a/idb/postgres/internal/encoding/types.go
+++ b/idb/postgres/internal/encoding/types.go
@@ -4,8 +4,30 @@ import (
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
 )
 
+type AlgodEncodedAddress sdk.Address
+
+// MarshalText returns the address string as an array of bytes
+func (addr *AlgodEncodedAddress) MarshalText() ([]byte, error) {
+	var a sdk.Address
+	copy(a[:], addr[:])
+	return []byte(a.String()), nil
+}
+
+// UnmarshalText initializes the Address from an array of bytes.
+// The bytes may be in the base32 checksum format, or the raw bytes base64 encoded.
+func (addr *AlgodEncodedAddress) UnmarshalText(text []byte) error {
+	var a sdk.Address
+	err := a.UnmarshalText(text)
+	if err != nil {
+		return err
+	}
+	copy(addr[:], a[:])
+	return nil
+}
+
 type blockHeader struct {
 	sdk.BlockHeader
+	ExpiredParticipationAccountsOverride []AlgodEncodedAddress `codec:"partupdrmv"`
 }
 
 type assetParams struct {

--- a/idb/postgres/internal/encoding/types.go
+++ b/idb/postgres/internal/encoding/types.go
@@ -4,26 +4,8 @@ import (
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
 )
 
+// AlgodEncodedAddress is an address encoded in the format used by algod.
 type AlgodEncodedAddress sdk.Address
-
-// MarshalText returns the address string as an array of bytes
-func (addr *AlgodEncodedAddress) MarshalText() ([]byte, error) {
-	var a sdk.Address
-	copy(a[:], addr[:])
-	return []byte(a.String()), nil
-}
-
-// UnmarshalText initializes the Address from an array of bytes.
-// The bytes may be in the base32 checksum format, or the raw bytes base64 encoded.
-func (addr *AlgodEncodedAddress) UnmarshalText(text []byte) error {
-	var a sdk.Address
-	err := a.UnmarshalText(text)
-	if err != nil {
-		return err
-	}
-	copy(addr[:], a[:])
-	return nil
-}
 
 type blockHeader struct {
 	sdk.BlockHeader


### PR DESCRIPTION
## Summary

The go-algorand based version of Indexer missed the `partupdrmv` block header field. When switching back to the go-SDK this has caused a scenario where the old and new versions of Indexer database are no longer compatible. This fix makes the decoding more lenient and fixes the encoding to match the previous version.

In addition, this PR removes redundant overrides.

See commit 1 for removing redundant overrides.
See commit 2 for the `partupdrmv` override.

## Test Plan

Update unit tests.