### PR TITLE
ci: fix release notes template formatting.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -117,6 +117,7 @@ release:
 
     Indexer 3.1.0 uses Conduit for data loading. This is a change from the 2.x version, which managed data loading internally. See our [Using Conduit to Populate an Indexer Database](https://github.com/algorand/conduit/blob/master/docs/tutorials/IndexerWriter.md) tutorial for more information on how to use Conduit.
   footer: |
-    **Full Changelog**: https://github.com/algorand/indexer/compare{{ .PreviousTag }}...{{ .Tag }}
+    **Full Changelog**: https://github.com/algorand/indexer/compare/{{ .PreviousTag }}...{{ .Tag }}
+
     ---
     [Docker images for this release are available on Docker Hub.](https://hub.docker.com/r/algorand/indexer)


### PR DESCRIPTION
## Summary

There were two issues with the new release template:
* missing forward slash in the diff URL.
* The triple-dash separator turned the changelog into a header, which was not intentional.