### PR TITLE
chore: Add Goreleaser/Docker image builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ api/.3tmp.json
 api/generate
 tmp/
 ./conduit-docs/
+dist
 
 # Binaries for programs and plugins
 *.exe

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ universal_binaries:
   - replace: true
 
 builds:
-  - main: ./cmd/algorand-indexer
+  - main: ./cmd/algorand-indexer/main.go
     env:
       - CGO_ENABLED=0
     goos:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,91 @@
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+# Build mac universal binary.
+universal_binaries:
+  - replace: true
+
+builds:
+  - main: cmd/algorand-indexer/main.go
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    # skip 386 architecture.
+    goarch:
+      - amd64
+      - arm64
+    ldflags: >
+      -s -w
+      -X github.com/algorand/indexer/version.Hash={{.FullCommit}}
+      -X github.com/algorand/indexer/version.ShortHash={{.ShortCommit}}
+      -X github.com/algorand/indexer/version.CompileTime={{.Timestamp}}
+      -X github.com/algorand/indexer/version.GitDecorateBase64=$(shell git log -n 1 --pretty="%D"|base64|tr -d ' \n')
+      -X github.com/algorand/indexer/version.ReleaseVersion={{.Version}}
+
+dockers:
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+    - "algorand/indexer:latest{{ if .IsSnapshot }}-snapshot{{ end }}-amd64"
+    - "algorand/indexer:{{ .Version }}-amd64"
+    build_flag_templates:
+    - --platform=linux/amd64
+    - --label=org.opencontainers.image.title={{ .ProjectName }}
+    - --label=org.opencontainers.image.version={{ .Version }}
+    - --label=org.opencontainers.image.created={{ .Date }}
+    - --label=org.opencontainers.image.revision={{ .FullCommit }}
+    - --label=org.opencontainers.image.licenses=MIT
+    extra_files:
+    - docker/docker-entrypoint.sh
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+    - "algorand/indexer:latest{{ if .IsSnapshot }}-snapshot{{ end }}-arm64"
+    - "algorand/indexer:{{ .Version }}-arm64"
+    build_flag_templates:
+    - --platform=linux/arm64
+    - --label=org.opencontainers.image.title={{ .ProjectName }}
+    - --label=org.opencontainers.image.version={{ .Version }}
+    - --label=org.opencontainers.image.created={{ .Date }}
+    - --label=org.opencontainers.image.revision={{ .FullCommit }}
+    - --label=org.opencontainers.image.licenses=MIT
+    extra_files:
+    - docker/docker-entrypoint.sh
+
+# automatically select amd64/arm64 when requesting "algorand/indexer"
+docker_manifests:
+  - name_template: "algorand/indexer:{{ .Version }}"
+    image_templates:
+    - "algorand/indexer:{{ .Version }}-amd64"
+    - "algorand/indexer:{{ .Version }}-arm64"
+  - name_template: "algorand/indexer:latest{{ if .IsSnapshot }}-snapshot{{ end }}"
+    image_templates:
+    - "algorand/indexer:latest{{ if .IsSnapshot }}-snapshot{{ end }}-amd64"
+    - "algorand/indexer:latest{{ if .IsSnapshot }}-snapshot{{ end }}-arm64"
+
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^chore:'
+      - '^docs:'
+      - '^test:'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ universal_binaries:
   - replace: true
 
 builds:
-  - main: cmd/algorand-indexer
+  - main: ./cmd/algorand-indexer
     env:
       - CGO_ENABLED=0
     goos:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,11 +73,8 @@ docker_manifests:
     - "algorand/indexer:latest{{ if .IsSnapshot }}-snapshot{{ end }}-arm64"
 
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
+
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,6 @@ builds:
       -X github.com/algorand/indexer/version.Hash={{.FullCommit}}
       -X github.com/algorand/indexer/version.ShortHash={{.ShortCommit}}
       -X github.com/algorand/indexer/version.CompileTime={{.Timestamp}}
-      -X github.com/algorand/indexer/version.GitDecorateBase64=$(shell git log -n 1 --pretty="%D"|base64|tr -d ' \n')
       -X github.com/algorand/indexer/version.ReleaseVersion={{.Version}}
 
 dockers:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,7 @@ universal_binaries:
 
 builds:
   - main: ./cmd/algorand-indexer
-    id: algorand-indexer
+    binary: algorand-indexer
     env:
       - CGO_ENABLED=0
     goos:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,7 @@ universal_binaries:
 
 builds:
   - main: ./cmd/algorand-indexer
+    id: algorand-indexer
     env:
       - CGO_ENABLED=0
     goos:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ universal_binaries:
   - replace: true
 
 builds:
-  - main: ./cmd/algorand-indexer/main.go
+  - main: ./cmd/algorand-indexer
     env:
       - CGO_ENABLED=0
     goos:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ universal_binaries:
   - replace: true
 
 builds:
-  - main: cmd/algorand-indexer/main.go
+  - main: cmd/algorand-indexer
     env:
       - CGO_ENABLED=0
     goos:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Build this Dockerfile with goreleaser.
+# The binary must be present at /algorand-indexer
+FROM debian:bullseye-slim
+
+# Hard code UID/GID to 999 for consistency in advanced deployments.
+# Install ca-certificates to enable using infra providers.
+# Install gosu for fancy data directory management.
+RUN groupadd --gid=999 --system algorand && \
+    useradd --uid=999 --no-log-init --create-home --system --gid algorand algorand && \
+    mkdir -p /data && \
+    chown -R algorand.algorand /data && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gosu ca-certificates && \
+    update-ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY algorand-indexer /usr/local/bin/algorand-indexer
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+ENV INDEXER_DATA /data
+WORKDIR /data
+# Note: docker-entrypoint.sh calls 'algorand-indexer'. Similar entrypoint scripts
+# accept the binary as the first argument in order to surface a suite of
+# tools (i.e. algod, goal, algocfg, ...). Maybe this will change in the
+# future, but for now this approach seemed simpler.
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,8 @@ endif
 export GOPATH := $(shell go env GOPATH)
 GOPATH1 := $(firstword $(subst :, ,$(GOPATH)))
 
-# TODO: ensure any additions here are mirrored in misc/release.py
 GOLDFLAGS += -X github.com/algorand/indexer/version.Hash=$(shell git log -n 1 --pretty="%H")
-GOLDFLAGS += -X github.com/algorand/indexer/version.Dirty=$(if $(filter $(strip $(shell git status --porcelain|wc -c)), "0"),,true)
 GOLDFLAGS += -X github.com/algorand/indexer/version.CompileTime=$(shell date -u +%Y-%m-%dT%H:%M:%S%z)
-GOLDFLAGS += -X github.com/algorand/indexer/version.GitDecorateBase64=$(shell git log -n 1 --pretty="%D"|base64|tr -d ' \n')
 GOLDFLAGS += -X github.com/algorand/indexer/version.ReleaseVersion=$(shell cat .version)
 
 COVERPKG := $(shell go list ./...  | grep -v '/cmd/' | egrep -v '(testing|test|mocks)$$' |  paste -s -d, - )
@@ -29,7 +26,7 @@ all: cmd/algorand-indexer/algorand-indexer idb/postgres/internal/schema/setup_po
 
 
 cmd/algorand-indexer/algorand-indexer: idb/postgres/internal/schema/setup_postgres_sql.go
-	cd cmd/algorand-indexer && go build -ldflags="${GOLDFLAGS}"
+	cd cmd/algorand-indexer && go build -ldflags='${GOLDFLAGS}'
 
 idb/postgres/internal/schema/setup_postgres_sql.go:	idb/postgres/internal/schema/setup_postgres.sql
 	cd idb/postgres/internal/schema && go generate

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -10,7 +10,7 @@ if [ "$(id -u)" = '0' ]; then
   exec gosu algorand "$0" "$@"
 fi
 
-# copy config.yml override to data directory
+# copy indexer.yml override to data directory
 if [[ -f /etc/algorand/indexer.yml ]]; then
   cp /etc/algorand/indexer.yml /data/indexer.yml
 fi

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+# To allow mounting the data directory we need to change permissions
+# to our algorand user. The script is initially run as the root user
+# in order to change permissions; afterwards, the script is re-launched
+# as the algorand user.
+if [ "$(id -u)" = '0' ]; then
+  chown -R algorand:algorand $INDEXER_DATA
+  exec gosu algorand "$0" "$@"
+fi
+
+# copy config.yml override to data directory
+if [[ -f /etc/algorand/indexer.yml ]]; then
+  cp /etc/algorand/indexer.yml /data/indexer.yml
+fi
+
+# always run the conduit command
+exec algorand-indexer "$@"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -15,5 +15,5 @@ if [[ -f /etc/algorand/indexer.yml ]]; then
   cp /etc/algorand/indexer.yml /data/indexer.yml
 fi
 
-# always run the conduit command
+# always run the algorand-indexer command
 exec algorand-indexer "$@"

--- a/version/strings.go
+++ b/version/strings.go
@@ -1,10 +1,7 @@
 package version
 
 import (
-	"encoding/base64"
 	"fmt"
-	"regexp"
-	"strings"
 )
 
 // These are targets for compiling in build information.
@@ -14,15 +11,8 @@ var (
 	// Hash Git commit hash. Output of `git log -n 1 --pretty="%H"`
 	Hash string
 
-	// Dirty "true" or ""
-	// A release build should have no modified files and no unknown files.
-	Dirty string
-
 	// CompileTime YYYY-mm-ddTHH:MM:SS+ZZZZ
 	CompileTime string
-
-	// GitDecorateBase64 Decorations of latest commit which may include tags. Output of `git log -n 1 --pretty="%D"|base64`
-	GitDecorateBase64 string
 
 	// ReleaseVersion What was in /.version when this was compiled.
 	ReleaseVersion string
@@ -33,38 +23,19 @@ const UnknownVersion = "(unknown version)"
 
 // Version the binary version.
 func Version() string {
-	// parse "tag: 1.2.3" out of the result of `git log -n 1 --pretty="%D"|base64`
-	if len(GitDecorateBase64) == 0 {
+	if ReleaseVersion == "" {
 		return UnknownVersion
 	}
-	b, err := base64.StdEncoding.DecodeString(GitDecorateBase64)
-	if err != nil {
-		return fmt.Sprintf("compiled with bad GitDecorateBase64, %s", err.Error())
-	}
-	tre := regexp.MustCompile(`tag:\s+([^,]+)`)
-	m := tre.FindAllStringSubmatch(string(b), -1)
-	if m == nil {
-		return UnknownVersion
-	}
-	for _, group := range m {
-		if len(group[1]) > 0 {
-			return strings.TrimSpace(group[1])
-		}
-	}
-	return UnknownVersion
+	return ReleaseVersion
 }
 
 // LongVersion the long form of the binary version.
 func LongVersion() string {
-	dirtyStr := ""
-	if (len(Dirty) > 0) && (Dirty != "false") {
-		dirtyStr = " (modified)"
-	}
 	tagVersion := Version()
 	if tagVersion == UnknownVersion {
 		tagVersion = fmt.Sprintf("%s-dev.unknown", ReleaseVersion)
 	} else if tagVersion != ReleaseVersion {
 		tagVersion = fmt.Sprintf("dev release build .version=%s tag=%s", ReleaseVersion, tagVersion)
 	}
-	return fmt.Sprintf("%s compiled at %s from git hash %s%s", tagVersion, CompileTime, Hash, dirtyStr)
+	return fmt.Sprintf("%s compiled at %s from git hash %s", tagVersion, CompileTime, Hash)
 }


### PR DESCRIPTION

## Summary

Implements #1540 


Convert indexer release to `goreleaser`. Also adds a Docker image build and release. 

Copied everything over from Conduit so it should be uniform with how we're configuring.

I changed up the `version/strings.go` file to match Conduit--I'm not sure if that will cause some of the generated metadata to change for the release. 

I also still need to replace some of what mule does for debian packaging using `aptly` in a future PR.

## Test Plan

Ran build and release (with `--skip-publish`) locally.

Also ran the docker image (only to exercise the CLI options and that the executable is run).