### PR TITLE
encoding: Better support for address encodings.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       go_version:
         type: string
     environment:
-      CI_E2E_FILENAME: "faab6dcf/rel-nightly"
+      CI_E2E_FILENAME: "rel-nightly"
     steps:
       - go/install:
           version: << parameters.go_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       go_version:
         type: string
     environment:
-      CI_E2E_FILENAME: "rel-nightly"
+      CI_E2E_FILENAME: "f99e7b0c/rel-nightly"
     steps:
       - go/install:
           version: << parameters.go_version >>

--- a/idb/postgres/internal/encoding/encoding.go
+++ b/idb/postgres/internal/encoding/encoding.go
@@ -4,18 +4,17 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	sdk_types "github.com/algorand/go-algorand-sdk/types"
+	"github.com/algorand/go-codec/codec"
+	"github.com/algorand/indexer/idb"
+	"github.com/algorand/indexer/idb/postgres/internal/types"
+	"github.com/algorand/indexer/util"
 
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
-	"github.com/algorand/go-codec/codec"
-
-	"github.com/algorand/indexer/idb"
-	"github.com/algorand/indexer/idb/postgres/internal/types"
-	"github.com/algorand/indexer/util"
 )
 
 var jsonCodecHandle *codec.JsonHandle

--- a/idb/postgres/internal/encoding/encoding.go
+++ b/idb/postgres/internal/encoding/encoding.go
@@ -84,6 +84,9 @@ func (addr *AlgodEncodedAddress) UnmarshalText(text []byte) error {
 }
 
 func convertExpiredAccounts(accounts []basics.Address) []AlgodEncodedAddress {
+	if len(accounts) == 0 {
+		return nil
+	}
 	res := make([]AlgodEncodedAddress, len(accounts))
 	for i, addr := range accounts {
 		res[i] = AlgodEncodedAddress(addr)
@@ -92,6 +95,9 @@ func convertExpiredAccounts(accounts []basics.Address) []AlgodEncodedAddress {
 }
 
 func unconvertExpiredAccounts(accounts []AlgodEncodedAddress) []basics.Address {
+	if len(accounts) == 0 {
+		return nil
+	}
 	res := make([]basics.Address, len(accounts))
 	for i, addr := range accounts {
 		res[i] = basics.Address(addr)

--- a/idb/postgres/internal/encoding/encoding.go
+++ b/idb/postgres/internal/encoding/encoding.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	sdk_types "github.com/algorand/go-algorand-sdk/types"
+
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
@@ -52,12 +54,59 @@ func decodeBase64(data string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(data)
 }
 
+// MarshalText returns the address string as an array of bytes
+func (addr *AlgodEncodedAddress) MarshalText() ([]byte, error) {
+	var a sdk_types.Address
+	copy(a[:], addr[:])
+	return []byte(a.String()), nil
+}
+
+// UnmarshalText initializes the Address from an array of bytes.
+// The bytes may be in the base32 checksum format, or the raw bytes base64 encoded.
+// Copied from newer version of go-algorand-sdk.
+func (addr *AlgodEncodedAddress) UnmarshalText(text []byte) error {
+	address, err := sdk_types.DecodeAddress(string(text))
+	if err == nil {
+		copy(addr[:], address[:])
+		return nil
+	}
+	// ignore the DecodeAddress error because it isn't the native MarshalText format.
+
+	// Check if its b64 encoded
+	data, err := base64.StdEncoding.DecodeString(string(text))
+	if err == nil {
+		if len(data) != len(addr[:]) {
+			return fmt.Errorf("decoded address is the wrong length, should be %d bytes", len(addr[:]))
+		}
+		copy(addr[:], data[:])
+		return nil
+	}
+	return err
+}
+
+func convertExpiredAccounts(accounts []basics.Address) []AlgodEncodedAddress {
+	res := make([]AlgodEncodedAddress, len(accounts))
+	for i, addr := range accounts {
+		res[i] = AlgodEncodedAddress(addr)
+	}
+	return res
+}
+
+func unconvertExpiredAccounts(accounts []AlgodEncodedAddress) []basics.Address {
+	res := make([]basics.Address, len(accounts))
+	for i, addr := range accounts {
+		res[i] = basics.Address(addr)
+	}
+	return res
+}
+
 func convertBlockHeader(header bookkeeping.BlockHeader) blockHeader {
 	return blockHeader{
-		BlockHeader:         header,
-		BranchOverride:      crypto.Digest(header.Branch),
-		FeeSinkOverride:     crypto.Digest(header.FeeSink),
-		RewardsPoolOverride: crypto.Digest(header.RewardsPool),
+		BlockHeader:                          header,
+		BranchOverride:                       crypto.Digest(header.Branch),
+		FeeSinkOverride:                      crypto.Digest(header.FeeSink),
+		RewardsPoolOverride:                  crypto.Digest(header.RewardsPool),
+		ExpiredParticipationAccountsOverride: convertExpiredAccounts(header.ExpiredParticipationAccounts),
 	}
 }
 
@@ -66,6 +115,7 @@ func unconvertBlockHeader(header blockHeader) bookkeeping.BlockHeader {
 	res.Branch = bookkeeping.BlockHash(header.BranchOverride)
 	res.FeeSink = basics.Address(header.FeeSinkOverride)
 	res.RewardsPool = basics.Address(header.RewardsPoolOverride)
+	res.ExpiredParticipationAccounts = unconvertExpiredAccounts(header.ExpiredParticipationAccountsOverride)
 	return res
 }
 

--- a/idb/postgres/internal/encoding/encoding_test.go
+++ b/idb/postgres/internal/encoding/encoding_test.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"fmt"
 	"math/rand"
 	"reflect"
 	"testing"
@@ -233,16 +234,26 @@ func TestBlockHeaderEncoding(t *testing.T) {
 			FeeSink:     newaddr(),
 			RewardsPool: newaddr(),
 		},
+		ParticipationUpdates: bookkeeping.ParticipationUpdates{
+			ExpiredParticipationAccounts: []basics.Address{newaddr()},
+		},
 	}
 
 	buf := EncodeBlockHeader(header)
 
-	expectedString := `{"fees":"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=","prev":"BQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=","rnd":3,"rwd":"AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`
+	template := `{"fees":"AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=","partupdrmv":["%s"],"prev":"BQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=","rnd":3,"rwd":"AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`
+	expectedString := fmt.Sprintf(template, "AMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANVWEXNA")
 	assert.Equal(t, expectedString, string(buf))
 
 	headerNew, err := DecodeBlockHeader(buf)
 	require.NoError(t, err)
 	assert.Equal(t, header, headerNew)
+
+	// Lenient decode from the corrupted data
+	badString := fmt.Sprintf(template, "AwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+	headerNewFromBad, err := DecodeBlockHeader([]byte(badString))
+	require.NoError(t, err)
+	assert.Equal(t, header, headerNewFromBad)
 }
 
 // Test that the encoding of byteArray in JSON is as expected and that decoding results in

--- a/idb/postgres/internal/encoding/encoding_test.go
+++ b/idb/postgres/internal/encoding/encoding_test.go
@@ -6,6 +6,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/algorand/go-algorand/crypto"
 	"github.com/algorand/go-algorand/crypto/merklesignature"
 	"github.com/algorand/go-algorand/data/basics"
@@ -13,8 +16,6 @@ import (
 	"github.com/algorand/go-algorand/data/transactions"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/protocol"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/algorand/indexer/idb"
 	"github.com/algorand/indexer/idb/postgres/internal/types"

--- a/idb/postgres/internal/encoding/types.go
+++ b/idb/postgres/internal/encoding/types.go
@@ -8,11 +8,14 @@ import (
 	"github.com/algorand/go-algorand/data/transactions"
 )
 
+type AlgodEncodedAddress basics.Address
+
 type blockHeader struct {
 	bookkeeping.BlockHeader
-	BranchOverride      crypto.Digest `codec:"prev"`
-	FeeSinkOverride     crypto.Digest `codec:"fees"`
-	RewardsPoolOverride crypto.Digest `codec:"rwd"`
+	BranchOverride                       crypto.Digest         `codec:"prev"`
+	FeeSinkOverride                      crypto.Digest         `codec:"fees"`
+	RewardsPoolOverride                  crypto.Digest         `codec:"rwd"`
+	ExpiredParticipationAccountsOverride []AlgodEncodedAddress `codec:"partupdrmv"`
 }
 
 type assetParams struct {

--- a/idb/postgres/internal/encoding/types.go
+++ b/idb/postgres/internal/encoding/types.go
@@ -8,6 +8,7 @@ import (
 	"github.com/algorand/go-algorand/data/transactions"
 )
 
+// AlgodEncodedAddress is an address encoded in the format used by algod.
 type AlgodEncodedAddress basics.Address
 
 type blockHeader struct {


### PR DESCRIPTION
## Summary

There is a bug in the newer version of Indexer used by Conduit which caused addresses to be encoded differently. This PR makes the decoding more lenient to allow for the different encodings.

## Test Plan

New unit test.