### PR TITLE
add txn_participation.round filter

### DIFF
--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -510,6 +510,16 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 		whereParts = append(whereParts, fmt.Sprintf("p.addr = $%d", partNumber))
 		whereArgs = append(whereArgs, tf.Address)
 		partNumber++
+		if tf.MinRound != 0 {
+			whereParts = append(whereParts, fmt.Sprintf("p.round >= $%d", partNumber))
+			whereArgs = append(whereArgs, tf.MinRound)
+			partNumber++
+		}
+		if tf.MaxRound != 0 {
+			whereParts = append(whereParts, fmt.Sprintf("p.round <= $%d", partNumber))
+			whereArgs = append(whereArgs, tf.MaxRound)
+			partNumber++
+		}
 		if tf.AddressRole != 0 {
 			addrBase64 := encoding.Base64(tf.Address)
 			roleparts := make([]string, 0, 8)


### PR DESCRIPTION
## Summary

A fix for inefficient round filtering when using address filter.
fixes #1577 

This request translates to query:
```sql
SELECT 
	t.round, t.intra, t.txn, root.txn, t.extra, t.asset FROM txn t
  JOIN txn_participation p ON t.round = p.round AND t.intra = p.intra
  LEFT OUTER JOIN txn root ON t.round = root.round AND (t.extra->>'root-intra')::int = root.intra 
  WHERE p.addr = '\x881a335631c1aaa46ed219bce34f30fb0e35a1bd8e1490802be795d8c2a7a16b' AND t.round <= 24553246
  ORDER BY p.addr, p.round DESC, p.intra DESC LIMIT 86
```
This query times out on any reasonable Postgres setup. 

Adding a filter on p.round makes for proper use of the txn_participation index:

```sql
SELECT 
	t.round, t.intra, t.txn, root.txn, t.extra, t.asset FROM txn t
  JOIN txn_participation p ON t.round = p.round AND t.intra = p.intra
  LEFT OUTER JOIN txn root ON t.round = root.round AND (t.extra->>'root-intra')::int = root.intra 
  WHERE p.addr = '\x881a335631c1aaa46ed219bce34f30fb0e35a1bd8e1490802be795d8c2a7a16b' AND p.round <= 24553246 AND t.round <= 24553246
  ORDER BY p.addr, p.round DESC, p.intra DESC LIMIT 86  
```


