### PR TITLE
CI: update CircleCI Ubuntu image to 24.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 parameters:
   ubuntu_image:
     type: string
-    default: "ubuntu-2204:2022.04.2"
+    default: "ubuntu-2404:2024.05.1"
 
 workflows:
   version: 2


### PR DESCRIPTION
## Summary

The previous image was deprecated and no longer works. This updates the image to the latest LTS (24.04) and a supported image.

## Test Plan

CI Tests should pass.
