### PR TITLE
ci: Use parameterized version in conduit notice.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -118,7 +118,7 @@ release:
     ![GitHub Logo](https://raw.githubusercontent.com/algorand/go-algorand/master/release/release-banner.jpg)
     ## Important
 
-    Indexer 3.1.0 uses Conduit for data loading. This is a change from the 2.x version, which managed data loading internally. See our [Using Conduit to Populate an Indexer Database](https://github.com/algorand/conduit/blob/master/docs/tutorials/IndexerWriter.md) tutorial for more information on how to use Conduit.
+    Indexer {{ .Tag }} uses Conduit for data loading. This is a change from the 2.x version, which managed data loading internally. See our [Using Conduit to Populate an Indexer Database](https://github.com/algorand/conduit/blob/master/docs/tutorials/IndexerWriter.md) tutorial for more information on how to use Conduit.
   footer: |
     **Full Changelog**: https://github.com/algorand/indexer/compare/{{ .PreviousTag }}...{{ .Tag }}
 


### PR DESCRIPTION
## Summary

Somehow the hard coded version got out of date. Use the tag parameter instead.

## Test Plan

N/A. The template uses `{{ .Tag }}` elsewhere, so I'm pretty confident that this should work as expected.