### PR TITLE
Performance: Convert before-time/after-time filters for transactions endpoint to rounds

### DIFF
--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -575,13 +575,15 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 	}
 	if !tf.BeforeTime.IsZero() {
 		convertedTime := tf.BeforeTime.In(time.UTC)
-		whereParts = append(whereParts, fmt.Sprintf("h.realtime < $%d", partNumber))
+		whereParts = append(whereParts, fmt.Sprintf("t.round <= ("+
+			"SELECT round from block_header WHERE realtime < $%d ORDER BY realtime DESC LIMIT 1)", partNumber))
 		whereArgs = append(whereArgs, convertedTime)
 		partNumber++
 	}
 	if !tf.AfterTime.IsZero() {
 		convertedTime := tf.AfterTime.In(time.UTC)
-		whereParts = append(whereParts, fmt.Sprintf("h.realtime > $%d", partNumber))
+		whereParts = append(whereParts, fmt.Sprintf("t.round >= ("+
+			"SELECT round from block_header WHERE realtime > $%d ORDER BY realtime ASC LIMIT 1)", partNumber))
 		whereArgs = append(whereArgs, convertedTime)
 		partNumber++
 	}


### PR DESCRIPTION


<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Convert before-time/after-time filters for transactions endpoint to rounds (major performance boost/avoid excessive query timeouts.

## Test Plan

Existing tests should all pass, tested against Mainnet API queries outlined in issue #1518 
