### PR TITLE
v3: Initial commit of release

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,43 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - 'v3.**'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.3
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+
+      - name: go dependency
+        uses: actions/setup-go@v4.0.1
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Setup QEMU (docker multi-arch dependency)
+        uses: docker/setup-qemu-action@v2
+
+      - name: Setup Docker Buildx (docker multi-arch dependency)
+        uses: docker/setup-buildx-action@v2
+
+      - name: dockerhub-login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

## Summary

Cuts a release to the `v3` branch which will be our v3 release branch for gitflow (which I duplicated from develop). Once this is merged I'll tag it and build artifacts from this.

## Test Plan

Test run on my fork https://github.com/Eric-Warehime/indexer/actions/runs/5326494829/jobs/9648607676   
It fails, but only because of insufficient permissions to publish to docker hub--all build artifacts expected are created.
