### PR TITLE
Ensure txn_participation is pruned corresponding with rows in txn

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,10 +12,12 @@ linters:
   exclusions:
     generated: lax
     rules:
-      # revive: types is an acceptable package name in this codebase
+      # revive: types and util are acceptable package names in this codebase
       - linters:
           - revive
-        path: types/
+        paths:
+          - types/
+          - util/
         text: 'var-naming: avoid meaningless package names'
       # ignore govet false positive fixed in https://github.com/golang/go/issues/45043
       - path: (.+)\.go$

--- a/idb/postgres/postgres.go
+++ b/idb/postgres/postgres.go
@@ -2909,12 +2909,23 @@ func (db *IndexerDb) DeleteTransactions(ctx context.Context, keep uint64) error 
 	// delete old transactions and update metastate
 	deleteTxns := func(tx pgx.Tx) error {
 		db.log.Infof("deleteTxns(): removing transactions before round %d", keep)
-		// delete query
+
+		// delete from txn
 		query := "DELETE FROM txn WHERE round < $1"
 		cmd, err2 := tx.Exec(ctx, query, keep)
 		if err2 != nil {
 			return fmt.Errorf("deleteTxns(): transaction delete err %w", err2)
 		}
+		db.log.Infof("%d transactions deleted", cmd.RowsAffected())
+
+		// delete from txn_participation
+		participationQuery := "DELETE FROM txn_participation WHERE round < $1"
+		participationCmd, err2 := tx.Exec(ctx, participationQuery, keep)
+		if err2 != nil {
+			return fmt.Errorf("deleteTxns(): txn_participation delete err %w", err2)
+		}
+		db.log.Infof("%d txn_participation records deleted", participationCmd.RowsAffected())
+
 		t := time.Now().UTC()
 		// update metastate
 		status := types.DeleteStatus{
@@ -2926,7 +2937,7 @@ func (db *IndexerDb) DeleteTransactions(ctx context.Context, keep uint64) error 
 		if err2 != nil {
 			return fmt.Errorf("deleteTxns(): metastate update err %w", err2)
 		}
-		db.log.Infof("%d transactions deleted, last pruned at %s", cmd.RowsAffected(), status.LastPruned)
+		db.log.Infof("last pruned at %s", status.LastPruned)
 		return nil
 	}
 	err := db.txWithRetry(serializable, deleteTxns)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Reported in [algorand/conduit#194](https://github.com/algorand/conduit/issues/194), `txn_participation` should be pruned when txn in for history. This PR addresses that.

## Test Plan

The test cases for `DeleteTransactions` were enhanced with before/after checks that the appropriate rows in `txn_participation` are removed.
