### PR TITLE
Fix load of custom consensus - get protocol err

### DIFF
--- a/cmd/algorand-indexer/daemon.go
+++ b/cmd/algorand-indexer/daemon.go
@@ -15,6 +15,8 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	sdkConfig "github.com/algorand/go-algorand-sdk/v2/protocol/config"
+
 	"github.com/algorand/indexer/v3/api"
 	"github.com/algorand/indexer/v3/api/generated/v2"
 	"github.com/algorand/indexer/v3/config"
@@ -199,6 +201,14 @@ func runDaemon(daemonConfig *daemonConfig) error {
 	if daemonConfig.configFile == "" {
 		daemonConfig.configFile = os.Getenv("INDEXER_CONFIGFILE")
 	}
+
+	// Read custom consensus file for custom protocols
+	var consensus sdkConfig.ConsensusProtocols
+	consensus , consensusErr := sdkConfig.PreloadConfigurableConsensusProtocols(daemonConfig.indexerDataDir)
+	if consensusErr != nil {
+		return consensusErr
+	}
+	sdkConfig.Consensus = consensus
 
 	// Create the data directory if necessary/possible
 	if err = configureIndexerDataDir(daemonConfig.indexerDataDir); err != nil {


### PR DESCRIPTION
## Summary

This is follow up on 
- https://github.com/algorand/indexer/pull/1327
- https://github.com/algorand/indexer/pull/1041

This PR related to 
- https://github.com/algorand/conduit/pull/162
- https://github.com/algorand/go-algorand-sdk/pull/625

Currently there is the bug in indexer and conduit that prevents usage with custom consensus file.

![image](https://github.com/user-attachments/assets/4f9d2f84-d3e5-4d2e-8af4-940fb4aa1ce9)

## Test Plan

We have built and we use the custom build of indexer and conduit made from this pull requests.
-https://github.com/scholtz/AlgorandNodes/blob/main/docker/indexer/aramidmain/compose-indexer-fix.dockerfile

Docker images:
- https://hub.docker.com/r/scholtz2/aramid-indexer/tags
- https://hub.docker.com/r/scholtz2/aramid-conduit/tags

