### PR TITLE
chore: update deprecated goreleaser option.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -90,7 +90,15 @@ nfpms:
         packager: deb
 
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else if eq .Arch "windows" }}Windows
+      {{- else if eq .Arch "linux" }}Linux
+      {{- else if eq .Arch "darwin" }}Darwin
+      {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
## Summary

Replaces the deprecated replacements option according to recommendation in docs: https://goreleaser.com/deprecations/#archivesreplacements

I don't recall why the old template had a replacement for Arm. @Eric-Warehime do you know if it's needed?