### PR TITLE
postgres: Mention Conduit in DB open error message.

### DIFF
--- a/cmd/algorand-indexer/main.go
+++ b/cmd/algorand-indexer/main.go
@@ -82,7 +82,7 @@ var (
 func indexerDbFromFlags(opts idb.IndexerDbOptions) (idb.IndexerDb, chan struct{}, error) {
 	if postgresAddr != "" {
 		db, ch, err := idb.IndexerDbByName("postgres", postgresAddr, opts, logger)
-		maybeFail(err, "could not init db, %v", err)
+		maybeFail(err, "unable to open database, if tables are not initialized ensure Conduit is running")
 		return db, ch, nil
 	}
 	if dummyIndexerDb {


### PR DESCRIPTION
## Summary

start postgres:
```
docker run -d --name some-postgres -p 5555:5432 -e POSTGRES_PASSWORD=pgpass -e POSTGRES_USER=algorand -e POSTGRES_DB=conduitdb postgres
```

old
```
$ ./algorand-indexer daemon  -P "host=127.0.0.1 port=5555 user=algorand password=pgpass dbname=conduitdb" -i . -S :8989
{"error":"openPostgres() err: getMigrationState() get state err: GetMetastate() err: ERROR: relation \"metastate\" does not exist (SQLSTATE 42P01)","level":"error","msg":"could not init db, openPostgres() err: getMigrationState() get state err: GetMetastate() err: ERROR: relation \"metastate\" does not exist (SQLSTATE 42P01)","time":"2023-08-24T13:38:32-04:00"}
```

new
```
$ ./algorand-indexer daemon  -P "host=127.0.0.1 port=5555 user=algorand password=pgpass dbname=conduitdb" -i . -S :8989
{"error":"openPostgres() err: getMigrationState() get state err: GetMetastate() err: ERROR: relation \"metastate\" does not exist (SQLSTATE 42P01)","level":"error","msg":"unable to open database, if tables are not initialized ensure Conduit is running","time":"2023-08-24T13:52:53-04:00"}
```