### PR TITLE
api: Add support for Private Network Access header preflight requests

### DIFF
--- a/api/middlewares/pna.go
+++ b/api/middlewares/pna.go
@@ -1,0 +1,19 @@
+package middlewares
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+func MakePNA() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(ctx echo.Context) error {
+			req := ctx.Request()
+			if req.Method == http.MethodOptions && req.Header.Get("Access-Control-Request-Private-Network") == "ture" {
+				ctx.Response().Header().Set("Access-Control-Allow-Private-Netowkr", "true")
+			}
+			return next(ctx)
+		}
+	}
+}

--- a/api/middlewares/pna.go
+++ b/api/middlewares/pna.go
@@ -6,6 +6,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// MakePNA constructs the Private Network Access middleware function
 func MakePNA() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(ctx echo.Context) error {

--- a/api/middlewares/pna.go
+++ b/api/middlewares/pna.go
@@ -10,8 +10,8 @@ func MakePNA() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(ctx echo.Context) error {
 			req := ctx.Request()
-			if req.Method == http.MethodOptions && req.Header.Get("Access-Control-Request-Private-Network") == "ture" {
-				ctx.Response().Header().Set("Access-Control-Allow-Private-Netowkr", "true")
+			if req.Method == http.MethodOptions && req.Header.Get("Access-Control-Request-Private-Network") == "true" {
+				ctx.Response().Header().Set("Access-Control-Allow-Private-Network", "true")
 			}
 			return next(ctx)
 		}

--- a/api/middlewares/pna_test.go
+++ b/api/middlewares/pna_test.go
@@ -1,0 +1,69 @@
+package middlewares
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakePNA(t *testing.T) {
+	// Create a new Echo instance
+	e := echo.New()
+
+	// Create a handler to be wrapped by the middleware
+	handler := func(c echo.Context) error {
+		return c.String(http.StatusOK, "OK")
+	}
+
+	// Create the middleware
+	middleware := MakePNA()
+
+	// Test case 1: OPTIONS request with Access-Control-Request-Private-Network header
+	t.Run("OPTIONS request with PNA header", func(t *testing.T) {
+		// Create a new HTTP request and response recorder
+		req := httptest.NewRequest(http.MethodOptions, "/", nil)
+		rec := httptest.NewRecorder()
+
+		// Set the expected PNA header
+		req.Header.Set("Access-Control-Request-Private-Network", "true")
+
+		// Create Echo context
+		c := e.NewContext(req, rec)
+
+		// Call our MakePNA middleware
+		err := middleware(handler)(c)
+
+		// Assert there's no error and check the PNA header was set correctly
+		assert.NoError(t, err)
+		assert.Equal(t, "true", rec.Header().Get("Access-Control-Allow-Private-Network"))
+	})
+
+	// Test case 2: Non-OPTIONS request
+	t.Run("Non-OPTIONS request", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		err := middleware(handler)(c)
+
+		// Assert there's no error and check the PNA header wasn't set
+		assert.NoError(t, err)
+		assert.Empty(t, rec.Header().Get("Access-Control-Allow-Private-Network"))
+	})
+
+	// Test case 3: OPTIONS request without Access-Control-Request-Private-Network header
+	t.Run("OPTIONS request without Private Network header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		err := middleware(handler)(c)
+
+		// Assert there's no error and check the PNA header wasn't set
+		assert.NoError(t, err)
+		assert.Empty(t, rec.Header().Get("Access-Control-Allow-Private-Network"))
+	})
+}

--- a/api/server.go
+++ b/api/server.go
@@ -23,6 +23,9 @@ type ExtraOptions struct {
 	// Tokens are the access tokens which can access the API.
 	Tokens []string
 
+	// Respond to Private Network Access preflight requests sent to the indexer.
+	EnablePrivateNetworkAccessHeader bool
+
 	// MetricsEndpoint turns on the /metrics endpoint for prometheus metrics.
 	MetricsEndpoint bool
 
@@ -101,7 +104,9 @@ func Serve(ctx context.Context, serveAddr string, db idb.IndexerDb, dataError fu
 	}
 
 	e.Use(middlewares.MakeLogger(log))
-	e.Use(middlewares.MakePNA())
+	if options.EnablePrivateNetworkAccessHeader {
+		e.Use(middlewares.MakePNA())
+	}
 	e.Use(middleware.CORS())
 	e.Use(middleware.GzipWithConfig(middleware.GzipConfig{
 		// we currently support compressed result only for GET /v2/blocks/ API

--- a/api/server.go
+++ b/api/server.go
@@ -101,6 +101,7 @@ func Serve(ctx context.Context, serveAddr string, db idb.IndexerDb, dataError fu
 	}
 
 	e.Use(middlewares.MakeLogger(log))
+	e.Use(middlewares.MakePNA())
 	e.Use(middleware.CORS())
 	e.Use(middleware.GzipWithConfig(middleware.GzipConfig{
 		// we currently support compressed result only for GET /v2/blocks/ API

--- a/api/server.go
+++ b/api/server.go
@@ -18,7 +18,7 @@ import (
 	"github.com/algorand/indexer/v3/idb"
 )
 
-// ExtraOptions are options which change the behavior or the HTTP server.
+// ExtraOptions are options which change the behavior of the HTTP server.
 type ExtraOptions struct {
 	// Tokens are the access tokens which can access the API.
 	Tokens []string

--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -23,33 +23,34 @@ import (
 )
 
 type daemonConfig struct {
-	flags                     *pflag.FlagSet
-	daemonServerAddr          string
-	developerMode             bool
-	metricsMode               string
-	tokenString               string
-	writeTimeout              time.Duration
-	readTimeout               time.Duration
-	maxConn                   uint32
-	maxAPIResourcesPerAccount uint32
-	maxTransactionsLimit      uint32
-	defaultTransactionsLimit  uint32
-	maxAccountsLimit          uint32
-	defaultAccountsLimit      uint32
-	maxAssetsLimit            uint32
-	defaultAssetsLimit        uint32
-	maxBoxesLimit             uint32
-	defaultBoxesLimit         uint32
-	maxBalancesLimit          uint32
-	defaultBalancesLimit      uint32
-	maxApplicationsLimit      uint32
-	defaultApplicationsLimit  uint32
-	enableAllParameters       bool
-	indexerDataDir            string
-	cpuProfile                string
-	pidFilePath               string
-	configFile                string
-	suppliedAPIConfigFile     string
+	flags                            *pflag.FlagSet
+	daemonServerAddr                 string
+	developerMode                    bool
+	enablePrivateNetworkAccessHeader bool
+	metricsMode                      string
+	tokenString                      string
+	writeTimeout                     time.Duration
+	readTimeout                      time.Duration
+	maxConn                          uint32
+	maxAPIResourcesPerAccount        uint32
+	maxTransactionsLimit             uint32
+	defaultTransactionsLimit         uint32
+	maxAccountsLimit                 uint32
+	defaultAccountsLimit             uint32
+	maxAssetsLimit                   uint32
+	defaultAssetsLimit               uint32
+	maxBoxesLimit                    uint32
+	defaultBoxesLimit                uint32
+	maxBalancesLimit                 uint32
+	defaultBalancesLimit             uint32
+	maxApplicationsLimit             uint32
+	defaultApplicationsLimit         uint32
+	enableAllParameters              bool
+	indexerDataDir                   string
+	cpuProfile                       string
+	pidFilePath                      string
+	configFile                       string
+	suppliedAPIConfigFile            string
 }
 
 // DaemonCmd creates the main cobra command, initializes flags, and viper aliases
@@ -71,6 +72,7 @@ func DaemonCmd() *cobra.Command {
 	cfg.flags.StringVarP(&cfg.daemonServerAddr, "server", "S", ":8980", "host:port to serve API on (default :8980)")
 	cfg.flags.StringVarP(&cfg.tokenString, "token", "t", "", "an optional auth token, when set REST calls must use this token in a bearer format, or in a 'X-Indexer-API-Token' header")
 	cfg.flags.BoolVarP(&cfg.developerMode, "dev-mode", "", false, "has no effect currently, reserved for future performance intensive operations")
+	cfg.flags.BoolVarP(&cfg.enablePrivateNetworkAccessHeader, "enable-private-network-access-header", "", false, "respond to Private Network Access preflight requests")
 	cfg.flags.StringVarP(&cfg.metricsMode, "metrics-mode", "", "OFF", "configure the /metrics endpoint to [ON, OFF, VERBOSE]")
 	cfg.flags.DurationVarP(&cfg.writeTimeout, "write-timeout", "", 30*time.Second, "set the maximum duration to wait before timing out writes to a http response, breaking connection")
 	cfg.flags.DurationVarP(&cfg.readTimeout, "read-timeout", "", 5*time.Second, "set the maximum duration for reading the entire request")
@@ -300,6 +302,7 @@ func runDaemon(daemonConfig *daemonConfig) error {
 
 // makeOptions converts CLI options to server options
 func makeOptions(daemonConfig *daemonConfig) (options api.ExtraOptions) {
+	options.EnablePrivateNetworkAccessHeader = daemonConfig.enablePrivateNetworkAccessHeader
 	if daemonConfig.tokenString != "" {
 		options.Tokens = append(options.Tokens, daemonConfig.tokenString)
 	}


### PR DESCRIPTION
## Summary

During development of Algorand smart contracts and platforms users will often run local environments consisting of algod, kmd, and indexer via sandbox or more recently algokit. By default all of these services are running on local/private network addresses (e.g. 127.0.0.1), however popular tools such as [DappFlow](https://app.dappflow.org/explorer) and [Lora](https://lora.algokit.io/localnet) are hosted on public network addresses and require the user to specify their local endpoints. Additionally some dapps allow their users to provide their own endpoints for a _more_ decentralised experience.

Schedule for [Google Chrome 130](https://developer.chrome.com/blog/private-network-access-update-2024-03) (although many users are already experiencing it), PNA protections will be enabled by default, disallowing public websites from making requests to local/private resources without a specific header response during a preflight request. This PR introduces a new configuration option that will add middleware to the API handler to support responding to the Private Network Access request header.

## Test Plan

I've currently just compiled this branch locally and tested it by changing the indexer.yml config and passing the command line flag.