### PR TITLE
before-time/after-time optimization for participation queries

### DIFF
--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -576,15 +576,25 @@ func buildTransactionQuery(tf idb.TransactionFilter) (query string, whereArgs []
 	}
 	if !tf.BeforeTime.IsZero() {
 		convertedTime := tf.BeforeTime.In(time.UTC)
-		whereParts = append(whereParts, fmt.Sprintf("t.round <= ("+
-			"SELECT round from block_header WHERE realtime < $%d ORDER BY realtime DESC LIMIT 1)", partNumber))
+		if joinParticipation {
+			whereParts = append(whereParts, fmt.Sprintf("p.round <= ("+
+				"SELECT round from block_header WHERE realtime < $%d ORDER BY realtime DESC LIMIT 1)", partNumber))
+		} else {
+			whereParts = append(whereParts, fmt.Sprintf("t.round <= ("+
+				"SELECT round from block_header WHERE realtime < $%d ORDER BY realtime DESC LIMIT 1)", partNumber))
+		}
 		whereArgs = append(whereArgs, convertedTime)
 		partNumber++
 	}
 	if !tf.AfterTime.IsZero() {
 		convertedTime := tf.AfterTime.In(time.UTC)
-		whereParts = append(whereParts, fmt.Sprintf("t.round >= ("+
-			"SELECT round from block_header WHERE realtime > $%d ORDER BY realtime ASC LIMIT 1)", partNumber))
+		if joinParticipation {
+			whereParts = append(whereParts, fmt.Sprintf("p.round >= ("+
+				"SELECT round from block_header WHERE realtime > $%d ORDER BY realtime ASC LIMIT 1)", partNumber))
+		} else {
+			whereParts = append(whereParts, fmt.Sprintf("t.round >= ("+
+				"SELECT round from block_header WHERE realtime > $%d ORDER BY realtime ASC LIMIT 1)", partNumber))
+		}
 		whereArgs = append(whereArgs, convertedTime)
 		partNumber++
 	}


### PR DESCRIPTION
## Summary

Recent optimization for before/after-time queries does not work for searches that filter by participating account.
Postgres plan optimizer chooses to loop through all of the account history without applying the round filter. 

This PR forces the round filter to be applied to the participation table index scan, resulting in way faster plans. 
Zero cons, all pros. 

Example API call where this optimization works:

`/v2/transactions?address=I2IE7JMC5PXOSC2XZE6DURBW4PASD2JGIAFMEJ5SKL4K5NV5YROUQOOHCE&after-time=2025-09-29T22%3A44%3A52.000Z`